### PR TITLE
Docs text describing icon-only button doesn't match code example

### DIFF
--- a/docs/buttons/buttons-icons.html
+++ b/docs/buttons/buttons-icons.html
@@ -140,7 +140,7 @@
 <p>Creates this button with right-aligned icon:</p>
 <a href="index.html" data-role="button" data-icon="delete" data-iconpos="right">Delete</a>
 
-		<p>You can also create an icon-only button, by setting the <code>data-iconpos</code> attribute to <code>notext</code>. The button plugin will hide the text on-screen, but add it as a <code>title</code> attribute on the link to provide context for screen readers and devices that support tooltips. In this example, we're adding a plus (+) icon and positioning it to the right of the text with our <code>data-</code> attributes on the link.</p> 
+		<p>You can also create an icon-only button, by setting the <code>data-iconpos</code> attribute to <code>notext</code>. The button plugin will hide the text on-screen, but add it as a <code>title</code> attribute on the link to provide context for screen readers and devices that support tooltips. For example, replacing <code>data-iconpos="right"</code> on the previous example with <code>data-iconpos="notext"</code>:</p>
 
 <code>
 &lt;a href=&quot;index.html&quot; data-role=&quot;button&quot; data-icon=&quot;delete&quot;<strong> data-iconpos=&quot;notext&quot;</strong>&gt;Delete&lt;/a&gt;


### PR DESCRIPTION
Text referred to a button with the + icon to the right, but code sample/demo were of a notext delete button. Updated text to reflect code sample
