### PR TITLE
Little hack, to prevent pages 'blinking' at the end of cliding effect.

### DIFF
--- a/themes/default/jquery.mobile.transitions.css
+++ b/themes/default/jquery.mobile.transitions.css
@@ -22,10 +22,12 @@ Built by David Kaneda and maintained by Jonathan Stark.
 }
 
 .slide.in {
+	z-index: 1;
 	-webkit-animation-name: slideinfromright;
 }
 
 .slide.out {
+	z-index: -1;
 	-webkit-animation-name: slideouttoleft;
 }
 


### PR DESCRIPTION
This bug was found by me in jQtouch few days ago, and looks like it's migrated to jQuery mobile together with animations code.
