### PR TITLE
Introduced 100% fluid width button groups

### DIFF
--- a/docs/buttons/buttons-grouped.html
+++ b/docs/buttons/buttons-grouped.html
@@ -34,7 +34,7 @@
 			<a href="index.html" data-role="button">Maybe</a>
 		</div>
 		
-		<p>By adding the <code>data-type="horizontal"</code> attribute to the <code>controlgroup</code> container, you can swap to a horizontal-style group that floats the buttons side-by-side and sets the width to only be large enough to fit the content. (Be aware that these will wrap to multiple lines if the number of buttons or the overall text length is too wide for the screen.)
+		<p>By adding the <code>data-type="horizontal"</code> attribute to the <code>controlgroup</code> container, you can swap to a horizontal-style group that floats the buttons side-by-side and sets the width to only be large enough to fit the content. (Be aware that these will wrap to multiple lines if the number of buttons or the overall text length is too wide for the screen). By adding <code>class=&quot;ui-fluid&quot;</code> to the controlgroup, the button group will be 100% width.
 		
 		<p>Horizontal grouped buttons:</p>
 		<div data-role="controlgroup" data-type="horizontal">
@@ -42,6 +42,14 @@
 			<a href="index.html" data-role="button">No</a>
 			<a href="index.html" data-role="button">Maybe</a>
 		</div>
+		
+		<p>Horizontal grouped buttons with fluid width:</p>
+		<div data-role="controlgroup" data-type="horizontal" class="ui-fluid">
+			<a href="index.html" data-role="button">$</a>
+			<a href="index.html" data-role="button">$$</a>
+			<a href="index.html" data-role="button">$$$</a>
+			<a href="index.html" data-role="button">$$$$</a>
+		</div>		
 			
 		<p>Horizontal grouped buttons with icons:</p>
 		<div data-role="controlgroup" data-type="horizontal" >
@@ -49,6 +57,7 @@
 			<a href="index.html" data-role="button" data-icon="arrow-d">Down</a>
 			<a href="index.html" data-role="button" data-icon="delete">Delete</a>
 		</div>
+	
 		
 		<p>Horizontal grouped buttons, icon only:</p>
 		<div data-role="controlgroup" data-type="horizontal" >

--- a/docs/forms/forms-checkboxes.html
+++ b/docs/forms/forms-checkboxes.html
@@ -94,8 +94,24 @@
 				<label for="checkbox-8">u</label>    
 		    </fieldset>
 		</div>
+		
+		<h3>Fluid 100% width</h3>
+		<p>Add <code>class=&quot;ui-fluid&quot;</code> to the <code>fieldset</code>.</p>
+		<div data-role="fieldcontain">
+		    <fieldset data-role="controlgroup" data-type="horizontal" class="ui-fluid">
+		    	<legend>Font styling:</legend>
+		    	<input type="checkbox" name="checkbox-9" id="checkbox-9" class="custom" />
+				<label for="checkbox-9">b</label>
 
+				<input type="checkbox" name="checkbox-10" id="checkbox-10" class="custom" />
+				<label for="checkbox-10"><em>i</em></label>
 
+				<input type="checkbox" name="checkbox-11" id="checkbox-11" class="custom" />
+				<label for="checkbox-11">u</label>    
+		    </fieldset>
+		</div>
+		
+		
 	</form>
 	
 	</div><!-- /content -->

--- a/docs/forms/forms-radiobuttons.html
+++ b/docs/forms/forms-radiobuttons.html
@@ -93,6 +93,21 @@
 	    </fieldset>
 	</div>
 	
+	<h3>Fluid 100% width</h3>
+	<p>Add <code>class=&quot;ui-fluid&quot;</code> to the <code>fieldset</code>.</p>
+	<div data-role="fieldcontain">
+	    <fieldset data-role="controlgroup" data-type="horizontal" class="ui-fluid">
+	     	<legend>Layout view:</legend>
+	         	<input type="radio" name="radio-view" id="radio-view-d" value="list"  />
+	         	<label for="radio-view-d">List</label>
+	         	<input type="radio" name="radio-view" id="radio-view-e" value="grid"  />
+	         	<label for="radio-view-e">Grid</label>
+	         	<input type="radio" name="radio-view" id="radio-view-f" value="gallery"  />
+	         	<label for="radio-view-f">Gallery</label>
+	    </fieldset>
+	</div>
+	
+	
 	<!--
 	<h2>No icon option</h2>
 	

--- a/js/jquery.mobile.controlGroup.js
+++ b/js/jquery.mobile.controlGroup.js
@@ -9,8 +9,8 @@ $.fn.controlgroup = function(options){
 		
 	return $(this).each(function(){
 	
-		if ($(this).hasClass("ui-fluid") && this.tagName != "FIELDSET") {
-			$(this).children().wrapAll("<div class='ui-table-row' />");
+		if ( $(this).hasClass("ui-fluid") && this.tagName != "FIELDSET" ) {
+			$(this).children().wrapAll( "<div class='ui-table-row' />" ) ;
 		}
 	
 		var o = $.extend({

--- a/js/jquery.mobile.controlGroup.js
+++ b/js/jquery.mobile.controlGroup.js
@@ -8,6 +8,11 @@
 $.fn.controlgroup = function(options){
 		
 	return $(this).each(function(){
+	
+		if ($(this).hasClass("ui-fluid") && this.tagName != "FIELDSET") {
+			$(this).children().wrapAll("<div class='ui-table-row' />");
+		}
+	
 		var o = $.extend({
 			direction: $( this ).data( "type" ) || "vertical",
 			shadow: false
@@ -18,9 +23,9 @@ $.fn.controlgroup = function(options){
 		
 		//replace legend with more stylable replacement div	
 		if( groupheading.length ){
-			$(this).wrapInner('<div class="ui-controlgroup-controls"></div>');	
+			$(this).wrapInner('<div class="ui-controlgroup-controls"></div>');
 			$('<div role="heading" class="ui-controlgroup-label">'+ groupheading.html() +'</div>').insertBefore( $(this).children(0) );	
-			groupheading.remove();	
+			groupheading.remove();
 		}
 
 		$(this).addClass('ui-corner-all ui-controlgroup ui-controlgroup-'+o.direction);

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -24,7 +24,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				icon: this.element.parents( "[data-type='horizontal']" ).length ? undefined : uncheckedicon,
 				shadow: false
 			});
-		
+
 		// wrap the input + label in a div 
 		input
 			.add( label )

--- a/themes/default/jquery.mobile.controlgroup.css
+++ b/themes/default/jquery.mobile.controlgroup.css
@@ -31,6 +31,6 @@
 .ui-fluid .ui-btn { display: table-cell; text-align: center; }
 .ui-fluid .ui-btn .ui-btn-inner { width: 100%; padding: 0.6em 0px; }
 
-.ui-fluid .ui-controlgroup-controls {width: 100%; display: table;}
-.ui-fluid .ui-checkbox, .ui-fluid .ui-radio {display: table-cell;}
-.ui-fluid .ui-checkbox label, .ui-fluid .ui-radio label {width: 100%;display: block; text-align: center;}
+.ui-fluid .ui-controlgroup-controls { width: 100%; display: table; }
+.ui-fluid .ui-checkbox, .ui-fluid .ui-radio { display: table-cell; }
+.ui-fluid .ui-checkbox label, .ui-fluid .ui-radio label { width: 100%;display: block; text-align: center; }

--- a/themes/default/jquery.mobile.controlgroup.css
+++ b/themes/default/jquery.mobile.controlgroup.css
@@ -25,3 +25,12 @@
 
 .min-width-480px .ui-controlgroup-label { vertical-align: top; display: inline-block;  width: 20%;  margin: 0 2% 0 0;  }
 .min-width-480px .ui-controlgroup-controls { width: 60%; display: inline-block; } 
+
+.ui-fluid { display: table; width: 100%; }
+.ui-table-row { display: table-row; }
+.ui-fluid .ui-btn { display: table-cell; text-align: center; }
+.ui-fluid .ui-btn .ui-btn-inner { width: 100%; padding: 0.6em 0px; }
+
+.ui-fluid .ui-controlgroup-controls {width: 100%; display: table;}
+.ui-fluid .ui-checkbox, .ui-fluid .ui-radio {display: table-cell;}
+.ui-fluid .ui-checkbox label, .ui-fluid .ui-radio label {width: 100%;display: block; text-align: center;}


### PR DESCRIPTION
Hello,

To replicate a native iPhone UI, I had to create button groups that are 100% width. To do this, I added mainly css, but with a touch of javascript. I used "display: table" on divs and such.

The instructions in the documentation I added were to include the css class "ui-fluid." This may go against jQueryMobile's model to only use data- attributes. But since data-type="horizontal" is already included, I had no choice but to use css class. I think this is logical and works. It is perfect for my employer's purpose, and I hope this will work for jQueryMobile's as well. Otherwise I can rework it with your guidance. 

Thanks,
Alex Grande
