### PR TITLE
Selectmenu: don't prevent events from bubbling

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -124,12 +124,12 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		//button events
 		button.bind( $.support.touch ? "touchstart" : "click", function(event){
 			self.open();
-			return false;
+			event.preventDefault();
 		});
 		
 		//events for list items
-		list.delegate("li",'click', function(){
-				//update select	
+		list.delegate("li",'click', function(event){
+				//update select
 				var newIndex = list.find( "li" ).index( this ),
 					prevIndex = select[0].selectedIndex;
 
@@ -144,14 +144,14 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 				
 				//hide custom select
 				self.close();
-				return false;
+				event.preventDefault();
 			});	
 	
 		//events on "screen" overlay
-		screen.click(function(){
+		screen.click(function(event){
 			self.close();
-			return false;
-		});	
+			event.preventDefault();
+		});
 	},
 	
 	_buildList: function(){


### PR DESCRIPTION
Provides a bit more flexibility.
