### PR TITLE
Tests for mobile.support

### DIFF
--- a/tests/unit/media/index.html
+++ b/tests/unit/media/index.html
@@ -23,13 +23,6 @@
 </ol>
 
 <div id="main" style="position: absolute; top: -10000px; left: -10000px;">
-
-<div id="widget-wrapper">
-	<div id="widget">
-		<div>...</div>
-	</div>
-</div>
-
 </div>
 
 </body>

--- a/tests/unit/support/index.html
+++ b/tests/unit/support/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Support Test Suite</title>
+
+	<script type="text/javascript" src="../../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.ui.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.media.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.support.js"></script>
+
+	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
+	<script type="text/javascript" src="../../../external/qunit.js"></script>
+
+	<script type="text/javascript" src="support_core.js"></script>
+</head>
+<body>
+
+<h1 id="qunit-header">jQuery Mobile Support Test Suite</h1>
+<h2 id="qunit-banner"></h2>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests">
+</ol>
+
+<div id="main" style="position: absolute; top: -10000px; left: -10000px;">
+
+<div id="widget-wrapper">
+	<div id="widget">
+		<div>...</div>
+	</div>
+</div>
+
+</div>
+
+</body>
+</html>

--- a/tests/unit/support/index.html
+++ b/tests/unit/support/index.html
@@ -24,13 +24,6 @@
 </ol>
 
 <div id="main" style="position: absolute; top: -10000px; left: -10000px;">
-
-<div id="widget-wrapper">
-	<div id="widget">
-		<div>...</div>
-	</div>
-</div>
-
 </div>
 
 </body>

--- a/tests/unit/support/support_core.js
+++ b/tests/unit/support/support_core.js
@@ -1,36 +1,88 @@
 /*
  * mobile support unit tests
  */
+
 (function( $ ) {
-	var reloadLib = function(){
-		$("script[src$=support.js]").appendTo("body");
-	};
+	//NOTE alert tester that running the file locally will not work for these tests
+	if ( location.protocol == "file:" ) {
+		var message = "Tests require script reload and cannot be run via file: protocol";
 
-	module("mobile.support", {
-		teardown: function(){
-			$("body script[src$=support.js]").remove();
-		}
-	});
+		test(message, function(){
+			ok(false, message);
+		});
+	} else {
+		var reloadCount = 0,
+		lib = $("script[src$=support.js]"),
+	  src = lib.attr('src'),
+	  reloadLib = function(){
+			//NOTE append "cache breaker" to force reload
+			lib.attr('src', src + "?" + reloadCount++);
+			$("body").append(lib);
+	  },
+		prependToFn = $.fn.prependTo;
 
-	// NOTE test has debatable value, only prevents property name changes
-	// and improper sources for attribute checks
-	test( "detects functionality from basic properties and attributes", function(){
-		// TODO expose properties for less brittle tests
-		$.extend(window, {
-			orientation: true,
-			WebKitTransitionEvent: true
+		module("mobile.support", {
+			teardown: function(){
+				//NOTE undo any mocking
+				$.fn.prependTo = prependToFn;
+			}
 		});
 
-		document["ontouchend"] = true;
-		history.pushState = function(){};
-		$.mobile.media = function(){ return true; };
+		// NOTE following two tests have debatable value as they only
+		//      prevent property name changes and improper attribute checks
+		test( "detects functionality from basic affirmative properties and attributes", function(){
+			// TODO expose properties for less brittle tests
+			$.extend(window, {
+				WebKitTransitionEvent: true,
+				orientation: true
+			});
 
-		reloadLib();
+			document.ontouchend = true;
 
-		ok($.support.orientation);
-		ok($.support.cssTransitions);
-		ok($.support.touch);
-		ok($.support.pushState);
-		ok($.support.mediaquery);
-	});
+			history.pushState = function(){};
+			$.mobile.media = function(){ return true; };
+
+			reloadLib();
+
+			ok($.support.orientation);
+			ok($.support.touch);
+			ok($.support.cssTransitions);
+			ok($.support.pushState);
+			ok($.support.mediaquery);
+		});
+
+		test( "detects functionality from basic negative properties and attributes (where possible)", function(){
+			delete window["orientation"];
+			delete document["ontouchend"];
+
+			reloadLib();
+
+			ok(!$.support.orientation);
+			ok(!$.support.touch);
+		});
+
+		// NOTE mocks prependTo to simulate base href updates or lack thereof
+		var mockBaseCheck = function( url ){
+			var prependToFn = $.fn.prependTo;
+
+			$.fn.prependTo = function( selector ){
+				var result = prependToFn.call($(this), selector);
+				if(this[0].href && this[0].href.indexOf("testurl") != -1)
+					result = [{href: url}];
+				return result;
+			};
+		};
+
+		test( "detects dynamic base tag when new base element added and base href updates", function(){
+			mockBaseCheck(location.protocol + '//' + location.host + location.pathname + "ui-dir/");
+			reloadLib();
+			ok($.support.dynamicBaseTag);
+		});
+
+		test( "detects no dynamic base tag when new base element added and base href unchanged", function(){
+			mockBaseCheck('testurl');
+			reloadLib();
+			ok(!$.support.dynamicBaseTag);
+		});
+	}
 })(jQuery);

--- a/tests/unit/support/support_core.js
+++ b/tests/unit/support/support_core.js
@@ -66,7 +66,7 @@
 			var prependToFn = $.fn.prependTo;
 
 			$.fn.prependTo = function( selector ){
-				var result = prependToFn.call($(this), selector);
+				var result = prependToFn.call(this, selector);
 				if(this[0].href && this[0].href.indexOf("testurl") != -1)
 					result = [{href: url}];
 				return result;

--- a/tests/unit/support/support_core.js
+++ b/tests/unit/support/support_core.js
@@ -84,5 +84,8 @@
 			reloadLib();
 			ok(!$.support.dynamicBaseTag);
 		});
+
+		//TODO propExists testing, refactor propExists into mockable method
+		//TODO scrollTop testing, refactor scrollTop logic into mockable method
 	}
 })(jQuery);

--- a/tests/unit/support/support_core.js
+++ b/tests/unit/support/support_core.js
@@ -1,0 +1,36 @@
+/*
+ * mobile support unit tests
+ */
+(function( $ ) {
+	var reloadLib = function(){
+		$("script[src$=support.js]").appendTo("body");
+	};
+
+	module("mobile.support", {
+		teardown: function(){
+			$("body script[src$=support.js]").remove();
+		}
+	});
+
+	// NOTE test has debatable value, only prevents property name changes
+	// and improper sources for attribute checks
+	test( "detects functionality from basic properties and attributes", function(){
+		// TODO expose properties for less brittle tests
+		$.extend(window, {
+			orientation: true,
+			WebKitTransitionEvent: true
+		});
+
+		document["ontouchend"] = true;
+		history.pushState = function(){};
+		$.mobile.media = function(){ return true; };
+
+		reloadLib();
+
+		ok($.support.orientation);
+		ok($.support.cssTransitions);
+		ok($.support.touch);
+		ok($.support.pushState);
+		ok($.support.mediaquery);
+	});
+})(jQuery);


### PR DESCRIPTION
There are two bits that still need testing/work:
- propExists: I'm actually curious about the behavior here since the for..in gives me indexes in Chrome/Firefox. Any explanation of why its `fbCSS[v]` and not `fbCSS[props[v]]` would be helpful for my education.
- scrollTop: Does it make sense to move the hanging functions and the rather large boolean statement for scrollTop detection in to methods under the $.support object? Maybe $.support.propExists/$.support.scrollTop? That might allow for easier testing.

There are `TODO`'s at the bottom for the rest of the tests. Of course if you have any feedback about the tests, and particularly the aggressive mocking I've used therein, I'll be happy to make the changes.
