### PR TITLE
Issue with list-divider rendering

### DIFF
--- a/docs/lists/index.html
+++ b/docs/lists/index.html
@@ -10,6 +10,7 @@
 <div data-role="page" data-theme="b">
 
 	<div data-role="header" data-theme="b">
+		<a href="../index.html" data-icon="arrow-l">Home</a>
 		<h1>Lists</h1>
 	</div><!-- /header -->
 

--- a/docs/pages/docs-transitions.html
+++ b/docs/pages/docs-transitions.html
@@ -34,6 +34,8 @@
 		<a href="transition-success.html" data-role="button" data-transition="flip">flip</a>
 		</p>
 		
+		<p>In addition, you can also force a "backwards" transition by specifying <code>data-back="true"</code> on your link.</p>
+		
 		<div class="ui-body ui-body-e">
 			<p><strong>Transitions from <a href="http://www.jqtouch.com/">jQtouch</a></strong> (<em>with small modifications</em>): Built by David Kaneda and maintained by Jonathan Stark.</p>
 		</div>

--- a/docs/pages/multipage-template.html
+++ b/docs/pages/multipage-template.html
@@ -2,10 +2,9 @@
 <html> 
 	<head> 
 	<title>Page Title</title> 
-	<link rel="stylesheet" href="http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.css" />
-	<script src="http://code.jquery.com/jquery-1.4.3.min.js"></script>
-	<script src="http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.js"></script>
-</head> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
+	<script type="text/javascript" src="../../js/all"></script>
+	<script type="text/javascript" src="../docs/docs.js"></script></head> 
 <body> 
 
 <!-- Start of first page -->

--- a/docs/pages/pages-themes.html
+++ b/docs/pages/pages-themes.html
@@ -24,8 +24,8 @@
 			
 			<p>The default Theme mixes styles from multiple swatches to create visual texture and present the various elements in optimal contrast to one another:</p>
 			
-			<div data-role="header" data-position="inline">
-				<h1>Default Theme Bar</h1>
+			<div data-role="header">
+				<h1>Default Theme</h1>
 			</div>
 			<div class="ui-bar ui-bar-c">
 				<div data-role="controlgroup" data-type="horizontal" >
@@ -58,7 +58,7 @@
 			<p>And each of the five "swatches" applies its style consistently across all page elements, as shown below:</p>
 						
 			<h2>Swatch A</h2>
-			<div data-role="header" data-position="inline" data-theme="a">
+			<div data-role="header" data-position="inline">
 				<h1>Header A</h1>
 			</div>
 			<div class="ui-body ui-body-a">
@@ -83,7 +83,7 @@
 
 
 			<h2>Swatch B</h2>
-			<div data-role="header" data-position="inline" data-theme="b">
+			<div data-role="header" data-theme="b">
 				<h1>Header B</h1>
 			</div>
 			<div class="ui-body ui-body-b">
@@ -107,7 +107,7 @@
 			</div>
 			
 			<h2>Swatch C</h2>
-			<div data-role="header" data-position="inline" data-theme="c">
+			<div data-role="header" data-theme="c">
 				<h1>Header C</h1>
 			</div>
 			<div class="ui-body ui-body-c">
@@ -131,7 +131,7 @@
 			</div>
 			
 			<h2>Swatch D</h2>
-			<div data-role="header" data-position="inline" data-theme="d">
+			<div data-role="header" data-theme="d">
 				<h1>Header D</h1>
 			</div>
 			<div class="ui-body ui-body-d">
@@ -155,7 +155,7 @@
 			</div>
 			
 			<h2>Swatch E</h2>
-			<div data-role="header" data-position="inline" data-theme="e">
+			<div data-role="header" data-theme="e">
 				<h1>Header E</h1>
 			</div>
 			<div class="ui-body ui-body-e">

--- a/docs/toolbars/docs-bars.html
+++ b/docs/toolbars/docs-bars.html
@@ -24,7 +24,7 @@
 	<li>The <a href="docs-footers.html"><strong>Footer bar</strong></a> is usually the last element inside each mobile page, and tends to be more freeform than the header in terms of content and functionality, but typically contains a combination of text and buttons.</li> 
 </ul>	
 
-	<p>It's very common to have a horizontal navigation or tab bar inside the header an/or footer; jQuery Mobile includes a <a href="navbar.html"><strong>nav bar widget </strong></a> that turns an unordered list of links into a horizontal button bar, which works well in these instances.</p>
+	<p>It's very common to have a horizontal navigation or tab bar inside the header an/or footer; jQuery Mobile includes a <a href="footer-persist-a.html"><strong>nav bar widget </strong></a> that turns an unordered list of links into a horizontal button bar, which works well in these instances.</p>
 
 			
 			<h2>Toolbar positioning options</h2>

--- a/experiments/converter/application.js
+++ b/experiments/converter/application.js
@@ -44,7 +44,7 @@ $(function() {
 	$( "#term" ).keyup(function() {
 		var value = this.value;
 		$.each( all, function( index, conversion ) {
-			$( "#" + conversion.from + conversion.to ).val( conversion.rate
+			$( "#" + conversion.from + conversion.to ).text( conversion.rate
 				? Math.ceil( value * conversion.rate * 100 ) / 100
 				: "Rate not available, yet."
 			);

--- a/experiments/converter/index.html
+++ b/experiments/converter/index.html
@@ -22,8 +22,8 @@
 	</style>
 	<script id="conversion-field" type="text/x-jquery-tmpl">
 	    <li data-role="fieldcontain">
-			<label for="${from}${to}" class="ui-input-text conversion-${type}" title="From ${from} to ${to}">${$item.symbols[from]} to ${$item.symbols[to]}</label>
-			<input type="text" readonly="readonly" name="${from}${to}" id="${from}${to}" value="" />
+			<label class="ui-input-text conversion-${type}" title="From ${from} to ${to}">${$item.symbols[from]} to ${$item.symbols[to]}</label>
+			<span type="text" id="${from}${to}"></span>
 		</li>
 	</script>
 	<script id="conversion-edit-field" type="text/x-jquery-tmpl">

--- a/experiments/converter/index.html
+++ b/experiments/converter/index.html
@@ -5,10 +5,14 @@
 	<title>jQuery Mobile Framework - Converter Demo Application</title> 
 	<link rel="stylesheet"  href="../../themes/default" />
 	<script type="text/javascript" src="../../js/all"></script>
+	<style>
+		input:disabled { background:none; }
+	</style>
+	
 </head> 
 <body> 
 
-<div data-role="page" class="ui-body-c">
+<div data-role="page" data-theme="c">
 	
 	<script type="text/javascript" src="jquery.tmpl.js"></script>
 	<script type="text/javascript" src="storage.js"></script>
@@ -17,7 +21,7 @@
 		.field { padding: 15px; }
 	</style>
 	<script id="conversion-field" type="text/x-jquery-tmpl">
-	    <li>
+	    <li data-role="fieldcontain">
 			<label for="${from}${to}" class="ui-input-text conversion-${type}" title="From ${from} to ${to}">${$item.symbols[from]} to ${$item.symbols[to]}</label>
 			<input type="text" readonly="readonly" name="${from}${to}" id="${from}${to}" value="" />
 		</li>
@@ -29,19 +33,18 @@
 		</li>
 	</script>
 	
-	<div data-role="header">
-		<a href="#customize" class="editbutton ui-aux" data-transition="flip">Edit</a>
+	<div data-role="header" data-theme="b">
+		<a href="#customize" data-rel="dialog" data-transition="pop">Edit</a>
 		<h1>Converter demo</h1>
 	</div>
-	<form method="get" action="" data-role="autoform" class="ui-bar-b">
-			<label for="term" data-role="nojs">Search:</label>
-			<input type="search" name="term" id="term" placeholder="type a value..." value="1" />
-		</form>
+	<div class="ui-bar ui-bar-d">
+			<form method="get" action="" data-role="autoform" >
+				<label for="term" data-role="nojs">Search:</label>
+				<input type="search" name="term" id="term" placeholder="type a value..." value="1" />
+			</form>
+	</div>
 	<div data-role="content">
-		
-		<div class="ui-content">
-			<ul id="conversions" data-role="listview" data-inset="true"></ul>
-		</div>
+		<ul id="conversions" data-role="listview" data-inset="true"></ul>
 	</div>
 </div>
 

--- a/js/jquery.mobile.controlGroup.js
+++ b/js/jquery.mobile.controlGroup.js
@@ -28,9 +28,12 @@ $.fn.controlgroup = function(options){
 		function flipClasses(els){
 			els
 				.removeClass('ui-btn-corner-all ui-shadow')
-				.eq(0).addClass(flCorners[0])
-				.end()
-				.filter(':last').addClass(flCorners[1]).addClass('ui-controlgroup-last');
+				.addClass(function() {
+					return !$(this).prev()[0] ? flCorners[0] : "";
+				})
+				.addClass(function() {
+					return !$(this).next()[0] ? flCorners[1] + " ui-controlgroup-last": "";
+				});
 		}
 		flipClasses($(this).find('.ui-btn'));
 		flipClasses($(this).find('.ui-btn-inner'));

--- a/js/jquery.mobile.controlGroup.js
+++ b/js/jquery.mobile.controlGroup.js
@@ -28,12 +28,9 @@ $.fn.controlgroup = function(options){
 		function flipClasses(els){
 			els
 				.removeClass('ui-btn-corner-all ui-shadow')
-				.addClass(function() {
-					return !$(this).prev()[0] ? flCorners[0] : "";
-				})
-				.addClass(function() {
-					return !$(this).next()[0] ? flCorners[1] + " ui-controlgroup-last": "";
-				});
+				.eq(0).addClass(flCorners[0])
+				.end()
+				.filter(':last').addClass(flCorners[1]).addClass('ui-controlgroup-last');
 		}
 		flipClasses($(this).find('.ui-btn'));
 		flipClasses($(this).find('.ui-btn-inner'));

--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -57,14 +57,23 @@ jQuery.fn.customTextInput = function(options){
 				focusedEl.removeClass('ui-focus');
 			});	
 			
-		//autogrow	
-		if(input.is('textarea')){
-			input.keydown(function(){
-				if( input[0].offsetHeight < input[0].scrollHeight ){
-					input.css({height: input[0].scrollHeight + 10 });
-				}
-			})
-		}	
+		//autogrow
+		if ( input.is('textarea') ) {
+			var extraLineHeight = 15,
+				keyupTimeoutBuffer = 100,
+				keyup = function() {
+					var scrollHeight = input[0].scrollHeight,
+						clientHeight = input[0].clientHeight;
+					if ( clientHeight < scrollHeight ) {
+						input.css({ height: (scrollHeight + extraLineHeight) });
+					}
+				},
+				keyupTimeout;
+			input.keyup(function() {
+				clearTimeout( keyupTimeout );
+				keyupTimeout = setTimeout( keyup, keyupTimeoutBuffer );
+			});
+		}
 	});
 };
 })(jQuery);

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -46,6 +46,7 @@
 		startPageId = 'ui-page-start',
 		activePageClass = 'ui-page-active',
 		pageTransition,
+		forceBack,
 		transitions = 'slide slideup slidedown pop flip fade',
 		transitionDuration = 350,
 		backBtnText = "Back",
@@ -102,6 +103,7 @@
 	jQuery.fn.ajaxClick = function() {
 		var href = jQuery( this ).attr( "href" );
 		pageTransition = jQuery( this ).data( "transition" ) || "slide";
+		forceBack = jQuery( this ).data( "back" ) || undefined;
 		nextPageRole = jQuery( this ).attr( "data-rel" );
 		  	
 		//find new base for url building
@@ -223,7 +225,9 @@
 				transition = urlStack.pop().transition;
 			} else {
 				urlStack.push({ url: url, transition: transition });
+				if ( forceBack ) back = true;
 			}
+			forceBack = undefined;
 			
 			//function for setting role of next page
 			function setPageRole( newPage ) {

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -129,7 +129,7 @@
 	};
 	
 	// ajaxify all navigable links
-	jQuery( "a:not([href=#]):not([target]):not([rel=external])" ).live( "click", function(event) {
+	jQuery( "a:not([href=#]):not([target]):not([rel=external]):not([href^=mailto:])" ).live( "click", function(event) {
 		jQuery( this ).ajaxClick();
 		return false;
 	});

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -18,7 +18,8 @@ $.widget( "mobile.listview", $.mobile.widget, {
 	},
 	
 	_create: function() {
-		var o = this.options
+		var o = this.options,
+			flCorners = ['ui-corner-top', 'ui-corner-bottom'],
 			$list = this.element;
 		
 		this._createSubPages();

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -66,7 +66,14 @@ $.widget( "mobile.listview", $.mobile.widget, {
 								.addClass( "ui-link-inherit" );
 					}
 					else if( role == "list-divider" ){
-						$li.addClass( "ui-li-divider ui-btn ui-bar-" + dividertheme ).attr( "role", "heading" );
+						$li
+							.addClass( "ui-li-divider ui-bar-" + dividertheme )
+							.addClass(function() {
+								return !$(this).prev()[0] ? flCorners[0] : "";
+							})
+							.addClass(function() {
+								return !$(this).next()[0] ? flCorners[1] + " ui-controlgroup-last": "";
+							}).attr( "role", "heading" );
 					}
 					else {
 						$li.addClass( "ui-li-static ui-btn-up-" + o.theme );

--- a/themes/default/jquery.mobile.core.css
+++ b/themes/default/jquery.mobile.core.css
@@ -33,6 +33,7 @@
 .ui-bar { font-size: 16px; margin: 0; }
 .ui-bar h1, .ui-bar h2, .ui-bar h3, .ui-bar h4, .ui-bar h5, .ui-bar h6 { margin: 0; padding: 0; font-size: 16px; display: inline-block; }
 
+.ui-header, .ui-footer { display: block; }
 .ui-page .ui-header, .ui-page .ui-footer { position: relative; }
 .ui-header .ui-btn-left { position: absolute; left: 10px; top: .4em;  }
 .ui-header .ui-title, .ui-footer .ui-title { text-align: center; font-size: 16px; display: block; margin: .6em 90px .8em;  padding: 0;  text-overflow: ellipsis; overflow: hidden; white-space: nowrap; outline: 0 !important; }


### PR DESCRIPTION
Previous version of flipClasses broke in accuont for singular list-dividers, rendering both the top and bottom corner roundedness. Updated version will work for all accounts.
