### PR TITLE
Finished mobile.core testing

### DIFF
--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -32,6 +32,19 @@
 			//NOTE append "cache breaker" to force reload
 			lib.attr('src', src + "?" + this.reloads[libName].count++);
 			$("body").append(lib);
+		},
+
+		alterExtend: function(extraExtension){
+			var extendFn = $.extend;
+
+			$.extend = function(object, extension){
+				// NOTE extend the object as normal
+				var result = extendFn.apply(this, arguments);
+
+				// NOTE add custom extensions
+				result = extendFn(result, extraExtension);
+				return result;
+			};
 		}
 	};
 })(jQuery);

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -145,5 +145,7 @@
 
 			$.testHelper.reloadLib(libName);
 		});
+
+		//TODO test that silentScroll is called on window load
 	});
 })(jQuery);

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -83,7 +83,7 @@
 
 			// TODO add post reload callback
 			$('.ui-loader').remove();
-			
+
 			$.mobile.pageLoading(true);
 			ok(!$(".ui-loader").length);
 		});

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -56,29 +56,17 @@
 			ok($("html").hasClass("ui-mobile"));
 		});
 
-		var alterExtend = function(extraExtension){
-			var extendFn = $.extend;
-
-			$.extend = function(object, extension){
-				// NOTE extend the object as normal
-				var result = extendFn.apply(this, arguments);
-
-				// NOTE add custom extensions
-				result = extendFn(result, extraExtension);
-				return result;
-			};
-		};
 
 		//TODO lots of duplication
 		test( "pageLoading doesn't add the dialog to the page when loading message is false", function(){
-			alterExtend({loadingMessage: false});
+			$.testHelper.alterExtend({loadingMessage: false});
 			$.testHelper.reloadLib(libName);
 			$.mobile.pageLoading(false);
 			ok(!$(".ui-loader").length);
 		});
 
 		test( "pageLoading doesn't add the dialog to the page when done is passed as true", function(){
-			alterExtend({loadingMessage: true});
+			$.testHelper.alterExtend({loadingMessage: true});
 			$.testHelper.reloadLib(libName);
 
 			// TODO add post reload callback
@@ -89,7 +77,7 @@
 		});
 
 		test( "pageLoading adds the dialog to the page when done is true", function(){
-			alterExtend({loadingMessage: true});
+			$.testHelper.alterExtend({loadingMessage: true});
 			$.testHelper.reloadLib(libName);
 			$.mobile.pageLoading(false);
 			ok($(".ui-loader").length);
@@ -98,7 +86,7 @@
 		var metaViewportSelector = "head meta[name=viewport]",
 				setViewPortContent = function(value){
 					$(metaViewportSelector).remove();
-					alterExtend({metaViewportContent: value});
+					$.testHelper.alterExtend({metaViewportContent: value});
 					$.testHelper.reloadLib(libName);
 				};
 
@@ -112,6 +100,50 @@
 			same($(metaViewportSelector).length, 0);
 		});
 
-		//TODO test the rest of the library after the $loader definition
+		var findFirstPage = function() {
+			return $("[data-role='page']").first();
+		};
+
+		test( "active page and start page should be set to the fist page in the selected set", function(){
+			var firstPage = findFirstPage();
+			$.testHelper.reloadLib(libName);
+
+			same($.mobile.startPage, firstPage);
+			same($.mobile.activePage, firstPage);
+		});
+
+		test( "mobile viewport class is defined on the first page's parent", function(){
+			var firstPage = findFirstPage();
+			$.testHelper.reloadLib(libName);
+
+			ok(firstPage.parent().hasClass('ui-mobile-viewport'));
+		});
+
+		test( "mobile page container is the first page's parent", function(){
+			var firstPage = findFirstPage();
+			$.testHelper.reloadLib(libName);
+
+			same($.mobile.pageContainer, firstPage.parent());
+		});
+
+		test( "page loading is called on document ready", function(){
+			expect( 2 );
+
+			$.testHelper.alterExtend({ pageLoading: function(){
+				ok("called");
+			}});
+
+			$.testHelper.reloadLib(libName);
+		});
+
+		test( "hashchange triggered on document ready with single argument: true", function(){
+			expect( 2 );
+
+			$(window).bind("hashchange", function(ev, arg){
+				same(arg, true);
+			});
+
+			$.testHelper.reloadLib(libName);
+		});
 	});
 })(jQuery);

--- a/tests/unit/core/core_scroll.js
+++ b/tests/unit/core/core_scroll.js
@@ -17,10 +17,15 @@
 		}
 	});
 
-	var scrollUp = function(){
+	var scrollUp = function( pos ){
 		$(window).scrollTop(1000);
 		ok($(window).scrollTop() > 0);
-		$.mobile.silentScroll();
+
+		if(pos) {
+			$.mobile.silentScroll(pos);
+		} else {
+			$.mobile.silentScroll();
+		}
 	};
 
 	test( "silent scroll scrolls the page to the top by default", function(){
@@ -29,6 +34,17 @@
 		stop();
 		setTimeout(function(){
 			same($(window).scrollTop(), 0);
+			start();
+		}, scrollTimeout);
+	});
+
+	test( "silent scroll scrolls the page to the passed y position", function(){
+		var pos = 10;
+		scrollUp(pos);
+
+		stop();
+		setTimeout(function(){
+			same($(window).scrollTop(), pos);
 			start();
 		}, scrollTimeout);
 	});

--- a/tests/unit/core/core_scroll.js
+++ b/tests/unit/core/core_scroll.js
@@ -1,0 +1,58 @@
+/*
+ * mobile core unit tests
+ */
+
+(function( $ ) {
+	var libName = "jquery.mobile.core.js",
+			scrollTimeout = 20, // TODO expose timing as an attribute
+			scrollStartEnabledTimeout = 150;
+
+	module(libName, {
+		setup: function(){
+			$("<div id='scroll-testing' style='height: 1000px'></div>").appendTo("body");
+		},
+
+		teardown: function(){
+			$("#scroll-testing").remove();
+		}
+	});
+
+	var scrollUp = function(){
+		$(window).scrollTop(1000);
+		ok($(window).scrollTop() > 0);
+		$.mobile.silentScroll();
+	};
+
+	test( "silent scroll scrolls the page to the top by default", function(){
+		scrollUp();
+
+		stop();
+		setTimeout(function(){
+			same($(window).scrollTop(), 0);
+			start();
+		}, scrollTimeout);
+	});
+
+	// NOTE may be brittle depending on timing
+	test( "silent scroll takes at least 20 ms to scroll to the top", function(){
+		scrollUp();
+
+		stop();
+		setTimeout(function(){
+			ok($(window).scrollTop() != 0);
+			start();
+		}, scrollTimeout - 1);
+	});
+
+	test( "scrolling marks scrollstart as disabled for 150 ms", function(){
+		$.event.special.scrollstart.enabled = true;
+		scrollUp();
+		ok(!$.event.special.scrollstart.enabled);
+
+		stop();
+		setTimeout(function(){
+			ok($.event.special.scrollstart.enabled);
+			start();
+		}, scrollStartEnabledTimeout);
+	});
+})(jQuery);

--- a/tests/unit/core/index.html
+++ b/tests/unit/core/index.html
@@ -28,6 +28,7 @@
 	<script type="text/javascript" src="../../../external/qunit.js"></script>
 
 	<script type="text/javascript" src="core.js"></script>
+	<script type="text/javascript" src="core_scroll.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
I've finished mobile.core testing save for the window load call to silentScroll which has a todo at the bottom of core.js. I moved the silent scroll tests out to their own js file as they have a unique setup and teardown, and they can be run without reloading the script tag. 

In the future I plan to split them based on similar criteria when there isn't an obvious division like those for some of the ui js files (eq core_methods or core_events)

As always thanks for reviewing my commits, and I hope everyone had a pleasant thanksgiving (to those of us in the US)
