### PR TITLE
Fix tap event cancellation for small movements

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -64,11 +64,15 @@ $.event.special.tap = {
 				
 				var moved = false,
 					touching = true,
+					origPos = [ event.pageX, event.pageY ],
 					originalType,
 					timer;
 				
 				function moveHandler() {
-					moved = true;
+					if ((Math.abs(origPos[0] - event.pageX) > 10) ||
+					    (Math.abs(origPos[1] - event.pageY) > 10)) {
+					    moved = true;
+					}
 				}
 				
 				timer = setTimeout(function() {


### PR DESCRIPTION
The 'tap' event is a combination of the 'touchStart', 'touchMove', and 'touchEnd' events.  If there's movement registered between start and end, a 'tap' is not triggered. On the Nexus 1 and many other platforms, any movement (even a single pixel) triggers touchMove and results in no triggering of a 'tap' event.

This pull request adds a small x/y delta in the moveHandler used by 'tap', allowing minor movement without cancelling the 'tap'.

This solves the underlying problems reported in issues [159](/jquery/jquery-mobile/issues/closed/#issue/159), [248](/jquery/jquery-mobile/issues/closed/#issue/248), [280](/jquery/jquery-mobile/issues/closed/#issue/280), and may aid [147](/jquery/jquery-mobile/issues/#issue/147).
