### PR TITLE
Use more specific selector when refreshing checkboxradio

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -55,7 +55,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			.bind({
 
 				click: function() {
-					jQuery( "input[name='" + input.attr( "name" ) + "'][type='" + input.attr( "type" ) + "']" ).checkboxradio( "refresh" );
+					jQuery( "input[name='" + input.attr( "name" ) + "'][type='" + inputtype + "']" ).checkboxradio( "refresh" );
 				},
 
 				focus: function() { 

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -55,7 +55,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			.bind({
 
 				click: function() {
-					jQuery( "input[name='" + input.attr( "name" ) + "']" ).checkboxradio( "refresh" );
+					jQuery( "input[name='" + input.attr( "name" ) + "'][type='checkbox']" ).checkboxradio( "refresh" );
 				},
 
 				focus: function() { 

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -55,7 +55,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			.bind({
 
 				click: function() {
-					jQuery( "input[name='" + input.attr( "name" ) + "'][type='checkbox']" ).checkboxradio( "refresh" );
+					jQuery( "input[name='" + input.attr( "name" ) + "'][type='" + input.attr( "type" ) + "']" ).checkboxradio( "refresh" );
 				},
 
 				focus: function() { 


### PR DESCRIPTION
If you use the Rails checkbox helper, it creates an additional hidden input with the same name as the checkbox input.  It is added before the checkbox input, so when checkboxradio tries to refresh the checkbox input it actually selects the hidden input.  

See why Rails does this here:

http://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-check_box

Basically, all that is needed is a more specific selector in checkboxradio.
