### PR TITLE
Update a few remaining links from 1.0a1 to 1.0a2 

### DIFF
--- a/docs/pages/docs-pages.html
+++ b/docs/pages/docs-pages.html
@@ -30,9 +30,9 @@
 &lt;html&gt; 
 	&lt;head&gt; 
 	&lt;title&gt;Page Title&lt;/title&gt; 
-	&lt;link rel=&quot;stylesheet&quot; href=&quot;http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.css&quot; /&gt;
+	&lt;link rel=&quot;stylesheet&quot; href=&quot;http://code.jquery.com/mobile/1.0a2/jquery.mobile-1.0a2.min.css&quot; /&gt;
 	&lt;script src=&quot;http://code.jquery.com/jquery-1.4.3.min.js&quot;&gt;&lt;/script&gt;
-	&lt;script src=&quot;http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.js&quot;&gt;&lt;/script&gt;
+	&lt;script src=&quot;http://code.jquery.com/mobile/1.0a2/jquery.mobile-1.0a2.min.js&quot;&gt;&lt;/script&gt;
 &lt;/head&gt; 
 &lt;body&gt; 
 
@@ -72,9 +72,9 @@
 &lt;html&gt; 
 	&lt;head&gt; 
 	&lt;title&gt;Page Title&lt;/title&gt; 
-	&lt;link rel=&quot;stylesheet&quot; href=&quot;http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.css&quot; /&gt;
+	&lt;link rel=&quot;stylesheet&quot; href=&quot;http://code.jquery.com/mobile/1.0a2/jquery.mobile-1.0a2.min.css&quot; /&gt;
 	&lt;script src=&quot;http://code.jquery.com/jquery-1.4.3.min.js&quot;&gt;&lt;/script&gt;
-	&lt;script src=&quot;http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.js&quot;&gt;&lt;/script&gt;
+	&lt;script src=&quot;http://code.jquery.com/mobile/1.0a2/jquery.mobile-1.0a2.min.js&quot;&gt;&lt;/script&gt;
 &lt;/head&gt; 
 &lt;body&gt; 
 

--- a/docs/pages/page-template.html
+++ b/docs/pages/page-template.html
@@ -3,9 +3,9 @@
 	<head>
 	<meta charset="utf-8" /> 
 	<title>Page Title</title> 
-	<link rel="stylesheet" href="http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.css" />
+	<link rel="stylesheet" href="http://code.jquery.com/mobile/1.0a2/jquery.mobile-1.0a2.min.css" />
 	<script src="http://code.jquery.com/jquery-1.4.3.min.js"></script>
-	<script src="http://code.jquery.com/mobile/1.0a1/jquery.mobile-1.0a1.min.js"></script>
+	<script src="http://code.jquery.com/mobile/1.0a2/jquery.mobile-1.0a2.min.js"></script>
 </head> 
 <body> 
 


### PR DESCRIPTION
Thanks for a great library!

The documentation still has a few pages which use the 1.0a1 hosted version. Let's fix that.

Cheers, Leon.
