### PR TITLE
Missing variable fixed

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -18,7 +18,8 @@ $.widget( "mobile.listview", $.mobile.widget, {
 	},
 	
 	_create: function() {
-		var o = this.options
+		var o = this.options,
+			flCorners = ['ui-corner-top', 'ui-corner-bottom'],
 			$list = this.element;
 		
 		this._createSubPages();

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -66,7 +66,14 @@ $.widget( "mobile.listview", $.mobile.widget, {
 								.addClass( "ui-link-inherit" );
 					}
 					else if( role == "list-divider" ){
-						$li.addClass( "ui-li-divider ui-btn ui-bar-" + dividertheme ).attr( "role", "heading" );
+						$li
+							.addClass( "ui-li-divider ui-bar-" + dividertheme )
+							.addClass(function() {
+								return !$(this).prev()[0] ? flCorners[0] : "";
+							})
+							.addClass(function() {
+								return !$(this).next()[0] ? flCorners[1] + " ui-controlgroup-last": "";
+							}).attr( "role", "heading" );
 					}
 					else {
 						$li.addClass( "ui-li-static ui-btn-up-" + o.theme );


### PR DESCRIPTION
Missing flCorners variable added.

(previous comment)
Implemented fix for border radius on list-dividers that I used previously in jquery.mobile.controlGroup.js's flipClasses function. Since the ui-btn class was being used to do border radius on dividers, that was removed.
