### PR TITLE
Selectmenu: add optgroup support

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -128,24 +128,24 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		});
 		
 		//events for list items
-		list.delegate("li:not(.ui-disabled)", "click", function(){
-				//update select	
-				var newIndex = list.find( "li" ).index( this ),
-					prevIndex = select[0].selectedIndex;
-
-				select[0].selectedIndex = newIndex;
-				
-				//trigger change event
-				if(newIndex !== prevIndex){ 
-					select.trigger( "change" ); 
-				}
-				
-				self.refresh();
-				
-				//hide custom select
-				self.close();
-				return false;
-			});	
+		list.delegate("li:not(.ui-disabled, .ui-li-divider)", "click", function(){
+			//update select
+			var newIndex = list.find( "li:not(.ui-li-divider)" ).index( this ),
+				prevIndex = select[0].selectedIndex;
+			
+			select[0].selectedIndex = newIndex;
+			
+			//trigger change event
+			if(newIndex !== prevIndex){ 
+				select.trigger( "change" ); 
+			}
+			
+			self.refresh();
+			
+			//hide custom select
+			self.close();
+			return false;
+		});
 	
 		//events on "screen" overlay
 		screen.click(function(){
@@ -155,12 +155,29 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 	},
 	
 	_buildList: function(){
-		var self = this;
+		var self = this, optgroups = [];
 		
 		self.list.empty().filter('.ui-listview').listview('destroy');
 		
 		//populate menu with options from select element
 		self.select.find( "option" ).each(function( i ){
+			var $this = $(this),
+				$parent = $this.parent();
+			
+			// are we inside an optgroup?
+			if( $parent.is("optgroup") ){
+				var optLabel = $parent.attr("label");
+				
+				// has this optgroup already been built yet?
+				if( $.inArray(optLabel, optgroups) === -1 ){
+					var optgroup = $('<li data-role="list-divider"></li>')
+						.text( optLabel )
+						.appendTo( self.list );
+					
+					optgroups.push( optLabel );
+				}
+			}
+			
 			var anchor = $("<a>", { 
 				"role": "option", 
 				"href": "#",
@@ -182,7 +199,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		});
 		
 		//now populated, create listview
-		self.list.listview();		
+		self.list.listview();
 	},
 	
 	refresh: function( forceRebuild ){
@@ -192,12 +209,20 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		
 		if( forceRebuild || select[0].options.length > self.list.find('li').length ){
 			self._buildList();
-		}	
-			
-		self.button.find( ".ui-btn-text" ).text( $(select[0].options.item(selected)).text() ); 
+		}
+		
+		self.button
+			.find( ".ui-btn-text" )
+			.text( $(select[0].options.item(selected)).text() );
+		
 		self.list
-			.find('li').removeClass( $.mobile.activeBtnClass ).attr('aria-selected', false)
-			.eq(selected).addClass( $.mobile.activeBtnClass ).find('a').attr('aria-selected', true);		
+			.find('li:not(.ui-li-divider)')
+			.removeClass( $.mobile.activeBtnClass )
+			.attr('aria-selected', false)
+			.eq(selected)
+			.addClass( $.mobile.activeBtnClass )
+			.find('a')
+			.attr('aria-selected', true);
 	},
 	
 	open: function(){

--- a/themes/default/jquery.mobile.forms.select.css
+++ b/themes/default/jquery.mobile.forms.select.css
@@ -13,8 +13,8 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 
 /*listbox*/
 .ui-selectmenu { position: absolute; padding: 0; z-index: 100 !important; width: 80%; max-width: 350px; padding: 6px; }
-.ui-selectmenu .ui-listview { margin: 0;
- }
+.ui-selectmenu .ui-listview { margin: 0; }
+.ui-selectmenu .ui-btn.ui-li-divider { cursor: default; }
 .ui-selectmenu-hidden { top: -999999px; left: -99999px; }
 .ui-selectmenu-screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%;  z-index: 99; }
 .ui-screen-hidden, .ui-selectmenu-list .ui-li .ui-icon { display: none; }


### PR DESCRIPTION
This pull adds optgroup support.  See: http://www.erichynds.com/mobile/select-optgroups/

Styling could use some love but the logic is there. I used data-role="list-divider" on the optgroup's list item to denote it as an optgroup, and used the class "ui-li-divider" to differentiate between options/optgroups inside click/refresh methods.

If "list-divider" isn't the correct role to use or another should be created specific to optgroups, all that need be changed inside the select widget is the data-role attribute and whatever associated class that role adds.

There are less changes than this pull leads you to believe; I think a lot of it is just indentation changes?
