### PR TITLE
href attribute no longer required

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -386,7 +386,7 @@
 		if( !$.mobile.ajaxLinksEnabled ){ return; }
 		var $this = $(this),
 			//get href, remove same-domain protocol and host
-			href = $this.attr( "href" ).replace( location.protocol + "//" + location.host, ""),
+			href = ($this.attr( "href" )) ? $this.attr( "href" ).replace( location.protocol + "//" + location.host, "") : "#",
 			//if target attr is specified, it's external, and we mimic _blank... for now
 			target = $this.is( "[target]" ),
 			//if it still starts with a protocol, it's external, or could be :mailto, etc


### PR DESCRIPTION
I have some list items that needed anchor tags inside them to properly display, but I'm actually controlling their clicks dynamically using changePage(). Since those anchor tags didn't have hrefs, they were throwing JS errors. I found the link throwing the error, and modified it so that if the href doesn't exist for the element, it will default to using the hash ('#'). I realize that not having an href is bad practice, but I've needed to do that in a few places and it doesn't seem like the JS should fail just because of that. 
- Brandon
