### PR TITLE
Navigation: Duplicate Cached Page is removed too early causing failure of hide event

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -212,10 +212,7 @@
 				}
 				removeActiveLinkClass();
 				
-				//if there's a duplicateCachedPage, remove it from the DOM now that it's hidden
-				if( duplicateCachedPage != null ){
-					duplicateCachedPage.remove();
-				}
+				
 				
 				//jump to top or prev scroll, if set
 				$.mobile.silentScroll( to.data( 'lastScroll' ) );
@@ -224,6 +221,11 @@
 				from.data("page")._trigger("hide", null, {nextPage: to});
 				if( to.data("page")._trigger("show", null, {prevPage: from}) !== false ){
 					$.mobile.activePage = to;
+				}
+
+				//if there's a duplicateCachedPage, remove it from the DOM now that it's hidden
+				if (duplicateCachedPage != null) {
+				    duplicateCachedPage.remove();
 				}
 			};
 			


### PR DESCRIPTION
This occurs when posting data to the same URL as the form page - you get the error:

Result of expression 'from.data("page")' [undefined] is not an object.

This also causes subsequent navigation to fail.

Think this might fix issue #660 as well
