### PR TITLE
translate back button / issue 416

### DIFF
--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -42,6 +42,9 @@
 		//show loading message during Ajax requests
 		//if false, message will not appear, but loading classes will still be toggled on html el
 		loadingMessage: "loading",
+
+		//set text for back buttons
+		backBtnText: "Back",
 		
 		//configure meta viewport tag's content attr:
 		metaViewportContent: "width=device-width, minimum-scale=1, maximum-scale=1",

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -2,7 +2,6 @@
 
 jQuery.widget( "mobile.page", jQuery.mobile.widget, {
 	options: {
-		backBtnText: "Back",
 		addBackBtn: true,
 		degradeInputs: {
 			color: true,
@@ -71,7 +70,7 @@ jQuery.widget( "mobile.page", jQuery.mobile.widget, {
 						(jQuery.mobile.urlStack.length > 1 || jQuery(".ui-page").length > 1) &&
 						!leftbtn && !$this.data( "noBackBtn" ) ) {
 
-					jQuery( "<a href='#' class='ui-btn-left' data-icon='arrow-l'>"+ o.backBtnText +"</a>" )
+					jQuery( "<a href='#' class='ui-btn-left' data-icon='arrow-l'>"+ jQuery.mobile.backBtnText +"</a>" )
 						.click(function() {
 							history.back();
 							return false;


### PR DESCRIPTION
Need to be able to translate the back button. Or is there some other way of overriding the page widget options hash that would be better to use?

https://github.com/jquery/jquery-mobile/issues/issue/416
