### PR TITLE
Option to prevent form element enhancements

### DIFF
--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -154,25 +154,30 @@ $.widget( "mobile.page", $.mobile.widget, {
 		// enchance form controls
 		this.element
 			.find( "[type='radio'], [type='checkbox']" )
+			.not(".no-enhance")
 			.checkboxradio();
 
 		this.element
 			.find( "button, [type='button'], [type='submit'], [type='reset'], [type='image']" )
+			.not(".no-enhance")
 			.not( ".ui-nojs" )
 			.button();
 
 		this.element
 			.find( "input, textarea" )
+			.not(".no-enhance")
 			.not( "[type='radio'], [type='checkbox'], button, [type='button'], [type='submit'], [type='reset'], [type='image']" )
 			.textinput();
 
 		this.element
 			.find( "input, select" )
+			.not(".no-enhance")
 			.filter( "[data-role='slider'], [data-type='range']" )
 			.slider();
 
 		this.element
 			.find( "select:not([data-role='slider'])" )
+			.not(".no-enhance")
 			.selectmenu();
 	}
 });


### PR DESCRIPTION
Just a suggestion. I'm sure there's a better way to do this:

If form elements are enhanced by default, there should be a way to prevent this should you wish to add a standard vanilla element (eg checkbox,select).

This approach offers a "no-enhance" class that can be added to the original element.
