### PR TITLE
Navigation problems: blank pages when using forward/back browser buttons, etc

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -193,8 +193,8 @@
 				
 				reFocus( to );
 				
-				if( changeHash !== false && url ){
-					path.set(url, (back !== true));
+				if( changeHash && url ){
+					path.set(url, true);
 				}
 				removeActiveLinkClass();
 				


### PR DESCRIPTION
There are a couple of issues fixed here but they are not straight forward to recreate. 

When using the test site (http://jquerymobile.com/test) try going two deep into the structure eg:

Menu -> Toolbars -> Navbars

Then back up to the menu using the browser back button, and then go back to Navbars using the browser forward button.

The main problem lies in the hashchange listener triggering changepage() twice as the hashChange var is "null" not "false".

The same thing happens if you use a hyperlink to the previous page. changepage() seems to wrongly assume you have used the browser back button.
