### PR TITLE
Refresh method on the listview throws an error when called

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -148,6 +148,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 		
 		var o = this.options,
 			$list = this.element,
+			self = this,
 			dividertheme = $list.data( "dividertheme" ) || o.dividerTheme,
 			li = $list.children( "li" ),
 			counter = jQuery.support.cssPseudoElement || !jQuery.nodeName( $list[0], "ol" ) ? 0 : 1;
@@ -264,7 +265,7 @@ jQuery.widget( "mobile.listview", jQuery.mobile.widget, {
 			item.addClass( itemClass );
 
 			if ( !create ) {
-				this._itemApply( $list, item );
+				self._itemApply( $list, item );
 			}
 		});
 	},


### PR DESCRIPTION
The "this" keyword gets overwritten by $.each in the refresh method, causing an error when calling this._itemApply
