### PR TITLE
Querystrings containing "http" in the middle will load synchronously

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ mobile:
 
 min: mobile
 	@@head -8 js/jquery.mobile.js > ${MIN}
-	@@java -jar ../jquery/build/google-compiler-20100917.jar --js ${MAX} --warning_level QUIET --js_output_file ${MIN}.tmp
+	@@java -jar build/google-compiler-20100917.jar --js ${MAX} --warning_level QUIET --js_output_file ${MIN}.tmp
 	@@cat ${MIN}.tmp >> ${MIN}
 	@@rm -f ${MIN}.tmp
 

--- a/docs/content/api-content.html
+++ b/docs/content/api-content.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 </head> 
 <body> 

--- a/docs/content/content-collapsible.html
+++ b/docs/content/content-collapsible.html
@@ -2,9 +2,8 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
-	<script type="text/javascript" src="../docs/docs.js"></script>
 	
 
 </head> 

--- a/docs/content/content-collapsible.html
+++ b/docs/content/content-collapsible.html
@@ -101,8 +101,33 @@
 			</ul>
 		</div><!-- /section 4 -->
 		
+		<h2>Nested Collapsibles</h2>
+		<div data-role="collapsible">
+			<h3>I'm a header</h3>
+			<p>I'm the collapsible content. By default I'm open and displayed on the page, but you can click the header to hide me.</p>
+			<div data-role="collapsible">
+				<h3>I'm a nested collapsible header</h3>
+				<p>I'm the collapsible content. By default I'm open and displayed on the page, but you can click the header to hide me.</p>
+			</div>
+		</div>
 		
+		<h2>Collapsible sets</h2>
+		<p>By giving a parent element a data-role of collapsible-set, you can cause other collapsibles within that parent to close whenever a new one is opened, acting like an accordion widget:</p>
 		
+		<div data-role="collapsible-set">
+			<div data-role="collapsible">
+				<h3>I'm a header in a set of collapsibles</h3>
+				<p>I'm the collapsible content. I'm hidden by default because I have the "collapsed" state; you need to expand the header to see me.</p>
+			</div>
+			<div data-role="collapsible" data-state="collapsed">
+				<h3>I'm a header in a set of collapsibles</h3>
+				<p>I'm the collapsible content. I'm hidden by default because I have the "collapsed" state; you need to expand the header to see me.</p>
+			</div>
+			<div data-role="collapsible" data-state="collapsed">
+				<h3>I'm a header in a set of collapsibles</h3>
+				<p>I'm the collapsible content. I'm hidden by default because I have the "collapsed" state; you need to expand the header to see me.</p>
+			</div>
+		</div>
 		
 	
 	</div><!-- /content -->

--- a/docs/content/content-grids.html
+++ b/docs/content/content-grids.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 	<script type="text/javascript" src="../docs/docs.js"></script>
 	

--- a/docs/content/content-html.html
+++ b/docs/content/content-html.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 	<script type="text/javascript" src="../docs/docs.js"></script>
 	

--- a/docs/content/content-themes.html
+++ b/docs/content/content-themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 	<script type="text/javascript" src="../docs/docs.js"></script>
 </head> 

--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 	<script type="text/javascript" src="../docs/docs.js"></script>
 </head> 

--- a/docs/forms/forms-all.html
+++ b/docs/forms/forms-all.html
@@ -4,7 +4,6 @@
 	<title>jQuery Mobile Docs - Forms</title> 
 	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
-	<script type="text/javascript" src="../docs/docs.js"></script>
 </head> 
 <body> 
 
@@ -30,8 +29,8 @@
 			</div>
 			
 			<div data-role="fieldcontain">
-	         <label for="name">Password:</label>
-	         <input type="password" name="name" id="name" value=""  />
+	         <label for="password">Password:</label>
+	         <input type="password" name="password" id="password" value=""  />
 			</div>
 			 
 			<div data-role="fieldcontain">

--- a/docs/pages/dialog-alt.html
+++ b/docs/pages/dialog-alt.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 </head> 
 <body> 

--- a/docs/pages/dialog-buttons.html
+++ b/docs/pages/dialog-buttons.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 </head> 
 <body> 

--- a/docs/pages/dialog-success.html
+++ b/docs/pages/dialog-success.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 </head> 
 <body> 

--- a/docs/pages/docs-link-scenarios.html
+++ b/docs/pages/docs-link-scenarios.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html> 
+<html> 
+	<head> 
+	<title>jQuery Mobile Docs - Pages</title> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
+	<script type="text/javascript" src="../../js/all"></script>
+</head> 
+<body> 
+
+<div data-role="page">
+
+	<div data-role="header">
+		<h1>Linking pages</h1>
+	</div><!-- /header -->
+
+	<div data-role="content">
+			
+			<p>jQuery Mobile is designed to work with simple page linking conventions. The following list demonstrates how different types of links will be handled, either remotely or through an Ajax Request.</p> 
+
+			<ul data-role="listview" data-inset="true" data-theme="c" data-dividertheme="b">
+				<li data-role="list-divider">Examples of links that work within a single-page (if the page exists)</li>
+				<li><a href="docs/pages/index.html">[href="docs/pages/index.html"]</a></li>
+				<li><a href="/docs/toolbars/index.html">[href="/docs/toolbars/index.html"]</a></li>
+				<li><a href="#somelocalID">[href="#somelocalID"]</a></li>
+				<li>Note: an full URL to the same-domain will also work</li>
+				<li data-role="list-divider">Examples of links that trigger a refresh</li>
+				<li><a href="docs/pages/index.html" rel="external">[rel="external"]</a></li>
+				<li><a href="docs/pages/index.html" target="_blank">[target="_blank"]</a></li>
+				<li><a href="mailto:john@doe.com">[href="mailto:john@doe.com"]</a></li>
+				<li><a href="tel:543-434-3454">[href="tel:543-434-3454"]</a></li>
+				<li><a href="http://google.com">[href="http://google.com"]</a></li>
+				<li data-role="list-divider">Links that return false</li>
+				<li><a href="#">[href="#"]</a></li>
+			</ul>
+			
+	</div><!-- /content -->
+</div><!-- /page -->
+
+</body>
+</html>

--- a/docs/pages/transition-success.html
+++ b/docs/pages/transition-success.html
@@ -2,7 +2,7 @@
 <html> 
 	<head> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
-	<link rel="stylesheet"  href="../../css/all" /> 
+	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
 </head> 
 <body> 

--- a/docs/pages/transition-success.html
+++ b/docs/pages/transition-success.html
@@ -14,7 +14,7 @@
 	</div><!-- /header -->
 	
 	<div data-role="content">
-		<p>That was an animated page transition effect that we added with a <class>code> data-transition</code> attribute on the link.</p>
+		<p>That was an animated page transition effect that we added with a <code>data-transition</code> attribute on the link.</p>
 		<p>Since it uses CSS transforms, this should be hardware accelerated on many mobile devices.</p>
 		<p>What do you think?</p>
 		<a href="docs-transitions.html" data-role="button" data-theme="b">I like it</a>   

--- a/experiments/photos/_photo2.html
+++ b/experiments/photos/_photo2.html
@@ -4,29 +4,27 @@
 	<title>jQuery Mobile Framework - Photo 1</title> 
 	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
+		<link rel="stylesheet"  href="photos.css" />
+	<script type="text/javascript" src="photos.js"></script>
 </head> 
 <body> 
 
-<div data-role="page" data-fullscreen="true">
-	<link rel="stylesheet"  href="photos.css" />
-	<script type="text/javascript" src="photos.js"></script>
+<div data-role="page" data-fullscreen="true" class="photoview">
 	
 	<div data-role="header" id="">
 		<h1>A canoe</h1>
 		
 	</div>
 	
-	<div data-role="content" class="photoview">
+	<div data-role="content" >
 		
-		<a href="_photo3.html">
-			<img src="images/photo-canoe.jpeg" alt="photo-canoe" />
-		</a>
+		<img src="images/photo-canoe.jpeg" alt="photo-canoe" />
 		
 	</div>
 	
 	<div class="ui-footer ui-bar-a">
-		<a href="_photo1.html">Prev</a>
-		<a href="_photo3.html">Next</a>
+		<a href="index.html" class="prev">Prev</a>
+		<a href="_photo3.html" class="next">Next</a>
 	</div>
 
 

--- a/experiments/photos/_photo3.html
+++ b/experiments/photos/_photo3.html
@@ -4,29 +4,27 @@
 	<title>jQuery Mobile Framework - Photo 1</title> 
 	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
+		<link rel="stylesheet"  href="photos.css" />
+	<script type="text/javascript" src="photos.js"></script>
 </head> 
 <body> 
 
-<div data-role="page" data-fullscreen="true">
-	<link rel="stylesheet"  href="photos.css" />
-	<script type="text/javascript" src="photos.js"></script>
+<div data-role="page" data-fullscreen="true" class="photoview">
 	
 	<div data-role="header" id="photoview">
 		<h1>A dock</h1>
 		
 	</div>
 	
-	<div data-role="content" class="photoview">
+	<div data-role="content" >
 		
-		<a href="_photo4.html">
-			<img src="images/photo-dock.jpeg" alt="photo-dock" />
-		</a>
+		<img src="images/photo-dock.jpeg" alt="photo-dock" />
 		
 	</div>
 	
 	<div class="ui-footer ui-bar-a">
-		<a href="_photo2.html">Prev</a>
-		<a href="_photo4.html">Next</a>
+		<a href="_photo2.html" class="prev">Prev</a>
+		<a href="_photo4.html" class="next">Next</a>
 	</div>
 
 

--- a/experiments/photos/_photo4.html
+++ b/experiments/photos/_photo4.html
@@ -4,29 +4,27 @@
 	<title>jQuery Mobile Framework - Photo 1</title> 
 	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
+	<link rel="stylesheet"  href="photos.css" />
+	<script type="text/javascript" src="photos.js"></script>
 </head> 
 <body> 
 
-<div data-role="page" data-fullscreen="true">
-	<link rel="stylesheet"  href="photos.css" />
-	<script type="text/javascript" src="photos.js"></script>
+<div data-role="page" data-fullscreen="true" class="photoview">
 	
 	<div data-role="header">
 		<h1>A kayak</h1>
 		
 	</div>
 	
-	<div data-role="content" class="photoview">
+	<div data-role="content" >
 		
-		<a href="_photo5.html">
-			<img src="images/photo-kayak.jpeg" alt="photo-kayak" />
-		</a>
+		<img src="images/photo-kayak.jpeg" alt="photo-kayak" />
 		
 	</div>
 	
 	<div class="ui-footer ui-bar-a">
-		<a href="_photo3.html">Prev</a>
-		<a href="_photo5.html">Next</a>
+		<a href="_photo3.html" class="prev">Prev</a>
+		<a href="_photo5.html" class="next">Next</a>
 	</div>
 
 

--- a/experiments/photos/_photo5.html
+++ b/experiments/photos/_photo5.html
@@ -4,28 +4,26 @@
 	<title>jQuery Mobile Framework - Photo 1</title> 
 	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
+		<link rel="stylesheet"  href="photos.css" />
+	<script type="text/javascript" src="photos.js"></script>
 </head> 
 <body> 
 
-<div data-role="page" data-fullscreen="true">
-	<link rel="stylesheet"  href="photos.css" />
-	<script type="text/javascript" src="photos.js"></script>
+<div data-role="page" data-fullscreen="true" class="photoview">
 	<div data-role="header">
 		<h1>Nathan running</h1>
 		
 	</div>
 	
-	<div data-role="content" class="photoview">
+	<div data-role="content" >
 		
-		<a href="_photo6.html">
-			<img src="images/photo-run.jpeg" alt="photo-run"  />
-		</a>
+		<img src="images/photo-run.jpeg" alt="photo-run"  />
 		
 	</div>
 	
 	<div class="ui-footer ui-bar-a">
-		<a href="_photo4.html">Prev</a>
-		<a href="_photo6.html">Next</a>
+		<a href="_photo4.html" class="prev">Prev</a>
+		<a href="_photo6.html" class="next">Next</a>
 	</div>
 
 

--- a/experiments/photos/_photo6.html
+++ b/experiments/photos/_photo6.html
@@ -4,27 +4,26 @@
 	<title>jQuery Mobile Framework - Photo 1</title> 
 	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
+		<link rel="stylesheet"  href="photos.css" />
+	<script type="text/javascript" src="photos.js"></script>
 </head> 
 <body> 
 
-<div data-role="page" data-fullscreen="true">
-	<link rel="stylesheet"  href="photos.css" />
-	<script type="text/javascript" src="photos.js"></script>
+<div data-role="page" data-fullscreen="true" class="photoview">
 	<div data-role="header">
 		<h1>Sandy beach</h1>
 		
 	</div>
 	
-	<div data-role="content" class="photoview">
+	<div data-role="content" >
 		
-		<a href="_photo7.html">
-			<img src="images/photo-sand.jpeg" alt="photo-sand"  />
-		</a>
+		<img src="images/photo-sand.jpeg" alt="photo-sand"  />
 		
 	</div>
 	
 	<div class="ui-footer ui-bar-a">
-		<a href="_photo5.html">Prev</a>
+		<a href="_photo5.html" class="prev">Prev</a>
+		<a href="index.html" class="next">First</a>
 	</div>
 
 

--- a/experiments/photos/index.html
+++ b/experiments/photos/index.html
@@ -4,28 +4,26 @@
 	<title>jQuery Mobile Framework - Photo 1</title> 
 	<link rel="stylesheet"  href="../../themes/default" /> 
 	<script type="text/javascript" src="../../js/all"></script>
+	<link rel="stylesheet"  href="photos.css" />
+	<script type="text/javascript" src="photos.js"></script>
 </head> 
 <body> 
 
-<div data-role="page" data-fullscreen="true">
-	<link rel="stylesheet"  href="photos.css" />
-	<script type="text/javascript" src="photos.js"></script>
+<div data-role="page" data-fullscreen="true" class="photoview">
 	
 	<div data-role="header">
 		<h1>A bridge</h1>
 		
 	</div>
 	
-	<div data-role="content" class="photoview">
+	<div data-role="content" >
 		
-		<a href="_photo2.html">
-			<img src="images/photo-bridge.jpeg" alt="photo-bridge"  />
-		</a>
+		<img src="images/photo-bridge.jpeg" alt="photo-bridge"  />
 		
 	</div>
 	
 	<div data-role="footer">
-		<a href="_photo2.html">Next</a>
+		<a href="_photo2.html" class="next">Next</a>
 	</div>
 
 

--- a/experiments/photos/photos.css
+++ b/experiments/photos/photos.css
@@ -1,1 +1,2 @@
-#photoview img { width: 100%; }
+.photoview .ui-content { padding: 0; }
+.photoview img { width: 100%; }

--- a/experiments/photos/photos.js
+++ b/experiments/photos/photos.js
@@ -1,23 +1,21 @@
-$(function(){
-		$('.photoview')
-			.live('swipeleft',function(){
-				$(this).find('a').ajaxClick();
-			})
-			.live('swiperight',function(){
-				$(this).next().find('a:contains(Prev)').ajaxClick();
-			});
-		$('.photoview a').click(function(){
-			event.stopImmediatePropagation();
-		})
-		.tap(function(event){
-			$(this).ajaxClick();
-			event.stopImmediatePropagation();
-		})
-		.taphold(function(event){
-			$.fixedToolbars.toggle();
-			event.stopImmediatePropagation();
-		})
-		
-	}	
-});
+
+$('.photoview')
+	.live('pagebeforehide',function(){
+		$.fixedToolbars.hide(true);
+	})
+	.live('pageshow',function(){
+		$.fixedToolbars.show();
+	})
+	.live('swipeleft',function(){
+		$(this).find('a.next').click();
+	})
+	.live('swiperight',function(){
+		$(this).next().find('a.prev').click();
+	});
+
+$('.photoview img').live('mousedown touchstart',function(event){
+	event.preventDefault();
+})	
+	
+
 

--- a/experiments/ui-datepicker/jquery.ui.datepicker.css
+++ b/experiments/ui-datepicker/jquery.ui.datepicker.css
@@ -23,6 +23,6 @@ div.hasDatepicker{ display: block; padding: 0; overflow: visible;  margin: 8px 0
 .ui-datepicker td { border-width: 1px; padding: 0; text-align: center; }
 .ui-datepicker td span, .ui-datepicker td a { display: block; padding: .2em 0; font-weight: bold; margin: 0; border-width: 0; text-align: center; text-decoration: none; }
 
-@media screen and (min-width: 480px){ 
+.min-width-480 { 
 	div.hasDatepicker  { width: 63%; display: inline-block; margin: 0; } 
 }

--- a/experiments/ui-datepicker/jquery.ui.datepicker.css
+++ b/experiments/ui-datepicker/jquery.ui.datepicker.css
@@ -23,6 +23,6 @@ div.hasDatepicker{ display: block; padding: 0; overflow: visible;  margin: 8px 0
 .ui-datepicker td { border-width: 1px; padding: 0; text-align: center; }
 .ui-datepicker td span, .ui-datepicker td a { display: block; padding: .2em 0; font-weight: bold; margin: 0; border-width: 0; text-align: center; text-decoration: none; }
 
-.min-width-480 { 
+.min-width-480px { 
 	div.hasDatepicker  { width: 63%; display: inline-block; margin: 0; } 
 }

--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -81,10 +81,10 @@ $.fn.collapsible = function(options){
 			
 		collapsibleHeading.click(function(){ 
 			if( collapsibleHeading.is('.ui-collapsible-heading-collapsed') ){
-				collapsibleContain.trigger('expand'); 
+				collapsibleContain.triggerHandler('expand'); 
 			}	
 			else {
-				collapsibleContain.trigger('collapse'); 
+				collapsibleContain.triggerHandler('collapse'); 
 			}
 			return false;
 		});

--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -19,7 +19,8 @@ $.fn.collapsible = function(options){
 		//define
 		var collapsibleContain = $(this).addClass('ui-collapsible-contain'),
 			collapsibleHeading = $(this).find(o.heading).eq(0),
-			collapsibleContent = collapsibleContain.wrapInner('<div class="ui-collapsible-content"></div>').find('.ui-collapsible-content');				
+			collapsibleContent = collapsibleContain.wrapInner('<div class="ui-collapsible-content"></div>').find('.ui-collapsible-content'),
+			collapsibleParent = $(this).closest('[data-role=collapsible-set]').addClass('ui-collapsible-set');				
 		
 		//replace collapsibleHeading if it's a legend	
 		if(collapsibleHeading.is('legend')){
@@ -36,17 +37,12 @@ $.fn.collapsible = function(options){
 			.wrapInner('<a href="#" class="ui-collapsible-heading-toggle"></a>')
 			.find('a:eq(0)')
 			.buttonMarkup({
-				shadow: true,
+				shadow: !!!collapsibleParent.length,
 				corners:false,
 				iconPos: 'left',
 				icon: 'plus',
 				theme: o.theme
 			})
-			.removeClass('ui-btn-corner-all')
-			.addClass('ui-corner-all')
-			.find('.ui-btn-inner')
-			.removeClass('ui-btn-corner-all')
-			.addClass('ui-corner-all')
 			.find('.ui-icon')
 			.removeAttr('class')
 			.buttonMarkup({
@@ -56,35 +52,91 @@ $.fn.collapsible = function(options){
 				icon: 'plus',
 				theme: o.iconTheme
 			});
+			
+			if( !collapsibleParent.length ){
+				collapsibleHeading
+					.find('a:eq(0)')	
+					.addClass('ui-corner-all')
+						.find('.ui-btn-inner')
+						.addClass('ui-corner-all');
+			}
+			else {
+				if( collapsibleContain.data('collapsible-last') ){
+					collapsibleHeading
+						.find('a:eq(0), .ui-btn-inner')	
+							.addClass('ui-corner-bottom');
+				}					
+			}
+			
 		
 		//events
 		collapsibleContain	
-			.bind('collapse', function(){
-				collapsibleHeading
-					.addClass('ui-collapsible-heading-collapsed')
-					.find('.ui-collapsible-heading-status').text(o.expandCueText);
-				
-				collapsibleHeading.find('.ui-icon').removeClass('ui-icon-minus').addClass('ui-icon-plus');	
-				collapsibleContent.addClass('ui-collapsible-content-collapsed').attr('aria-hidden',true);						
+			.bind('collapse', function(event){
+				if( !event.isDefaultPrevented() ){
+					event.preventDefault();
+					collapsibleHeading
+						.addClass('ui-collapsible-heading-collapsed')
+						.find('.ui-collapsible-heading-status').text(o.expandCueText);
+					
+					collapsibleHeading.find('.ui-icon').removeClass('ui-icon-minus').addClass('ui-icon-plus');	
+					collapsibleContent.addClass('ui-collapsible-content-collapsed').attr('aria-hidden',true);
+					
+					if( collapsibleContain.data('collapsible-last') ){
+						collapsibleHeading
+							.find('a:eq(0), .ui-btn-inner')
+							.addClass('ui-corner-bottom');
+					}
+				}						
 				
 			})
-			.bind('expand', function(){
-				collapsibleHeading
-					.removeClass('ui-collapsible-heading-collapsed')
-					.find('.ui-collapsible-heading-status').text(o.collapseCueText);
-				
-				collapsibleHeading.find('.ui-icon').removeClass('ui-icon-plus').addClass('ui-icon-minus');	
-				collapsibleContent.removeClass('ui-collapsible-content-collapsed').attr('aria-hidden',false);
-
+			.bind('expand', function(event){
+				if( !event.isDefaultPrevented() ){
+					event.preventDefault();
+					collapsibleHeading
+						.removeClass('ui-collapsible-heading-collapsed')
+						.find('.ui-collapsible-heading-status').text(o.collapseCueText);
+					
+					collapsibleHeading.find('.ui-icon').removeClass('ui-icon-plus').addClass('ui-icon-minus');	
+					collapsibleContent.removeClass('ui-collapsible-content-collapsed').attr('aria-hidden',false);
+					
+					if( collapsibleContain.data('collapsible-last') ){
+						collapsibleHeading
+							.find('a:eq(0), .ui-btn-inner')
+							.removeClass('ui-corner-bottom');
+					}
+					
+				}
 			})
 			.trigger(o.collapsed ? 'collapse' : 'expand');
 			
+		
+		//close others in a set
+		if( collapsibleParent.length && !collapsibleParent.data("collapsiblebound") ){
+			collapsibleParent
+				.data("collapsiblebound", true)
+				.bind("expand", function( event ){
+					$(this).find( ".ui-collapsible-contain" )
+						.not( $(event.target).closest( ".ui-collapsible-contain" ) )
+						.not( "> .ui-collapsible-contain .ui-collapsible-contain" )
+						.trigger( "collapse" );
+				})
+			var set = collapsibleParent.find('[data-role=collapsible]')
+					
+			set.first()
+				.find('a:eq(0)')	
+				.addClass('ui-corner-top')
+					.find('.ui-btn-inner')
+					.addClass('ui-corner-top');
+					
+			set.last().data('collapsible-last', true)	
+		}
+					
 		collapsibleHeading.click(function(){ 
 			if( collapsibleHeading.is('.ui-collapsible-heading-collapsed') ){
-				collapsibleContain.triggerHandler('expand'); 
+				collapsibleContain.trigger('expand'); 
 			}	
 			else {
-				collapsibleContain.triggerHandler('collapse'); 
+				collapsibleContain.trigger('collapse'); 
 			}
 			return false;
 		});

--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -4,23 +4,36 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) and GPL (GPL-LICENSE.txt) licenses.
 * Note: Code is in draft form and is subject to change 
 */ 
-(function($){
-$.fn.customButton = function(){
-	return $(this).each(function(){	
-		var button = $(this).addClass('ui-btn-hidden').attr('tabindex','-1');
+(function ( $ ) {
+$.widget( "mobile.button", $.mobile.widget, {
+	options: {},
+	_create: function(){
+		var $el = this.element;
+			$el
+				.addClass('ui-btn-hidden')
+				.attr('tabindex','-1');
+		
 		//add ARIA role
-		$('<a href="#" role="button">'+ (button.text() || button.val()) +'</a>')
-			.buttonMarkup({
-				theme: button.data('theme'), 
-				icon: button.data('icon'),
-				iconpos: button.data('iconpos'),
-				inline: button.data('inline')
-			})
+		$( "<a>", { 
+				"href": "#",
+				"role": "button",
+				"aria-label": $el.attr( "type" ) 
+			} )
+			.text( $el.text() || $el.val() )
+			.insertBefore( $el )
 			.click(function(){
-				button.click(); 
+				$el.click(); 
 				return false;
 			})
-			.insertBefore(button);
-	});
-};
-})(jQuery);
+			.buttonMarkup({
+				theme: $el.data("theme"), 
+				icon: $el.data("icon"),
+				iconpos: $el.data("iconpos"),
+				inline: $el.data("inline"),
+				corners: $el.data("corners"),
+				shadow: $el.data("shadow"),
+				iconshadow: $el.data("icon-shadow")
+			});
+	}
+});
+})( jQuery );

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -4,82 +4,86 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) and GPL (GPL-LICENSE.txt) licenses.
 * Note: Code is in draft form and is subject to change 
 */  
-(function(jQuery){
+(function ( $ ) {
+$.widget( "mobile.checkboxradio", $.mobile.widget, {
+	options: {
+		theme: undefined,
+		icon: undefined
+	},
+	_create: function(){
+		var input = this.element,
+			label = jQuery("label[for='" + input.attr( "id" ) + "']"),
+			inputtype = input.attr( "type" ),
+			checkedicon = "ui-icon-" + inputtype + "-on",
+			uncheckedicon = "ui-icon-" + inputtype + "-off";
 
-jQuery.fn.customCheckboxRadio = function( options ) {
-	return this.each(function() {
-		var input = jQuery( this ),
-			type = input.attr( "type" );
-
-		if ( type === "checkbox" || type === "radio" ) {
-			var o = jQuery.extend({
-				theme: input.data( "theme" ),
-				icon: input.data( "icon" ) || !input.parents( "[data-type='horizontal']" ).length,
-				checkedicon: "ui-icon-" + type + "-on",
-				uncheckedicon: "ui-icon-" + type + "-off"
-			}, options );
-			
-			// get the associated label using the input's id
-			var label = jQuery("label[for='" + input.attr( "id" ) + "']")
-				.buttonMarkup({
-					iconpos: o.icon ? "left" : "",
-					theme: o.theme,
-					icon: o.icon ? o.uncheckedicon : null,
-					shadow: false
-				});
+		if ( inputtype != "checkbox" && inputtype != "radio" ) { return; }
 						
-			var icon = label.find( ".ui-icon" );
-			
-			// wrap the input + label in a div 
-			input
-				.add( label )
-				.wrapAll( "<div class='ui-" + type +"'></div>" );
-			
-			// necessary for browsers that don't support the :hover pseudo class on labels
-			label.bind({
-				mousedown: function() {
-					label.data( "state", input.attr( "checked" ) );
-				},
+		label
+			.buttonMarkup({
+				iconpos: this.options.icon,
+				theme: this.options.theme,
+				icon: this.options.icon ? uncheckedicon : ( this.element.parents( "[data-type='horizontal']" ).length ? undefined : uncheckedicon ),
+				shadow: false
+			});
+		
+		// wrap the input + label in a div 
+		input
+			.add( label )
+			.wrapAll( "<div class='ui-" + inputtype +"'></div>" );
+		
+		label.bind({
+			mousedown: function() {
+				label.data( "state", input.attr( "checked" ) );
+			},
+			click: function() {
+				setTimeout(function() {
+					if ( input.attr( "checked" ) === label.data( "state" ) ) {
+						input.trigger( "click" );
+					}
+				}, 1);
+			}
+		});
+		
+		//bind custom event, trigger it, bind click,focus,blur events					
+		input
+			.bind({
+
 				click: function() {
-					setTimeout(function() {
-						if ( input.attr( "checked" ) === label.data( "state" ) ) {
-							input.trigger( "click" );
-						}
-					}, 1);
+					jQuery( "input[name='" + input.attr( "name" ) + "']" ).checkboxradio( "refresh" );
+				},
+
+				focus: function() { 
+					label.addClass( "ui-focus" ); 
+				},
+
+				blur: function() {
+					label.removeClass( "ui-focus" );
 				}
 			});
 			
-			//bind custom event, trigger it, bind click,focus,blur events					
-			input
-				.bind({
-					updateState: function() {
-						if ( this.checked ) {
-							label.addClass( "ui-btn-active" );
-							icon.addClass( o.checkedicon );
-							icon.removeClass( o.uncheckedicon );
+		this.refresh();
+		
+	},
+	
+	refresh: function( ){
+		var input = this.element,
+			label = jQuery("label[for='" + input.attr( "id" ) + "']"),
+			inputtype = input.attr( "type" ),
+			icon = label.find( ".ui-icon" ),
+			checkedicon = "ui-icon-" + inputtype + "-on",
+			uncheckedicon = "ui-icon-" + inputtype + "-off";
+		
+		if ( input[0].checked ) {
+			label.addClass( "ui-btn-active" );
+			icon.addClass( checkedicon );
+			icon.removeClass( uncheckedicon );
 
-						} else {
-							label.removeClass( "ui-btn-active" ); 
-							icon.removeClass( o.checkedicon );
-							icon.addClass( o.uncheckedicon );
-						}
-					},
-
-					click: function() {
-						jQuery( "input[name='" + input.attr( "name" ) + "']" ).trigger( "updateState" );
-					},
-
-					focus: function() { 
-						label.addClass( "ui-focus" ); 
-					},
-
-					blur: function() {
-						label.removeClass( "ui-focus" );
-					}
-				})
-				.trigger( "updateState" );
+		} else {
+			label.removeClass( "ui-btn-active" ); 
+			icon.removeClass( checkedicon );
+			icon.addClass( uncheckedicon );
 		}
-	});
-};
-
-})(jQuery);
+	}
+});
+})( jQuery );

--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -28,7 +28,6 @@ $.fn.customSelect = function(options){
 		button = $( "<a>", { 
 				"href": "#",
 				"role": "button",
-				"title": "select menu",
 				"id": buttonId,
 				"aria-haspopup": "true",
 				"aria-owns": menuId 

--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -24,14 +24,14 @@ jQuery.fn.customTextInput = function(options){
 		if(o.search){
 			focusedEl = input.wrap('<div class="ui-input-search ui-shadow-inset ui-btn-corner-all ui-body-c ui-btn-shadow ui-icon-search"></div>').parent();
 			var clearbtn = $('<a href="#" class="ui-input-clear" title="clear text">clear text</a>')
-				.buttonMarkup({icon: 'delete', iconpos: 'notext', corners:true, shadow:true})
 				.click(function(){
 					input.val('').focus();
 					input.trigger('change'); 
 					clearbtn.addClass('ui-input-clear-hidden');
 					return false;
 				})
-				.appendTo(focusedEl);
+				.appendTo(focusedEl)
+				.buttonMarkup({icon: 'delete', iconpos: 'notext', corners:true, shadow:true});
 			
 			function toggleClear(){
 				if(input.val() == ''){

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -402,17 +402,18 @@
 	//add breakpoint classes for faux media-q support
 	function resolutionBreakpoints(){
 		var currWidth = $window.width(),
-			classPrefix = "maxwidth-",
-			breakPoint;
+			minPrefix = "minwidth-",
+			minBreakpoints = [];
 			
-		$html.removeClass( classPrefix + $.mobile.resolutionBreakpoints.join(" " + classPrefix) );			
+		$html.removeClass( minPrefix + $.mobile.resolutionBreakpoints.join(" " + minPrefix) );
+					
 		$.each($.mobile.resolutionBreakpoints,function( i ){
 			if( currWidth >= $.mobile.resolutionBreakpoints[ i ] ){
-				breakPoint = $.mobile.resolutionBreakpoints[ i ];
+				minBreakpoints.push( $.mobile.resolutionBreakpoints[ i ] );
 			}
 		});
 		
-		$html.addClass(classPrefix+breakPoint);	
+		$html.addClass( minPrefix + minBreakpoints.join(" " + minPrefix) );	
 	};
 	
 	//common breakpoints, overrideable, changeable

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -399,22 +399,25 @@
 			maxPrefix = "max-width-",
 			minBreakpoints = [],
 			maxBreakpoints = [],
+			unit = "px",
 			breakpointClasses;
+			console.log(minPrefix + resolutionBreakpoints.join(unit + " " + minPrefix) + unit + " " + 
+			maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix) + unit);
 			
-		$html.removeClass( minPrefix + resolutionBreakpoints.join(" " + minPrefix) + " " + 
-			maxPrefix + resolutionBreakpoints.join(" " + maxPrefix) );
+		$html.removeClass( minPrefix + resolutionBreakpoints.join(unit + " " + minPrefix) + unit + " " + 
+			maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix) + unit );
 					
 		$.each(resolutionBreakpoints,function( i ){
 			if( currWidth >= resolutionBreakpoints[ i ] ){
-				minBreakpoints.push( resolutionBreakpoints[ i ] );
+				minBreakpoints.push( minPrefix + resolutionBreakpoints[ i ] + unit );
 			}
 			if( currWidth <= resolutionBreakpoints[ i ] ){
-				maxBreakpoints.push( resolutionBreakpoints[ i ] );
+				maxBreakpoints.push( maxPrefix + resolutionBreakpoints[ i ] + unit );
 			}
 		});
 		
-		if( minBreakpoints.length ){ breakpointClasses = minPrefix + minBreakpoints.join(" " + minPrefix); }
-		if( maxBreakpoints.length ){ breakpointClasses += " " +  maxPrefix + maxBreakpoints.join(" " + maxPrefix); }
+		if( minBreakpoints.length ){ breakpointClasses = minBreakpoints.join(" "); }
+		if( maxBreakpoints.length ){ breakpointClasses += " " +  maxBreakpoints.join(" "); }
 		
 		$html.addClass( breakpointClasses );	
 	};

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -401,8 +401,8 @@
 			maxBreakpoints = [],
 			breakpointClasses;
 			
-		$html.removeClass( minPrefix + resolutionBreakpoints.join(" " + minPrefix) + maxPrefix +
-			 " " +  resolutionBreakpoints.join(" " + maxPrefix) );
+		$html.removeClass( minPrefix + resolutionBreakpoints.join(" " + minPrefix) + " " + 
+			maxPrefix + resolutionBreakpoints.join(" " + maxPrefix) );
 					
 		$.each(resolutionBreakpoints,function( i ){
 			if( currWidth >= resolutionBreakpoints[ i ] ){

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -113,12 +113,14 @@
 			//get href, remove same-domain protocol and host
 			href = $this.attr( "href" ).replace( location.protocol + "//" + location.host, ""),
 			//if it still starts with a protocol, it's external, or could be :mailto, etc
-			external = /^(:?\w+:|#)/.test( href ) || $this.is( "[target],[rel=external]" );
+			external = /^(:?\w+:)/.test( href ) || $this.is( "[target],[rel=external]" );
 
 		if( href === '#' ){
 			//for links created purely for interaction - ignore
 			return false;
 		}
+		
+		href.replace(/^#/,'');
 		
 		activeClickedLink = $this.closest( ".ui-btn" ).addClass( activeBtnClass );
 		

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -113,10 +113,9 @@
 			//get href, remove same-domain protocol and host
 			href = $this.attr( "href" ).replace( location.protocol + "//" + location.host, ""),
 			//if it still starts with a protocol, it's external, or could be :mailto, etc
-			external = /^(:?\w+:|#)/.test( href ) || $this.is( "[target],[rel=external]" ),
-			nullLink = href == '#';
+			external = /^(:?\w+:|#)/.test( href ) || $this.is( "[target],[rel=external]" );
 
-		if( nullLink ){
+		if( href === '#' ){
 			//for links created purely for interaction - ignore
 			return false;
 		}

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -402,7 +402,7 @@
 	//add breakpoint classes for faux media-q support
 	function resolutionBreakpoints(){
 		var currWidth = $window.width(),
-			minPrefix = "minwidth-",
+			minPrefix = "min-width-",
 			minBreakpoints = [];
 			
 		$html.removeClass( minPrefix + $.mobile.resolutionBreakpoints.join(" " + minPrefix) );

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -59,7 +59,8 @@
 		nextPageRole = null,
 		hashListener = true,
 		unHashedSelectors = '[data-rel=dialog]',
-		baseUrl = location.protocol + '//' + location.host + location.pathname;
+		baseUrl = location.protocol + '//' + location.host + location.pathname,
+		resolutionBreakpoints = [320,480,768,1024];
 	
 	// TODO: don't expose (temporary during code reorg)
 	$.mobile.urlStack = urlStack;
@@ -392,33 +393,43 @@
 	});
 	
 	//add breakpoint classes for faux media-q support
-	function resolutionBreakpoints(){
+	function detectResolutionBreakpoints(){
 		var currWidth = $window.width(),
 			minPrefix = "min-width-",
 			maxPrefix = "max-width-",
 			minBreakpoints = [],
 			maxBreakpoints = [];
 			
-		$html.removeClass( minPrefix + $.mobile.resolutionBreakpoints.join(" " + minPrefix) + maxPrefix +
-			 " " +  $.mobile.resolutionBreakpoints.join(" " + maxPrefix) );
+		$html.removeClass( minPrefix + resolutionBreakpoints.join(" " + minPrefix) + maxPrefix +
+			 " " +  resolutionBreakpoints.join(" " + maxPrefix) );
 					
-		$.each($.mobile.resolutionBreakpoints,function( i ){
-			if( currWidth >= $.mobile.resolutionBreakpoints[ i ] ){
-				minBreakpoints.push( $.mobile.resolutionBreakpoints[ i ] );
+		$.each(resolutionBreakpoints,function( i ){
+			if( currWidth >= resolutionBreakpoints[ i ] ){
+				minBreakpoints.push( resolutionBreakpoints[ i ] );
 			}
-			if( currWidth <= $.mobile.resolutionBreakpoints[ i ] ){
-				maxBreakpoints.push( $.mobile.resolutionBreakpoints[ i ] );
+			if( currWidth <= resolutionBreakpoints[ i ] ){
+				maxBreakpoints.push( resolutionBreakpoints[ i ] );
 			}
 		});
 		
 		$html.addClass( minPrefix + minBreakpoints.join(" " + minPrefix) + " " + maxPrefix + maxBreakpoints.join(" " + maxPrefix) );	
 	};
 	
-	//common breakpoints, overrideable, changeable
-	$.mobile.resolutionBreakpoints = [320,480,768,1024];
-	$window.bind( "orientationchange resize", resolutionBreakpoints);
-	resolutionBreakpoints();
+	//add breakpoints now and on oc/resize events
+	$window.bind( "orientationchange resize", detectResolutionBreakpoints);
+	detectResolutionBreakpoints();
 	
+	//common breakpoints, overrideable, changeable
+	$.mobile.addResolutionBreakpoints = function( newbps ){
+		if( $.type( newbps ) === "array" ){
+			resolutionBreakpoints = resolutionBreakpoints.concat( newbps );
+		}
+		else {
+			resolutionBreakpoints.push( newbps );
+		}
+		detectResolutionBreakpoints();
+	}
+		
 	//insert mobile meta - these will need to be configurable somehow.
 	var headPrepends = 
 	$head.prepend(

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -399,7 +399,8 @@
 			minBreakpoints = [],
 			maxBreakpoints = [];
 			
-		$html.removeClass( minPrefix + $.mobile.resolutionBreakpoints.join(" " + minPrefix) + maxPrefix + " " +  $.mobile.resolutionBreakpoints.join(" " + maxPrefix) );
+		$html.removeClass( minPrefix + $.mobile.resolutionBreakpoints.join(" " + minPrefix) + maxPrefix +
+			 " " +  $.mobile.resolutionBreakpoints.join(" " + maxPrefix) );
 					
 		$.each($.mobile.resolutionBreakpoints,function( i ){
 			if( currWidth >= $.mobile.resolutionBreakpoints[ i ] ){

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -120,8 +120,6 @@
 			return false;
 		}
 		
-		href.replace(/^#/,'');
-		
 		activeClickedLink = $this.closest( ".ui-btn" ).addClass( activeBtnClass );
 		
 		if( external ){
@@ -140,6 +138,8 @@
 			if( href.indexOf('/') && href.indexOf('#') !== 0 ){
 				href = getBaseURL() + href;
 			}
+			
+			href.replace(/^#/,'');
 			
 			changePage(href, pageTransition, forceBack, changeHashOnSuccess);			
 		}

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -398,7 +398,8 @@
 			minPrefix = "min-width-",
 			maxPrefix = "max-width-",
 			minBreakpoints = [],
-			maxBreakpoints = [];
+			maxBreakpoints = [],
+			breakpointClasses;
 			
 		$html.removeClass( minPrefix + resolutionBreakpoints.join(" " + minPrefix) + maxPrefix +
 			 " " +  resolutionBreakpoints.join(" " + maxPrefix) );
@@ -412,7 +413,10 @@
 			}
 		});
 		
-		$html.addClass( minPrefix + minBreakpoints.join(" " + minPrefix) + " " + maxPrefix + maxBreakpoints.join(" " + maxPrefix) );	
+		if( minBreakpoints.length ){ breakpointClasses = minPrefix + minBreakpoints.join(" " + minPrefix); }
+		if( maxBreakpoints.length ){ breakpointClasses += " " +  maxPrefix + maxBreakpoints.join(" " + maxPrefix); }
+		
+		$html.addClass( breakpointClasses );	
 	};
 	
 	//add breakpoints now and on oc/resize events

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -403,17 +403,22 @@
 	function resolutionBreakpoints(){
 		var currWidth = $window.width(),
 			minPrefix = "min-width-",
-			minBreakpoints = [];
+			maxPrefix = "max-width-",
+			minBreakpoints = [],
+			maxBreakpoints = [];
 			
-		$html.removeClass( minPrefix + $.mobile.resolutionBreakpoints.join(" " + minPrefix) );
+		$html.removeClass( minPrefix + $.mobile.resolutionBreakpoints.join(" " + minPrefix) + maxPrefix + " " +  $.mobile.resolutionBreakpoints.join(" " + maxPrefix) );
 					
 		$.each($.mobile.resolutionBreakpoints,function( i ){
 			if( currWidth >= $.mobile.resolutionBreakpoints[ i ] ){
 				minBreakpoints.push( $.mobile.resolutionBreakpoints[ i ] );
 			}
+			if( currWidth <= $.mobile.resolutionBreakpoints[ i ] ){
+				maxBreakpoints.push( $.mobile.resolutionBreakpoints[ i ] );
+			}
 		});
 		
-		$html.addClass( minPrefix + minBreakpoints.join(" " + minPrefix) );	
+		$html.addClass( minPrefix + minBreakpoints.join(" " + minPrefix) + " " + maxPrefix + maxBreakpoints.join(" " + maxPrefix) );	
 	};
 	
 	//common breakpoints, overrideable, changeable

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -189,6 +189,14 @@
 		return wrapper;
 	}
 	
+	//remove active classes after page transition or error
+	function removeActiveLinkClass(){
+		if(activeClickedLink){
+			activeClickedLink.removeClass( activeBtnClass );
+			activeClickedLink = null;
+		}
+	}
+	
 
 	//for getting or creating a new page 
 	function changePage( to, transition, back, changeHash){
@@ -239,11 +247,7 @@
 						hashListener = true;
 					}, 500);
 				}
-				//remove active classes
-				if(activeClickedLink){
-					activeClickedLink.removeClass( activeBtnClass );
-					activeClickedLink = null;
-				}
+				removeActiveLinkClass();
 			}
 			
 			if(transition){		
@@ -341,7 +345,7 @@
 				},
 				error: function() {
 					pageLoading( true );
-
+					removeActiveLinkClass();
 					jQuery("<div class='ui-loader ui-overlay-shadow ui-body-e ui-corner-all'><h1>Error Loading Page</h1></div>")
 						.css({ "display": "block", "opacity": 0.96, "top": $(window).scrollTop() + 100 })
 						.appendTo( $pageContainer )

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -46,6 +46,8 @@
 		$pageContainer,
 		startPageId = 'ui-page-start',
 		activePageClass = 'ui-page-active',
+		activeBtnClass = 'ui-btn-active',
+		activeClickedLink = null,
 		pageTransition,
 		forceBack,
 		transitions = 'slide slideup slidedown pop flip fade',
@@ -118,7 +120,10 @@
 			//for links created purely for interaction - ignore
 			return false;
 		}
-		else if( external ){
+		
+		activeClickedLink = $this.closest( ".ui-btn" ).addClass( activeBtnClass );
+		
+		if( external ){
 			//deliberately redirect, in case click was triggered
 			location.href = href;
 		}
@@ -232,6 +237,11 @@
 					setTimeout(function(){
 						hashListener = true;
 					}, 500);
+				}
+				//remove active classes
+				if(activeClickedLink){
+					activeClickedLink.removeClass( activeBtnClass );
+					activeClickedLink = null;
 				}
 			}
 			

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -130,7 +130,7 @@
 			//use ajax
 			var pageTransition = $this.data( "transition" ) || "slide",
 				forceBack = $this.data( "back" ) || undefined,
-				changeHashOnSuccess = !$(this).is(unHashedSelectors);
+				changeHashOnSuccess = !$this.is(unHashedSelectors);
 				
 			nextPageRole = $this.attr( "data-rel" );	
 				

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -104,47 +104,39 @@
 		$('#ui-base').attr('href', baseUrl);
 	}
 	
-	
-	// send a link through hash tracking
-	jQuery.fn.ajaxClick = function() {
-		var href = jQuery( this ).attr( "href" );
-		pageTransition = jQuery( this ).data( "transition" ) || "slide";
-		forceBack = jQuery( this ).data( "back" ) || undefined;
-		nextPageRole = jQuery( this ).attr( "data-rel" );
-		  	
-		//find new base for url building
-		var newBaseURL = getBaseURL();
-		
-		//if href is absolute but local, or a local ID, no base needed
-		if( /^\//.test(href) || (/https?:\/\//.test(href) && !!(href).match(location.hostname)) || /^#/.test(href) ){
-			newBaseURL = '';
+	//click routing - direct to HTTP or Ajax, accordingly
+	jQuery( "a" ).live( "click", function(event) {
+		var $this = $(this),
+			//get href, remove same-domain protocol and host
+			href = $this.attr( "href" ).replace( location.protocol + "//" + location.host, ""),
+			//if it still starts with a protocol, it's external, or could be :mailto, etc
+			external = /^\w+:|#/.test( href ) || $this.is( "[target],[rel=external]" ),
+			nullLink = href == '#';
+
+		if( nullLink ){
+			//for links created purely for interaction - ignore
+			return false;
 		}
-		
-		// set href to relative path using baseURL and
-		if( !/https?:\/\//.test(href) ){
-			href = newBaseURL + href;
+		else if( external ){
+			//deliberately redirect, in case click was triggered
+			location.href = href;
 		}
-						
-		//if it's a non-local-anchor and Ajax is not supported, or if it's an external link, go to page without ajax
-		if ( ( /^[^#]/.test(href) && !jQuery.support.ajax ) || ( /https?:\/\//.test(href) && !!!href.match(location.hostname) ) ) {
-			location = href
-		}
-		else{			
-			if( $(this).is(unHashedSelectors) ){
-				changePage(href, pageTransition, undefined);
-			}
-			else{
-				changePage(href, pageTransition, undefined, true);
+		else {	
+			//use ajax
+			var pageTransition = $this.data( "transition" ) || "slide",
+				forceBack = $this.data( "back" ) || undefined,
+				changeHashOnSuccess = !$(this).is(unHashedSelectors);
+				
+			nextPageRole = $this.attr( "data-rel" );	
+				
+			//if it's a relative href, prefix href with base url
+			if( href.indexOf('/') !== 0 && href.indexOf('#') !== 0 ){
+				href = getBaseURL() + href;
 			}
 			
+			changePage(href, pageTransition, forceBack, changeHashOnSuccess);			
 		}
-		return this;
-	};
-	
-	// ajaxify all navigable links
-	jQuery( "a:not([href='#']):not([target]):not([rel='external']):not([href^='mailto:'])" ).live( "click", function(event) {
-		jQuery( this ).ajaxClick();
-		return false;
+		event.preventDefault();
 	});
 	
 	// turn on/off page loading message.
@@ -199,7 +191,7 @@
 			from = toIsArray ? to[0] : $.activePage,
 			to = toIsArray ? to[1] : to,
 			url = fileUrl = $.type(to) === "string" ? to.replace( /^#/, "" ) : null,
-			back = (back !== undefined) ? back : (forceBack || ( urlStack.length > 1 && urlStack[ urlStack.length - 2 ].url === url )),
+			back = (back !== undefined) ? back : ( urlStack.length > 1 && urlStack[ urlStack.length - 2 ].url === url ),
 			transition = (transition !== undefined) ? transition :  ( pageTransition || "slide" );
 		
 		//unset pageTransition, forceBack	

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -478,9 +478,9 @@
 
 	//dom-ready
 	jQuery(function(){
-		
+		var $pages = jQuery("[data-role='page']");
 		//set up active page
-		$startPage = $.activePage = jQuery("[data-role='page']").first();
+		$startPage = $.activePage = $pages.first();
 		
 		//set page container
 		$pageContainer = $startPage.parent();
@@ -495,7 +495,7 @@
 		}
 		
 		//initialize all pages present
-		jQuery("[data-role='page']").page();
+		$pages.page();
 		
 		//trigger a new hashchange, hash or not
 		$window.trigger( "hashchange", { manuallyTriggered: true } );

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -314,10 +314,8 @@
 					if( !$.support.dynamicBaseTag ){
 						var baseUrl = getBaseURL(fileUrl);
 						to.find('[src],[href]').each(function(){
-							var thisHref = $(this).attr('href'),
-								thisSrc = $(this).attr('src'),
-								thisAttr = thisHref ? 'href' : 'src',
-								thisUrl = thisHref || thisSrc;
+							var thisAttr = $(this).is('[href]') ? 'href' : 'src',
+								thisUrl = $(this).attr(thisAttr);
 							
 							//if full path exists and is same, chop it - helps IE out
 							thisUrl.replace( location.protocol + '//' + location.host + location.pathname, '' );

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -191,10 +191,10 @@
 	
 	//remove active classes after page transition or error
 	function removeActiveLinkClass(){
-		if(activeClickedLink){
+		if(activeClickedLink && !activeClickedLink.closest( '.ui-page-active' ).length ){
 			activeClickedLink.removeClass( activeBtnClass );
-			activeClickedLink = null;
 		}
+		activeClickedLink = null;
 	}
 	
 

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -113,7 +113,7 @@
 			//get href, remove same-domain protocol and host
 			href = $this.attr( "href" ).replace( location.protocol + "//" + location.host, ""),
 			//if it still starts with a protocol, it's external, or could be :mailto, etc
-			external = /^\w+:|#/.test( href ) || $this.is( "[target],[rel=external]" ),
+			external = /^(:?\w+:|#)/.test( href ) || $this.is( "[target],[rel=external]" ),
 			nullLink = href == '#';
 
 		if( nullLink ){

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -411,8 +411,6 @@
 			maxBreakpoints = [],
 			unit = "px",
 			breakpointClasses;
-			console.log(minPrefix + resolutionBreakpoints.join(unit + " " + minPrefix) + unit + " " + 
-			maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix) + unit);
 			
 		$html.removeClass( minPrefix + resolutionBreakpoints.join(unit + " " + minPrefix) + unit + " " + 
 			maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix) + unit );

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -135,7 +135,7 @@
 			nextPageRole = $this.attr( "data-rel" );	
 				
 			//if it's a relative href, prefix href with base url
-			if( href.indexOf('/') !== 0 && href.indexOf('#') !== 0 ){
+			if( href.indexOf('/') && href.indexOf('#') !== 0 ){
 				href = getBaseURL() + href;
 			}
 			

--- a/js/jquery.mobile.listview.filter.js
+++ b/js/jquery.mobile.listview.filter.js
@@ -24,7 +24,7 @@ $( "[data-role='listview']" ).live( "listviewcreate", function() {
 					}).hide();
 				}
 				
-				listview._numberItems();
+				//listview._numberItems();
 			})
 			.appendTo( wrapper )
 			.customTextInput();

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -150,6 +150,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 		
 		var o = this.options,
 			$list = this.element,
+			self = this,
 			dividertheme = $list.data( "dividertheme" ) || o.dividerTheme,
 			li = $list.children( "li" ),
 			counter = jQuery.support.cssPseudoElement || !jQuery.nodeName( $list[0], "ol" ) ? 0 : 1;
@@ -266,7 +267,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 			item.addClass( itemClass );
 
 			if ( !create ) {
-				this._itemApply( $list, item );
+				self._itemApply( $list, item );
 			}
 		});
 	},

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -109,7 +109,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 			}
 		});	
 
-		// tapping the whole LI triggers ajaxClick on the first link
+		// tapping the whole LI triggers click on the first link
 		$list.delegate( "li", "click", function(event) {
 			if ( !jQuery( event.target ).closest( "a" ).length ) {
 				jQuery( this ).find( "a" ).first().trigger( "click" );

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -4,9 +4,9 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) and GPL (GPL-LICENSE.txt) licenses.
 * Note: Code is in draft form and is subject to change 
 */
-(function( $ ) {
+(function( jQuery ) {
 
-$.widget( "mobile.listview", $.mobile.widget, {
+jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 	options: {
 		theme: "c",
 		countTheme: "c",
@@ -18,71 +18,101 @@ $.widget( "mobile.listview", $.mobile.widget, {
 	},
 	
 	_create: function() {
+		var $list = this.element,
+			o = this.options;
+
 		// create listview markup 
-		this.element
+		$list
 			.addClass( "ui-listview" )
 			.attr( "role", "listbox" )
 		
-		if ( this.options.inset ) {
-			this.element.addClass( "ui-listview-inset ui-corner-all ui-shadow" );
+		if ( o.inset ) {
+			$list.addClass( "ui-listview-inset ui-corner-all ui-shadow" );
 		}	
 
-		this.element.delegate(".ui-li", "focusin", function() {
-			jQuery(this).attr( "tabindex", "0" );
+		$list.delegate( ".ui-li", "focusin", function() {
+			jQuery( this ).attr( "tabindex", "0" );
 		});
 
-		this._itemApply( this.element, this.element );
+		this._itemApply( $list, $list );
 		
 		this.refresh( true );
 	
 		//keyboard events for menu items
-		this.element.keydown(function(event){
-			//switch logic based on which key was pressed
-			switch(event.keyCode){
-				//up or left arrow keys
+		$list.keydown(function( e ) {
+			var target = jQuery( e.target ),
+				li = target.closest( "li" );
+
+			// switch logic based on which key was pressed
+			switch ( e.keyCode ) {
+				// up or left arrow keys
 				case 38:
-					//if there's a previous option, focus it
-					if( $(event.target).closest('li').prev().length  ){
-						$(event.target).blur().attr("tabindex","-1").closest('li').prev().find('a').eq(0).focus();
+					var prev = li.prev();
+
+					// if there's a previous option, focus it
+					if ( prev.length ) {
+						target
+							.blur()
+							.attr( "tabindex", "-1" );
+
+						prev.find( "a" ).first().focus();
 					}	
-					//prevent native scroll
+
 					return false;
 				break;
-				//down or right arrow keys
+
+				// down or right arrow keys
 				case 40:
+					va next = li.next();
 				
-					//if there's a next option, focus it
-					if( $(event.target).closest('li').next().length ){
-						$(event.target).blur().attr("tabindex","-1").closest('li').next().find('a').eq(0).focus();
+					// if there's a next option, focus it
+					if ( next.length ) {
+						target
+							.blur()
+							.attr( "tabindex", "-1" );
+						
+						next.find( "a" ).first().focus();
 					}	
-					//prevent native scroll
+
 					return false;
 				break;
+
 				case 39:
-					if( $(event.target).closest('li').find('a.ui-li-link-alt').length ){
-						$(event.target).blur().closest('li').find('a.ui-li-link-alt').eq(0).focus();
+					var a = li.find( "a.ui-li-link-alt" );
+
+					if ( a.length ) {
+						target.blur();
+						a.first().focus();
 					}
+
 					return false;
 				break;
+
 				case 37:
-					if( $(event.target).closest('li').find('a.ui-link-inherit').length ){
-						$(event.target).blur().closest('li').find('a.ui-link-inherit').eq(0).focus();
+					var a = li.find( "a.ui-link-inherit" );
+
+					if ( a.length ) {
+						target.blur();
+						a.first().focus();
 					}
+
 					return false;
 				break;
-				//if enter or space is pressed, trigger click
+
+				// if enter or space is pressed, trigger click
 				case 13:
 				case 32:
-					 $(event.target).trigger('click'); //should trigger select
+					 target.trigger( "click" );
+
 					 return false;
 				break;	
 			}
 		});	
 
-		//tapping the whole LI triggers ajaxClick on the first link
-		this.element.delegate( "li:has(a)", "tap", function(event) {
-			if( !$(event.target).closest('a').length ){
-				$( this ).find( "a:first" ).trigger('click');
+		// tapping the whole LI triggers ajaxClick on the first link
+		$list.dlegate( "li", "tap", function(event) {
+			if ( !jQuery( e.target ).closest( "a" ).length ) {
+				jQuery( this ).find( "a" ).first().trigger( "click" );
 				return false;
 			}
 		});

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -111,7 +111,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 
 		// tapping the whole LI triggers ajaxClick on the first link
 		$list.delegate( "li", "tap", function(event) {
-			if ( !jQuery( e.target ).closest( "a" ).length ) {
+			if ( !jQuery( event.target ).closest( "a" ).length ) {
 				jQuery( this ).find( "a" ).first().trigger( "click" );
 				return false;
 			}

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -110,7 +110,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 		});	
 
 		// tapping the whole LI triggers ajaxClick on the first link
-		$list.delegate( "li", "tap", function(event) {
+		$list.delegate( "li", "click", function(event) {
 			if ( !jQuery( event.target ).closest( "a" ).length ) {
 				jQuery( this ).find( "a" ).first().trigger( "click" );
 				return false;

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -129,7 +129,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 
 		item.find( "img" ).addClass( "ui-li-thumb" ).each(function() {
 			jQuery( this ).closest( "li" )
-				.addClass( jQuery(this).is( "ui-li-icon" ) ? "ui-li-has-icon" : "ui-li-has-thumb" );
+				.addClass( jQuery(this).is( ".ui-li-icon" ) ? "ui-li-has-icon" : "ui-li-has-thumb" );
 		});
 
 		var aside = item.find( ".ui-li-aside" );

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -135,7 +135,9 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 		var aside = item.find( ".ui-li-aside" );
 
 		if ( aside.length ) {
-			aside.prependTo( aside.parent() ); //shift aside to front for css float
+            aside.each(function(i, el) {
+			    $(el).prependTo( $(el).parent() ); //shift aside to front for css float
+            });
 		}
 
 		if ( jQuery.support.cssPseudoElement || !jQuery.nodeName( item[0], "ol" ) ) {

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -63,7 +63,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 
 				// down or right arrow keys
 				case 40:
-					va next = li.next();
+					var next = li.next();
 				
 					// if there's a next option, focus it
 					if ( next.length ) {
@@ -110,7 +110,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 		});	
 
 		// tapping the whole LI triggers ajaxClick on the first link
-		$list.dlegate( "li", "tap", function(event) {
+		$list.delegate( "li", "tap", function(event) {
 			if ( !jQuery( e.target ).closest( "a" ).length ) {
 				jQuery( this ).find( "a" ).first().trigger( "click" );
 				return false;

--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -32,7 +32,7 @@ $.fn.navbar = function(settings){
 		$navbar
 			.find('ul a')
 			.buttonMarkup({corners: false, shadow:false, iconpos: o.iconpos})
-			.bind('tap',function(){
+			.bind('click',function(){
 				//NOTE: we'll need to find a way to highlight an active tab at load as well
 				$navbar.find('.ui-btn-active').removeClass('ui-btn-active');
 				$(this).addClass('ui-btn-active');

--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -4,40 +4,36 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) and GPL (GPL-LICENSE.txt) licenses.
 * Note: Code is in draft form and is subject to change 
 */
-(function($){
-$.fn.navbar = function(settings){
-	return $(this).each(function(){ 
-
-		var o = $.extend({
-			iconpos: $(this).data('iconpos') || 'top',
-			transition: $(this).data('transition') || 'slideup'
-		},settings);
-		
-		//wrap it with footer classes
-		var $navbar = $(this).addClass('ui-navbar'),
-			numTabs = $navbar.find('li').length,
-			moreIcon = $navbar.find('a[data-icon]').length ? 'arrow-r' : null;
-			
-			if( moreIcon == null ){ 
-				o.iconpos = null; 
-				$navbar.add( $navbar.children(0) ).addClass('ui-navbar-noicons');
-			}
-			
-			$navbar
-				//add ARIA role
-				.attr("role","navigation")
-				.find('ul')
-				.grid({grid: numTabs > 2 ? 'b' : 'a'});		
+(function ( $ ) {
+$.widget( "mobile.navbar", $.mobile.widget, {
+	options: {
+		iconpos: 'top'
+	},
+	_create: function(){
+		var $navbar = this.element,
+			$navbtns = $navbar.find("a"),
+			iconpos = $navbtns.filter('icon').length ? this.options.iconpos : undefined;
 		
 		$navbar
-			.find('ul a')
-			.buttonMarkup({corners: false, shadow:false, iconpos: o.iconpos})
-			.bind('click',function(){
-				//NOTE: we'll need to find a way to highlight an active tab at load as well
-				$navbar.find('.ui-btn-active').removeClass('ui-btn-active');
-				$(this).addClass('ui-btn-active');
+			.addClass('ui-navbar')
+			.attr("role","navigation")
+			.find("ul")
+				.grid({grid: $navbtns.length > 2 ? "b" : "a"});		
+		
+		if( !iconpos ){ 
+			$navbar.addClass("ui-navbar-noicons");
+		}
+		
+		$navbtns
+			.buttonMarkup({
+				corners:	false, 
+				shadow:		false, 
+				iconpos:	iconpos
 			});
-
-	});
-};	
-})(jQuery);
+		
+		$navbar.delegate("a", "click",function(event){
+			$navbtns.removeClass("ui-btn-active");
+		});	
+	}
+});
+})( jQuery );

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -132,7 +132,7 @@ jQuery.widget( "mobile.page", jQuery.mobile.widget, {
 		this.element
 			.find( "button, [type='button'], [type='submit'], [type='reset'], [type='image']" )
 			.not( ".ui-nojs" )
-			.customButton();
+			.button();
 
 		this.element
 			.find( "input, textarea" )

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -127,7 +127,7 @@ jQuery.widget( "mobile.page", jQuery.mobile.widget, {
 		// enchance form controls
 		this.element
 			.find( "[type='radio'], [type='checkbox']" )
-			.customCheckboxRadio();
+			.checkboxradio();
 
 		this.element
 			.find( "button, [type='button'], [type='submit'], [type='reset'], [type='image']" )

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -46,12 +46,11 @@ function propExists( prop ){
 function baseTagTest(){
 	var fauxBase = location.protocol + '//' + location.host + location.pathname + "ui-dir/",
 		base = $("<base>", {"href": fauxBase}).appendTo("head"),
-		link = $( "<a href='testurl'></a>" ).prependTo( fakeBody );	
-	$.support.dynamicBaseTag = link[0].href.indexOf(fauxBase) === 0;
+		link = $( "<a href='testurl'></a>" ).prependTo( fakeBody ),
+		rebase = link[0].href;
 	base.remove();
+	return rebase.indexOf(fauxBase) === 0;
 };
-
-baseTagTest();
 
 $.extend( $.support, {
 	orientation: "orientation" in window,
@@ -61,7 +60,8 @@ $.extend( $.support, {
 	mediaquery: $.media('only all'),
 	cssPseudoElement: !!propExists('content'),
 	boxShadow: !!propExists('boxShadow') && !bb,
-	scrollTop: ("pageXOffset" in window || "scrollTop" in document.documentElement || "scrollTop" in fakeBody[0]) && !webos
+	scrollTop: ("pageXOffset" in window || "scrollTop" in document.documentElement || "scrollTop" in fakeBody[0]) && !webos,
+	dynamicBaseTag: baseTagTest()
 });
 
 fakeBody.remove();

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -47,7 +47,7 @@ function baseTagTest(){
 	var fauxBase = location.protocol + '//' + location.host + location.pathname + "ui-dir/",
 		base = $("<base>", {"href": fauxBase}).appendTo("head"),
 		link = $( "<a href='testurl'></a>" ).prependTo( fakeBody );	
-	$.support.dynamicBaseTag = !!link[0].href.match(fauxBase);
+	$.support.dynamicBaseTag = link[0].href.indexOf(fauxBase) === 0;
 	base.remove();
 };
 

--- a/themes/default/jquery.mobile.button.css
+++ b/themes/default/jquery.mobile.button.css
@@ -19,10 +19,10 @@
 .ui-bar .ui-btn-icon-left .ui-btn-inner { padding-left: 27px; }
 .ui-btn-icon-right .ui-btn-inner { padding-right: 33px; }
 .ui-header .ui-btn-icon-right .ui-btn-inner,
-.ui-footer .ui-btn-icon-right .ui-btn-inner
+.ui-footer .ui-btn-icon-right .ui-btn-inner,
 .ui-bar .ui-btn-icon-right .ui-btn-inner { padding-right: 27px; }
 .ui-btn-icon-top .ui-btn-inner { padding-top: 33px; }
-.ui-header .ui-btn-icon-top .ui-btn-inner
+.ui-header .ui-btn-icon-top .ui-btn-inner,
 .ui-footer .ui-btn-icon-top .ui-btn-inner,
 .ui-bar .ui-btn-icon-top .ui-btn-inner { padding-top: 27px; }
 .ui-btn-icon-bottom .ui-btn-inner { padding-bottom: 33px; }

--- a/themes/default/jquery.mobile.collapsible.css
+++ b/themes/default/jquery.mobile.collapsible.css
@@ -13,3 +13,6 @@
 .ui-collapsible-heading-status { position:absolute; left:-99999px; }
 .ui-collapsible-content {  display: block; padding: 10px 0 10px 8px; }
 .ui-collapsible-content-collapsed { display: none; }
+
+.ui-collapsible-set { margin: .5em 0; }
+.ui-collapsible-set .ui-collapsible-contain { margin: -1px 0 0; }

--- a/themes/default/jquery.mobile.collapsible.css
+++ b/themes/default/jquery.mobile.collapsible.css
@@ -9,7 +9,7 @@
 .ui-collapsible-heading a .ui-btn-inner { padding-left: 40px; }
 .ui-collapsible-heading a span.ui-btn { position: absolute; left: 6px; top: 50%; margin: -12px 0 0 0; width: 20px; height: 20px; padding: 1px 0px 1px 2px; text-indent: -9999px; }
 .ui-collapsible-heading a span.ui-btn .ui-btn-inner { padding: 0; }
-.ui-collapsible-heading a span.ui-btn .ui-icon { left: 2px; }
+.ui-collapsible-heading a span.ui-btn .ui-icon { left: 0; margin-top: -10px; }
 .ui-collapsible-heading-status { position:absolute; left:-99999px; }
 .ui-collapsible-content {  display: block; padding: 10px 0 10px 8px; }
 .ui-collapsible-content-collapsed { display: none; }

--- a/themes/default/jquery.mobile.controlgroup.css
+++ b/themes/default/jquery.mobile.controlgroup.css
@@ -23,7 +23,5 @@
 .ui-controlgroup .ui-btn-icon-notext .ui-btn-inner {  padding: 5px 6px 5px 5px; }
 */
 
-@media screen and (min-width: 480px){ 
-	.ui-controlgroup-label { vertical-align: top; display: inline-block;  width: 20%;  margin: 0 2% 0 0;  }
-	.ui-controlgroup-controls { width: 60%; display: inline-block; } 
-}
+.min-width-480 .ui-controlgroup-label { vertical-align: top; display: inline-block;  width: 20%;  margin: 0 2% 0 0;  }
+.min-width-480 .ui-controlgroup-controls { width: 60%; display: inline-block; } 

--- a/themes/default/jquery.mobile.controlgroup.css
+++ b/themes/default/jquery.mobile.controlgroup.css
@@ -23,5 +23,5 @@
 .ui-controlgroup .ui-btn-icon-notext .ui-btn-inner {  padding: 5px 6px 5px 5px; }
 */
 
-.min-width-480 .ui-controlgroup-label { vertical-align: top; display: inline-block;  width: 20%;  margin: 0 2% 0 0;  }
-.min-width-480 .ui-controlgroup-controls { width: 60%; display: inline-block; } 
+.min-width-480px .ui-controlgroup-label { vertical-align: top; display: inline-block;  width: 20%;  margin: 0 2% 0 0;  }
+.min-width-480px .ui-controlgroup-controls { width: 60%; display: inline-block; } 

--- a/themes/default/jquery.mobile.controlgroup.css
+++ b/themes/default/jquery.mobile.controlgroup.css
@@ -9,13 +9,13 @@
 .ui-controlgroup-controls { display: block; width: 95%;}
 .ui-controlgroup li { list-style: none; }
 .ui-controlgroup-vertical .ui-btn,
-.ui-controlgroup-vertical div.ui-checkbox, .ui-controlgroup-vertical div.ui-radio { margin: 0; border-bottom-width: 0;  }
+.ui-controlgroup-vertical .ui-checkbox, .ui-controlgroup-vertical .ui-radio { margin: 0; border-bottom-width: 0;  }
 .ui-controlgroup-vertical .ui-controlgroup-last { border-bottom-width: 1px; }
 .ui-controlgroup-horizontal { padding: 0; }
 .ui-controlgroup-horizontal .ui-btn,
-.ui-controlgroup-horizontal div.ui-checkbox, .ui-controlgroup-horizontal div.ui-radio { margin: 0 -5px 0 0; display: inline-block;  }
-.ui-controlgroup-horizontal div.ui-checkbox .ui-btn, .ui-controlgroup-horizontal div.ui-radio .ui-btn,
-.ui-controlgroup-horizontal div.ui-checkbox:last-child, .ui-controlgroup-horizontal div.ui-radio:last-child { margin-right: 0; }
+.ui-controlgroup-horizontal .ui-checkbox, .ui-controlgroup-horizontal .ui-radio { margin: 0 -5px 0 0; display: inline-block;  }
+.ui-controlgroup-horizontal .ui-checkbox .ui-btn, .ui-controlgroup-horizontal .ui-radio .ui-btn,
+.ui-controlgroup-horizontal .ui-checkbox:last-child, .ui-controlgroup-horizontal .ui-radio:last-child { margin-right: 0; }
 .ui-controlgroup-horizontal .ui-controlgroup-last { margin-right: 0; }
 .ui-controlgroup .ui-checkbox label, .ui-controlgroup .ui-radio label { font-size: 16px;  }
 /* conflicts with listview..

--- a/themes/default/jquery.mobile.forms.checkboxradio.css
+++ b/themes/default/jquery.mobile.forms.checkboxradio.css
@@ -3,7 +3,7 @@
 * Copyright (c) jQuery Project
 * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
 */
-div.ui-checkbox, div.ui-radio { position:relative;  margin: .2em 0 .5em;  }
+.ui-checkbox, .ui-radio { position:relative;  margin: .2em 0 .5em;  }
 .ui-checkbox .ui-btn, .ui-radio .ui-btn { margin: 0; text-align: left; }
 .ui-checkbox .ui-btn-icon-left .ui-btn-inner,.ui-radio .ui-btn-icon-left .ui-btn-inner { padding-left: 45px; }
 .ui-checkbox .ui-btn-icon-right .ui-btn-inner, .ui-radio .ui-btn-icon-right .ui-btn-inner { padding-right: 45px; }

--- a/themes/default/jquery.mobile.forms.select.css
+++ b/themes/default/jquery.mobile.forms.select.css
@@ -23,7 +23,5 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 /*used in listbox - to be removed/replaced with page-style hiding*/
 .ui-helper-hidden,.ui-mobile .ui-content-hidden { display: none; }
 
-@media screen and (min-width: 480px){ 
-	label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
-	.ui-select { width: 60%; display: inline-block; } 
-}
+.min-width-480 label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
+.min-width-480 .ui-select { width: 60%; display: inline-block; } 

--- a/themes/default/jquery.mobile.forms.select.css
+++ b/themes/default/jquery.mobile.forms.select.css
@@ -23,5 +23,5 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 /*used in listbox - to be removed/replaced with page-style hiding*/
 .ui-helper-hidden,.ui-mobile .ui-content-hidden { display: none; }
 
-.min-width-480 label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
-.min-width-480 .ui-select { width: 60%; display: inline-block; } 
+.min-width-480px label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
+.min-width-480px .ui-select { width: 60%; display: inline-block; } 

--- a/themes/default/jquery.mobile.forms.slider.css
+++ b/themes/default/jquery.mobile.forms.slider.css
@@ -9,8 +9,8 @@ select.ui-slider-switch { display: none; }
 div.ui-slider { position: relative; display: inline-block; overflow: visible; height: 15px; padding: 0; margin: 0 2% 0 15px; top: 4px; width: 66%; }
 a.ui-slider-handle { position: absolute; z-index: 10;  top: 50%; width: 28px; height: 28px; margin-top: -15px; margin-left: -15px; }
 a.ui-slider-handle .ui-btn-inner { padding-left: 0; padding-right: 0; }
-.min-width-480 label.ui-slider { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
-.min-width-480 div.ui-slider { width: 45%; }
+.min-width-480px label.ui-slider { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
+.min-width-480px div.ui-slider { width: 45%; }
 
 div.ui-slider-switch { height: 32px;  overflow: hidden; margin-left: 0; }
 div.ui-slider-inneroffset { margin-left: 50%; position: absolute; top: 1px; height: 100%; width: 50%; }

--- a/themes/default/jquery.mobile.forms.slider.css
+++ b/themes/default/jquery.mobile.forms.slider.css
@@ -9,10 +9,8 @@ select.ui-slider-switch { display: none; }
 div.ui-slider { position: relative; display: inline-block; overflow: visible; height: 15px; padding: 0; margin: 0 2% 0 15px; top: 4px; width: 66%; }
 a.ui-slider-handle { position: absolute; z-index: 10;  top: 50%; width: 28px; height: 28px; margin-top: -15px; margin-left: -15px; }
 a.ui-slider-handle .ui-btn-inner { padding-left: 0; padding-right: 0; }
-@media screen and (min-width: 480px){ 
-	label.ui-slider { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
-	div.ui-slider { width: 45%; }
-}	
+.min-width-480 label.ui-slider { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
+.min-width-480 div.ui-slider { width: 45%; }
 
 div.ui-slider-switch { height: 32px;  overflow: hidden; margin-left: 0; }
 div.ui-slider-inneroffset { margin-left: 50%; position: absolute; top: 1px; height: 100%; width: 50%; }

--- a/themes/default/jquery.mobile.forms.textinput.css
+++ b/themes/default/jquery.mobile.forms.textinput.css
@@ -12,9 +12,7 @@ textarea.ui-input-text { height: 50px; -webkit-transition: height 200ms linear; 
 .ui-input-search .ui-input-clear-hidden { display: none; }
 
 /* orientation adjustments - incomplete!*/
-@media screen and (min-width: 480px){ 
-	label.ui-input-text  { vertical-align: top;   }
-	label.ui-input-text, label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
-	input.ui-input-text, textarea.ui-input-text, .ui-input-search { width: 60%; display: inline-block; } 
-	.ui-input-search { width: 50%; }
-}
+.min-width-480 label.ui-input-text  { vertical-align: top;   }
+.min-width-480 label.ui-input-text, label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
+.min-width-480 input.ui-input-text, textarea.ui-input-text, .ui-input-search { width: 60%; display: inline-block; } 
+.min-width-480 .ui-input-search { width: 50%; }

--- a/themes/default/jquery.mobile.forms.textinput.css
+++ b/themes/default/jquery.mobile.forms.textinput.css
@@ -12,7 +12,7 @@ textarea.ui-input-text { height: 50px; -webkit-transition: height 200ms linear; 
 .ui-input-search .ui-input-clear-hidden { display: none; }
 
 /* orientation adjustments - incomplete!*/
-.min-width-480 label.ui-input-text  { vertical-align: top;   }
-.min-width-480 label.ui-input-text, label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
-.min-width-480 input.ui-input-text, textarea.ui-input-text, .ui-input-search { width: 60%; display: inline-block; } 
-.min-width-480 .ui-input-search { width: 50%; }
+.min-width-480px label.ui-input-text  { vertical-align: top;   }
+.min-width-480px label.ui-input-text, label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
+.min-width-480px input.ui-input-text, textarea.ui-input-text, .ui-input-search { width: 60%; display: inline-block; } 
+.min-width-480px .ui-input-search { width: 50%; }


### PR DESCRIPTION
So, when working on a mobile project, I accidentally forgot to urlencode one of the values in the querystring. So the local url ended up being something like: somePage.php?bla=bla&path=http://...

The problem is that jQuery Mobile seems to test if "http" exists at all in the url. If it does, it's considered an external link, and loads synchronously. 

Granted, this was an error on my part. Technically, 'http://' shouldn't exist in the querystring. But, assuming others make the same mistakes, and forget to url encode, the framework should compensate. Ensuring that the value "http://" occurs at the beginning of the string fixes it: ^https?

Very quick video example, if it helps: http://screenr.com/YkD
