### PR TITLE
Core tests begun

### DIFF
--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -1,0 +1,19 @@
+/*
+ * mobile support unit tests
+ */
+
+(function( $ ) {
+	$.testHelper = {
+		excludeFileProtocol: function(callback){
+			var message = "Tests require script reload and cannot be run via file: protocol";
+			//NOTE alert tester that running the file locally will not work for these tests
+			if ( location.protocol == "file:" ) {
+				test(message, function(){
+					ok(false, message);
+				});
+			} else {
+				callback();
+			}
+		}
+	};
+})(jQuery);

--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -7,7 +7,7 @@
 		excludeFileProtocol: function(callback){
 			var message = "Tests require script reload and cannot be run via file: protocol";
 
-			if ( location.protocol == "file:" ) {
+			if (location.protocol == "file:") {
 				test(message, function(){
 					ok(false, message);
 				});

--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -16,18 +16,21 @@
 			}
 		},
 
-		reloadCounts: {},
+		reloads: {},
 
 		reloadLib: function(libName){
-			var lib = $("script[src$=" + libName + "]").clone(),
-					src = lib.attr('src');
-
-			if(this.reloadCounts[libName] === undefined) {
-				this.reloadCounts[libName] = 0;
+			if(this.reloads[libName] === undefined) {
+				this.reloads[libName] = {
+					lib: $("script[src$=" + libName + "]"),
+					count: 0
+				};
 			}
 
+			var	lib = this.reloads[libName].lib.clone(),
+			    src = lib.attr('src');
+
 			//NOTE append "cache breaker" to force reload
-			lib.attr('src', src + "?" + this.reloadCounts[libName]++);
+			lib.attr('src', src + "?" + this.reloads[libName].count++);
 			$("body").append(lib);
 		}
 	};

--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -6,7 +6,7 @@
 	$.testHelper = {
 		excludeFileProtocol: function(callback){
 			var message = "Tests require script reload and cannot be run via file: protocol";
-			//NOTE alert tester that running the file locally will not work for these tests
+
 			if ( location.protocol == "file:" ) {
 				test(message, function(){
 					ok(false, message);
@@ -14,6 +14,21 @@
 			} else {
 				callback();
 			}
+		},
+
+		reloadCounts: {},
+
+		reloadLib: function(libName){
+			var lib = $("script[src$=" + libName + "]").clone(),
+					src = lib.attr('src');
+
+			if(this.reloadCounts[libName] === undefined) {
+				this.reloadCounts[libName] = 0;
+			}
+
+			//NOTE append "cache breaker" to force reload
+			lib.attr('src', src + "?" + this.reloadCounts[libName]++);
+			$("body").append(lib);
 		}
 	};
 })(jQuery);

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -6,7 +6,11 @@
 	var libName = "jquery.mobile.core.js",
 			setGradeA = function(value) { $.support.mediaquery = value; };
 
-	module(libName);
+	module(libName, {
+		setup: function(){
+			$('html').removeClass('ui-mobile');
+		}
+	});
 
 	$.testHelper.excludeFileProtocol(function(){
 
@@ -28,6 +32,21 @@
 			});
 
 			$.testHelper.reloadLib(libName);
+		});
+
+		test("enhancments are skipped when the browser is not grade A", function(){
+			setGradeA(false);
+			$.testHelper.reloadLib(libName);
+
+			//NOTE easiest way to check for enhancements, not the most obvious
+			ok(!$("html").hasClass("ui-mobile"));
+		});
+
+		test("enhancments are added when the browser is not grade A", function(){
+			setGradeA(true);
+			$.testHelper.reloadLib(libName);
+
+			ok($("html").hasClass("ui-mobile"));
 		});
 	});
 })(jQuery);

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -1,0 +1,33 @@
+/*
+ * mobile core unit tests
+ */
+
+(function( $ ) {
+	var libName = "jquery.mobile.core.js",
+			setGradeA = function(value) { $.support.mediaquery = value; };
+
+	module(libName);
+
+	$.testHelper.excludeFileProtocol(function(){
+
+		test("grade A browser support media queries", function(){
+			setGradeA(false);
+			$.testHelper.reloadLib(libName);
+			ok(!$.mobile.gradeA());
+
+			setGradeA(true);
+			$.testHelper.reloadLib(libName);
+			ok($.mobile.gradeA());
+		});
+
+		test("loading the core library triggers mobilinit on the document", function(){
+			expect( 1 );
+
+			$(window.document).bind('mobileinit', function(event){
+				ok(true);
+			});
+
+			$.testHelper.reloadLib(libName);
+		});
+	});
+})(jQuery);

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -4,17 +4,20 @@
 
 (function( $ ) {
 	var libName = "jquery.mobile.core.js",
-			setGradeA = function(value) { $.support.mediaquery = value; };
+			setGradeA = function(value) { $.support.mediaquery = value; },
+	    extendFn = $.extend;
 
 	module(libName, {
 		setup: function(){
 			$('html').removeClass('ui-mobile');
+		},
+		teardown: function(){
+			$.extend = extendFn;
 		}
 	});
 
 	$.testHelper.excludeFileProtocol(function(){
-
-		test("grade A browser support media queries", function(){
+		test( "grade A browser support media queries", function(){
 			setGradeA(false);
 			$.testHelper.reloadLib(libName);
 			ok(!$.mobile.gradeA());
@@ -24,7 +27,7 @@
 			ok($.mobile.gradeA());
 		});
 
-		test("loading the core library triggers mobilinit on the document", function(){
+		test( "loading the core library triggers mobilinit on the document", function(){
 			expect( 1 );
 
 			$(window.document).bind('mobileinit', function(event){
@@ -34,7 +37,7 @@
 			$.testHelper.reloadLib(libName);
 		});
 
-		test("enhancments are skipped when the browser is not grade A", function(){
+		test( "enhancments are skipped when the browser is not grade A", function(){
 			setGradeA(false);
 			$.testHelper.reloadLib(libName);
 
@@ -42,11 +45,45 @@
 			ok(!$("html").hasClass("ui-mobile"));
 		});
 
-		test("enhancments are added when the browser is not grade A", function(){
+		test( "enhancments are added when the browser is not grade A", function(){
 			setGradeA(true);
 			$.testHelper.reloadLib(libName);
 
 			ok($("html").hasClass("ui-mobile"));
 		});
+
+		var alterExtend = function(extraExtension){
+			var extendFn = $.extend;
+
+			$.extend = function(object, extension){
+				// NOTE extend the object as normal
+				var result = extendFn.apply(this, arguments);
+				result = extendFn(result, extraExtension);
+				return result;
+			};
+		};
+
+		test( "pageLoading doesn't add the dialog to the page when loading message is false", function(){
+			alterExtend({loadingMessage: false});
+			$.testHelper.reloadLib(libName);
+			$.mobile.pageLoading(false);
+			ok(!$(".ui-loader").length);
+		});
+
+		test( "pageLoading doesn't add the dialog to the page when done is passed as true", function(){
+			alterExtend({loadingMessage: true});
+			$.testHelper.reloadLib(libName);
+			$.mobile.pageLoading(true);
+			ok(!$(".ui-loader").length);
+		});
+
+		test( "pageLoading adds the dialog to the page when done is true", function(){
+			alterExtend({loadingMessage: true});
+			$.testHelper.reloadLib(libName);
+			$.mobile.pageLoading(false);
+			ok($(".ui-loader").length);
+		});
+
+		//TODO test the rest of the library after the $loader definition
 	});
 })(jQuery);

--- a/tests/unit/core/index.html
+++ b/tests/unit/core/index.html
@@ -12,9 +12,18 @@
 	<script type="text/javascript" src="../../../js/jquery.mobile.support.js"></script>
 	<script type="text/javascript" src="../../../js/jquery.mobile.event.js"></script>
 	<script type="text/javascript" src="../../../js/jquery.mobile.hashchange.js"></script>
-	<script type="text/javascript" src="../../../js/jquery.mobile.page.js"></script>
-
 	<script type="text/javascript" src="../../../js/jquery.mobile.core.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.page.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.ui.position.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.fixHeaderFooter.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.checkboxradio.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.textinput.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.select.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.buttonMarkup.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.button.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.slider.js"></script>
+  <script type="text/javascript" src="../../../js/jquery.mobile.controlGroup.js"></script>
+
 
 	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
 	<script type="text/javascript" src="../../../external/qunit.js"></script>
@@ -30,6 +39,8 @@
 </ol>
 
 <div id="main" style="position: absolute; top: -10000px; left: -10000px;">
+	<div data-role="page">
+	</div>
 </div>
 
 </body>

--- a/tests/unit/core/index.html
+++ b/tests/unit/core/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Core Test Suite</title>
+
+	<script type="text/javascript" src="../../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../../tests/jquery.testHelper.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.ui.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.media.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.support.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.event.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.hashchange.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.page.js"></script>
+
+	<script type="text/javascript" src="../../../js/jquery.mobile.core.js"></script>
+
+	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
+	<script type="text/javascript" src="../../../external/qunit.js"></script>
+
+	<script type="text/javascript" src="core.js"></script>
+</head>
+<body>
+
+<h1 id="qunit-header">jQuery Mobile Core Test Suite</h1>
+<h2 id="qunit-banner"></h2>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests">
+</ol>
+
+<div id="main" style="position: absolute; top: -10000px; left: -10000px;">
+</div>
+
+</body>
+</html>

--- a/tests/unit/media/media_core.js
+++ b/tests/unit/media/media_core.js
@@ -7,7 +7,7 @@
 	    widthFn = $.fn.width;
 
 	// make sure original definitions are reset
-	module('mobile.media', {
+	module('jquery.mobile.media.js', {
 		teardown: function(){
 			$.fn.css = cssFn;
 			$.fn.width = widthFn;

--- a/tests/unit/support/index.html
+++ b/tests/unit/support/index.html
@@ -5,6 +5,7 @@
 	<title>jQuery Mobile Support Test Suite</title>
 
 	<script type="text/javascript" src="../../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../../tests/jquery.testHelper.js"></script>
 	<script type="text/javascript" src="../../../js/jquery.ui.widget.js"></script>
 	<script type="text/javascript" src="../../../js/jquery.mobile.widget.js"></script>
 	<script type="text/javascript" src="../../../js/jquery.mobile.media.js"></script>

--- a/tests/unit/support/support_core.js
+++ b/tests/unit/support/support_core.js
@@ -4,15 +4,8 @@
 
 (function( $ ) {
 	$.testHelper.excludeFileProtocol(function(){
-		var reloadCount = 0,
-		lib = $("script[src$=support.js]"),
-	  src = lib.attr('src'),
-	  reloadLib = function(){
-			//NOTE append "cache breaker" to force reload
-			lib.attr('src', src + "?" + reloadCount++);
-			$("body").append(lib);
-	  },
-		prependToFn = $.fn.prependTo;
+		var	prependToFn = $.fn.prependTo,
+				libName = "jquery.mobile.support.js";
 
 		module("mobile.support", {
 			teardown: function(){
@@ -35,7 +28,7 @@
 			history.pushState = function(){};
 			$.mobile.media = function(){ return true; };
 
-			reloadLib();
+			$.testHelper.reloadLib(libName);
 
 			ok($.support.orientation);
 			ok($.support.touch);
@@ -48,7 +41,7 @@
 			delete window["orientation"];
 			delete document["ontouchend"];
 
-			reloadLib();
+			$.testHelper.reloadLib(libName);
 
 			ok(!$.support.orientation);
 			ok(!$.support.touch);
@@ -68,13 +61,13 @@
 
 		test( "detects dynamic base tag when new base element added and base href updates", function(){
 			mockBaseCheck(location.protocol + '//' + location.host + location.pathname + "ui-dir/");
-			reloadLib();
+			$.testHelper.reloadLib(libName);
 			ok($.support.dynamicBaseTag);
 		});
 
 		test( "detects no dynamic base tag when new base element added and base href unchanged", function(){
 			mockBaseCheck('testurl');
-			reloadLib();
+			$.testHelper.reloadLib(libName);
 			ok(!$.support.dynamicBaseTag);
 		});
 

--- a/tests/unit/support/support_core.js
+++ b/tests/unit/support/support_core.js
@@ -3,14 +3,7 @@
  */
 
 (function( $ ) {
-	//NOTE alert tester that running the file locally will not work for these tests
-	if ( location.protocol == "file:" ) {
-		var message = "Tests require script reload and cannot be run via file: protocol";
-
-		test(message, function(){
-			ok(false, message);
-		});
-	} else {
+	$.testHelper.excludeFileProtocol(function(){
 		var reloadCount = 0,
 		lib = $("script[src$=support.js]"),
 	  src = lib.attr('src'),
@@ -87,5 +80,5 @@
 
 		//TODO propExists testing, refactor propExists into mockable method
 		//TODO scrollTop testing, refactor scrollTop logic into mockable method
-	}
+	});
 })(jQuery);

--- a/tests/unit/support/support_core.js
+++ b/tests/unit/support/support_core.js
@@ -7,7 +7,7 @@
 		var	prependToFn = $.fn.prependTo,
 				libName = "jquery.mobile.support.js";
 
-		module("mobile.support", {
+		module(libName, {
 			teardown: function(){
 				//NOTE undo any mocking
 				$.fn.prependTo = prependToFn;

--- a/tests/unit/widget/widget_core.js
+++ b/tests/unit/widget/widget_core.js
@@ -3,7 +3,7 @@
  */
 
 (function( $ ) {
-	module('mobile.widget');
+	module('jquery.mobile.widget.js');
 
 	test( "getting data from creation options", function(){
 		var expected = "bizzle";


### PR DESCRIPTION
I've started the tests for jquery.mobile.core.js and added some simple helpers to jquery.testHelper.js to make the testing process a bit smoother
- $.testHelper.reloadLib reloads a script file to test onload functionality
- $.testHelper.excludeFileProtocol loads a single failing test with a notice to alert folks to test sets that require reloading scripts (and thus can't use the local file protocol)

Any suggestions on a better namespace or location for the helpers is welcome.
