### PR TITLE
Point to jquery-mobile's google-compiler-xxx.jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ mobile:
 
 min: mobile
 	@@head -8 js/jquery.mobile.js > ${MIN}
-	@@java -jar ../jquery/build/google-compiler-20100917.jar --js ${MAX} --warning_level QUIET --js_output_file ${MIN}.tmp
+	@@java -jar ./build/google-compiler-20100917.jar --js ${MAX} --warning_level QUIET --js_output_file ${MIN}.tmp
 	@@cat ${MIN}.tmp >> ${MIN}
 	@@rm -f ${MIN}.tmp
 


### PR DESCRIPTION
The jar exists in jquery-mobile, why not use that instead of requiring folks to have jquery proper cloned?
