### PR TITLE
Adding webkit animations to listviews

### DIFF
--- a/docs/lists/index.html
+++ b/docs/lists/index.html
@@ -34,6 +34,7 @@
 			<li><a href="lists-search.html">Search filter bar</a></li>	
 			<li><a href="lists-inset.html">Inset styled lists</a></li>
 			<li><a href="lists-performance.html">List performance test</a></li>
+			<li><a href="list-animations.html">Animation Lists</a></li>
 			<li><a href="lists-themes.html">Theming lists</a></li>
 			<!--<li><a href="api-lists.html">API documentation</a></li>-->
 		</ul>

--- a/docs/lists/list-animations.html
+++ b/docs/lists/list-animations.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> 
+<html> 
+	<head>
+	<meta charset="utf-8" /> 
+	<title>jQuery Mobile Docs - Lists</title> 
+	<link rel="stylesheet"  href="../../themes/default" />  
+	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>
+	<script type="text/javascript" src="../../js/"></script>
+</head> 
+<body> 
+
+<div data-role="page" data-theme="b">
+
+	<div data-role="header" data-theme="b">
+		<h1>Lists Animations</h1>
+	</div><!-- /header -->
+
+	<div data-role="content">
+
+		<p>Animations are cool, enough said. Currently works best with lists already in the DOM, not in seperate HTML files.</p>	
+
+		<h2>Blind Down</h2>
+		<p>To add, use the <code>animation-type="blind-down"</code> on the list's <code>ul</code>.</p>
+		<ul data-role="listview" data-inset="true" animation-type="blind-down">
+			<li><a href="#">1</a></li>
+			<li><a href="#">2</a></li>
+			<li><a href="#">3</a></li>
+			<li><a href="#">4</a></li>
+			<li><a href="#">5</a></li>
+			<li><a href="#">6</a></li>	
+			<li><a href="#">7</a></li>
+		</ul>
+		
+		<h2>3D Swing (Works only on iOS Devices &amp; Safari)</h2>
+		<p>To add, use the <code>animation-type="swing"</code> on the list's <code>ul</code>.</p>
+		<ul data-role="listview" data-inset="true" animation-type="swing">
+			<li><a href="#">1</a></li>
+			<li><a href="#">2</a></li>
+			<li><a href="#">3</a></li>
+			<li><a href="#">4</a></li>
+			<li><a href="#">5</a></li>
+			<li><a href="#">6</a></li>	
+			<li><a href="#">7</a></li>
+		</ul>
+
+	</div><!-- /content -->
+</div><!-- /page -->
+
+
+
+</body>
+</html>

--- a/js/index.php
+++ b/js/index.php
@@ -24,6 +24,7 @@ $elements = array(
 	'jquery.mobile.fieldContain.js',
 	'jquery.mobile.listview.js',
 	'jquery.mobile.listview.filter.js',
+	'jquery.mobile.listview.animation.js',
 	'jquery.mobile.dialog.js',
 	'jquery.mobile.navbar.js',
 	'jquery.mobile.grid.js'

--- a/js/jquery.mobile.listview.animation.js
+++ b/js/jquery.mobile.listview.animation.js
@@ -3,7 +3,6 @@
 		
 		return this.each(function() {
 			var $this = $(this);
-		console.log("hi");
 				$this.addClass("swing-wrapper no-border");
 				
 				$this.children("li").each(function(i, el) {

--- a/js/jquery.mobile.listview.animation.js
+++ b/js/jquery.mobile.listview.animation.js
@@ -1,0 +1,77 @@
+(function($) {
+	$.fn.swing = function() {  
+		
+		return this.each(function() {
+			var $this = $(this);
+		console.log("hi");
+				$this.addClass("swing-wrapper no-border");
+				
+				$this.children("li").each(function(i, el) {
+					$(this).css("-webkit-animation-duration", ((.3/$(this).length)*(i+1))+"s");
+				});
+						
+				$(this).closest(".ui-page").bind("pageshow", function() {
+					$this.addClass("go");
+				});
+				$(this).closest(".ui-page").bind("pagehide", function() {
+					$this.removeClass("swing-wrapper no-border go");
+				});
+				
+		});
+	};
+
+// Blind Down
+
+	var methods = {
+		down : function( ) {
+			var myheight = function(element) {
+				var h = window.getComputedStyle(element).height;
+				h = parseFloat(h);
+				return h;	
+			}
+			var blindDown = function($this) {
+				var children = $this.children(),
+					lastElHeight = 0,
+					totalHeight = 0;
+					
+				$this.addClass("blindDown-wrapper no-border");
+				children.each(function(i, el) {
+					$(el).css({
+						"webkitTransform": "translate(0px, "+totalHeight + "px)",
+						"opacity": 1
+					});
+					lastElHeight = myheight(el);
+					totalHeight+=lastElHeight;
+				});
+				$this.css("height",  totalHeight+15);
+				totalHeight = lastElHeight =  0;
+			}
+			
+			return this.each(function() {
+				var first = 0;
+				var $this = $(this);
+				$this.closest(".ui-page").bind("pageshow", function() {
+					blindDown($this);
+				});
+				
+				$(this).closest(".ui-page").bind("pagehide", function() {
+					$this.removeClass("blindDown-wrapper no-border");
+				});
+								
+			});
+		}
+	};
+	
+	$.fn.blind = function(method) {
+		// Method calling logic
+		if ( methods[method] ) {
+		  return methods[ method ].apply( this, Array.prototype.slice.call( arguments, 1 ));
+		} else if ( typeof method === 'object' || ! method ) {
+		  return methods.init.apply( this, arguments );
+		} else {
+		  $.error( 'Method ' +  method + ' does not exist on jQuery.blind' );
+		} 
+	};
+})(jQuery);
+
+

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -161,6 +161,19 @@ $.widget( "mobile.listview", $.mobile.widget, {
 			li = $list.children( "li" ),
 			counter = $.support.cssPseudoElement || !$.nodeName( $list[0], "ol" ) ? 0 : 1;
 
+		var animationType = $list.attr("animation-type");
+		if (animationType != "undefined") {
+			switch(animationType) {
+				case "blind-down":
+					$list.blind("down");
+					break;
+				case "swing":
+					$list.swing();
+					break;
+			}
+		}
+
+
 		if ( counter ) {
 			$list.find( ".ui-li-dec" ).remove();
 		}

--- a/themes/default/jquery.mobile.listview.css
+++ b/themes/default/jquery.mobile.listview.css
@@ -66,6 +66,7 @@ div[data-role=page] {-webkit-transform-style: preserve-3d;}
 	opacity: 0;
 	-webkit-transition: 1s ease-in-out;	position:  absolute;
 }
+
 .ui-listview > li {
 	width: 100%;
 }

--- a/themes/default/jquery.mobile.listview.css
+++ b/themes/default/jquery.mobile.listview.css
@@ -41,3 +41,31 @@ ol.ui-listview .ui-li-jsnumbering:before { content: "" !important; } /* to avoid
 @media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
     .ui-li .ui-btn-text { overflow:  visible; }
 }
+
+.no-border {border: none !important; -webkit-border-radius: 0 !important; -webkit-box-shadow: none !important; }
+/* listview animations */
+div[data-role=page] {-webkit-transform-style: preserve-3d;}
+
+/* 3D Swing Listview */
+.swing-wrapper {-webkit-perspective: 500;}
+.swing-wrapper li {-webkit-transform: rotateY(0deg);}
+.swing-wrapper.go li {
+	-webkit-transform-origin: right;
+	-webkit-animation-name: rotate-in;
+	-webkit-transition-timing-function: ease-out, cubic-bezier(0.5, 0.2, 0.3, 1.0);
+}
+@-webkit-keyframes rotate-in {
+  0%    {-webkit-transform: rotateY(-90deg);opacity: 0; }
+  100%  {-webkit-transform: rotateY(0deg);  opacity: 1;}
+}
+
+/* Blind Down */
+
+.blindDown-wrapper {-webkit-perspective: 1300;}
+.blindDown-wrapper > li {
+	opacity: 0;
+	-webkit-transition: 1s ease-in-out;	position:  absolute;
+}
+.ui-listview > li {
+	width: 100%;
+}


### PR DESCRIPTION
The video says it all: http://www.vimeo.com/17614876
- Works best on lists already in the DOM rather than lists in separate html files.
- The 3D swing works only on iOS devices and Safari.
- Tested on Android and iPhone. Need to load up my Blackberry Torch (doing that tomorrow).
- 3D Swing acts different on non-inset lists.
- As a quick fix for the blind down, I set a style for all .ui-listview > li to be 100% width. This probably needs to be removed.
- Uses new attribute animation-type for listviews. Options are animation-type="swing" and animation-type="blind-down".
- Creates "wow" and "pop" effect, clients are always asking for :)
