### PR TITLE
Allow Select Menus to receive browser-default behavior and UI by ignoring data-role="none"

### DIFF
--- a/docs/forms/forms-selects.html
+++ b/docs/forms/forms-selects.html
@@ -114,7 +114,10 @@
 
 
 	<h2>Data attribute support</h2>
-	<p>You can specify any jQuery Mobile button data- attribute on a select element too.</p>		 
+	<p>You can specify any jQuery Mobile button data- attribute on a select element too.</p>	
+	<p>To allow a default select to show, and disable jQuery Mobile's custom select menu, use <code>data-role="none"</code>.</p>
+	
+		 
 			 
 	<div data-role="fieldcontain">
 		<label for="select-choice-3" class="select">Actions</label>

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -173,7 +173,7 @@ $.widget( "mobile.page", $.mobile.widget, {
 
 		this.element
 			.find( "select" )
-			.not( "[data-role='slider' ], [data-role='none' ]" )
+			.not( "[data-role='slider'], [data-role='none']" )
 			.selectmenu();
 	}
 });

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -172,7 +172,8 @@ $.widget( "mobile.page", $.mobile.widget, {
 			.slider();
 
 		this.element
-			.find( "select:not([data-role='slider'])" )
+			.find( "select" )
+			.not( "[data-role='slider' ], [data-role='none' ]" )
 			.selectmenu();
 	}
 });


### PR DESCRIPTION
I added:

```
    this.element
        .find( "select" )
        .not( "[data-role='slider'], [data-role='none']" )
        .selectmenu();
```

I also added this feature to the Select menu documentation.
