### PR TITLE
Removing focus when submitting a form

### DIFF
--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -188,6 +188,7 @@
 			undefined,
 			true
 		);
+		$(':focus').blur();
 		event.preventDefault();
 	});	
 	


### PR DESCRIPTION
This simple fix prevents the blinking indicator from showing over the "loading" message on iPhones.
Got the idea from jQTouch: https://github.com/senchalabs/jQTouch/blob/master/jqtouch/jqtouch.js#L143
