### PR TITLE
multiple select documentation & minor CSS fix

### DIFF
--- a/docs/forms/forms-selects.html
+++ b/docs/forms/forms-selects.html
@@ -54,7 +54,7 @@
 					</div>
 
 
-					<p>If there is a select menu with too many options to show on the device's screen, the framework will automatically create a new "page" populated with a standard list view that contains all the options. This allows us to use the native scrolling included on the device for moving through a long list. The text inside the <code>label</code> is used as the title for this page.</p>
+					<p>If there is a select menu with too many options to show on the device's screen, the framework will automatically create a new &quot;page&quot; populated with a standard list view that contains all the options. This allows us to use the native scrolling included on the device for moving through a long list. The text inside the <code>label</code> is used as the title for this page.</p>
 
 					<div data-role="fieldcontain">
 						<label for="select-choice-3" class="select">Your state:</label>
@@ -126,7 +126,7 @@
 	
 	
 	<h2>Placeholder options</h2>
-	<p>It's common for developers to include a "null" option in their select element to force a user to choose an option. jQuery Mobile detects these null options and hides them in the overlay menu, showing only valid choices to the user. Examples of null options are either:</p>
+	<p>It's common for developers to include a &quot;null&quot; option in their select element to force a user to choose an option. If a placeholder option is present in your markup, jQuery Mobile will hide them in the overlay menu, showing only valid choices to the user, and display the placeholder text inside the menu as a header.  Examples of null options are either:</p>
 	<ul>
 		<li>An option with no value attribute (or an empty value attribute)</li>
 		<li>An option with no text node</li>
@@ -136,10 +136,9 @@
 	<p>You can disable this feature through the selectmenu plugin's <code>hidePlaceholderMenuItems</code> option, like this:</p>
 	<pre>
 	<code>
-$.mobile.selectmenu.prototype.options.hidePlaceholderMenuItems = false;		
+$.mobile.selectmenu.prototype.options.hidePlaceholderMenuItems = false;
 	</code>
 	</pre>
-	
 	
 	<p>Here's a demo of various placeholder options:</p>
 		 
@@ -165,7 +164,7 @@ $.mobile.selectmenu.prototype.options.hidePlaceholderMenuItems = false;
 			<option value="express">Express: next day</option>
 			<option value="overnight">Overnight</option>
 		</select>
-	</div>		 
+	</div>
 		 
 		 
 	<div data-role="fieldcontain">
@@ -177,11 +176,10 @@ $.mobile.selectmenu.prototype.options.hidePlaceholderMenuItems = false;
 			<option value="express">Express: next day</option>
 			<option value="overnight">Overnight</option>
 		</select>
-	</div>	 
-
+	</div>
 	
 	<h2>Disabled options</h2>
-	<p>jQuery Mobile will automatically disable and style option tags with the <code>disabled=&quot;disabled&quot;</code> attribute.  In the demo below, the second option &quot;Rush: 3 days&quot; has been set to disabled.</p>
+	<p>jQuery Mobile will automatically disable and style option tags with the <code>disabled</code> attribute.  In the demo below, the second option &quot;Rush: 3 days&quot; has been set to disabled.</p>
 
 	<div data-role="fieldcontain">
 		<label for="select-choice-7" class="select">Choose shipping method:</label>
@@ -192,10 +190,9 @@ $.mobile.selectmenu.prototype.options.hidePlaceholderMenuItems = false;
 			<option value="overnight">Overnight</option>
 		</select>
 	</div>
-
 	
 	<h2>Optgroup support</h2>
-	<p>If a select menu contains <code>optgroup</code> elements, jQuery Mobile will create a divider based on their <code>label</code> attribute:</p>
+	<p>If a select menu contains <code>optgroup</code> elements, jQuery Mobile will create a divider &amp; group items based on the <code>label</code> attribute's text:</p>
 
 	<div data-role="fieldcontain">
 		<label for="select-choice-8" class="select">Choose shipping method:</label>
@@ -207,14 +204,98 @@ $.mobile.selectmenu.prototype.options.hidePlaceholderMenuItems = false;
 				<option value="overnight">Overnight</option>
 			</optgroup>
 			<optgroup label="FedEx">
-				<option value="sameday">First Overnight</option>
-				<option value="sameday">Express Saver</option>
-				<option value="sameday">Ground</option>
+				<option value="firstOvernight">First Overnight</option>
+				<option value="expressSaver">Express Saver</option>
+				<option value="ground">Ground</option>
 			</optgroup>
 		</select>
 	</div>
-	</form>
 	
+	
+	<h2>Multiple selects</h2>
+	<p>If the <code>multiple</code> attribute is present in your markup, jQuery Mobile will enhance the element with a few extra considerations:</p>
+	
+	<ul>
+	<li>A header element will be created inside the menu and display the placeholder text and a close button.</li>
+	<li>Clicking on an item inside the overlay menu will not close the widget.</li>
+	<li>A ghosted, unchecked icon will appear adjacent to each unselected item.  When the item is selected the icon will change to a checkbox.  Neither icon will appear inside a single select box.</li>
+	<li>Once 2+ items are selected, a counter element with the total number of selected items will appear inside the button.</li>
+	<li>The text of each selected item will appear inside the button as a list.  If the button is not wide enough to display the entire list, it is truncated with an ellipses.</li>
+	<li>If no items are selected, the button's text will default to the placeholder text.</li>
+	<li>If no placeholder element exists, the default button text will be blank and the header will appear with just a close button. Because this isn't a friendly user experience, we recommended that you always specify a placeholder element when using multiple select boxes.</li>
+	</ul>
+	
+	<div data-role="fieldcontain">
+		<label for="select-choice-9" class="select">Choose shipping method(s):</label>
+		<select name="select-choice-9" id="select-choice-9" multiple="multiple">
+			<option>Choose options</option>
+			<option value="standard">Standard: 7 day</option>
+			<option value="rush">Rush: 3 days</option>
+			<option value="express">Express: next day</option>
+			<option value="overnight">Overnight</option>
+		</select>
+	</div>
+	
+	<p>When a select is large enough to where the menu will open in a new page, the placeholder text is displayed in the button when no items are selected, and the <code>label</code> text is displayed in the menu's header.  This differs from smaller overlay menus where the placeholder text is displayed in both the button and the header, and from full-page single selects where the placeholder text is not used at all.</p>
+	
+	<div data-role="fieldcontain">
+		<label for="select-choice-10" class="select">Choose state(s):</label>
+		<select name="select-choice-10" id="select-choice-10" multiple="multiple">
+			<option>Choose options</option>
+			<option value="AL">Alabama</option>
+			<option value="AK">Alaska</option>
+			<option value="AZ">Arizona</option>
+			<option value="AR">Arkansas</option>
+			<option value="CA">California</option>
+			<option value="CO">Colorado</option>
+			<option value="CT">Connecticut</option>
+			<option value="DE">Delaware</option>
+			<option value="FL">Florida</option>
+			<option value="GA">Georgia</option>
+			<option value="HI">Hawaii</option>
+			<option value="ID">Idaho</option>
+			<option value="IL">Illinois</option>
+			<option value="IN">Indiana</option>
+			<option value="IA">Iowa</option>
+			<option value="KS">Kansas</option>
+			<option value="KY">Kentucky</option>
+			<option value="LA">Louisiana</option>
+			<option value="ME">Maine</option>
+			<option value="MD">Maryland</option>
+			<option value="MA">Massachusetts</option>
+			<option value="MI">Michigan</option>
+			<option value="MN">Minnesota</option>
+			<option value="MS">Mississippi</option>
+			<option value="MO">Missouri</option>
+			<option value="MT">Montana</option>
+			<option value="NE">Nebraska</option>
+			<option value="NV">Nevada</option>
+			<option value="NH">New Hampshire</option>
+			<option value="NJ">New Jersey</option>
+			<option value="NM">New Mexico</option>
+			<option value="NY">New York</option>
+			<option value="NC">North Carolina</option>
+			<option value="ND">North Dakota</option>
+			<option value="OH">Ohio</option>
+			<option value="OK">Oklahoma</option>
+			<option value="OR">Oregon</option>
+			<option value="PA">Pennsylvania</option>
+			<option value="RI">Rhode Island</option>
+			<option value="SC">South Carolina</option>
+			<option value="SD">South Dakota</option>
+			<option value="TN">Tennessee</option>
+			<option value="TX">Texas</option>
+			<option value="UT">Utah</option>
+			<option value="VT">Vermont</option>
+			<option value="VA">Virginia</option>
+			<option value="WA">Washington</option>
+			<option value="WV">West Virginia</option>
+			<option value="WI">Wisconsin</option>
+			<option value="WY">Wyoming</option>
+		</select>
+	</div>
+
+	</form>
 	</div><!-- /content -->
 </div><!-- /page -->
 

--- a/docs/lists/lists-themes.html
+++ b/docs/lists/lists-themes.html
@@ -19,7 +19,7 @@
 	<div data-role="content" class="ui-body">
 		
 
-		<p>All the standard button swatches can be applied to lists. The framework assigns a default list theme swatch of "c" (silver in the default theme) and swatch "b" (blue in default theme) for dividers. Below is a default themed list.</p>
+		<p>All the standard button swatches can be applied to lists. The framework assigns a default list theme swatch of &quot;c&quot; (silver in the default theme) and swatch &quot;b&quot; (blue in default theme) for dividers. Below is a default themed list.</p>
 		
 <code>
 &lt;ul data-role=&quot;listview&quot; data-inset=&quot;true&quot;&gt;
@@ -30,9 +30,9 @@
 			<li><a href="index.html">Outbox</a> <span class="ui-li-count">0</span></li>
 			<li><a href="index.html">Sent</a> <span class="ui-li-count">328</span></li>
 		</ul>
-
-				<h2>Theming list items</h2>
-		<p>The list item color scheme can be changed to any button color theme swatch by adding the <code>data-theme</code> attribute to the list, and setting the letter theme swatch. Here is the same list above with the "a" swatch applied. </p>
+		
+		<h2>Theming list items</h2>
+		<p>The list item color scheme can be changed to any button color theme swatch by adding the <code>data-theme</code> attribute to the list, and setting the letter theme swatch. Here is the same list above with the &quot;a&quot; swatch applied. </p>
 		
 <code>
 &lt;ul data-role=&quot;listview&quot; data-inset=&quot;true&quot; data-theme=&quot;d&quot;&gt;
@@ -47,7 +47,7 @@
 		
 		<h2>Theming dividers</h2>
 		
-		<p>The theme for <strong>list dividers</strong> can be set by adding the <code>data-dividertheme</code> to the list and specifying a swatch letter. Here is an example of the same list above with swatch "d" set on the dividers.</p>
+		<p>The theme for <strong>list dividers</strong> can be set by adding the <code>data-dividertheme</code> to the list and specifying a swatch letter. Here is an example of the same list above with swatch &quot;d&quot; set on the dividers.</p>
 		
 <code>
 &lt;ul data-role=&quot;listview&quot; data-inset=&quot;true&quot; data-theme=&quot;d&quot; data-dividertheme=&quot;c&quot;&gt;
@@ -62,7 +62,7 @@
 		
 		<h2>Theming count bubbles</h2>
 		
-		<p>The theme for <strong>count bubbles</strong> can be set by adding the <code>data-counttheme</code> to the list and specifying a swatch letter. Here is an example with swatch "e" set on the dividers.</p>
+		<p>The theme for <strong>count bubbles</strong> can be set by adding the <code>data-counttheme</code> to the list and specifying a swatch letter. Here is an example with swatch &quot;e&quot; set on the dividers.</p>
 		
 <code>
 &lt;ul data-role=&quot;listview&quot; data-inset=&quot;true&quot; data-theme=&quot;a&quot; data-dividertheme=&quot;d&quot; data-counttheme=&quot;e&quot;&gt;
@@ -75,9 +75,26 @@
 			<li><a href="index.html">Sent</a> <span class="ui-li-count">328</span></li>
 		</ul>
 		
+		<h2>Theming icons</h2>
+		
+		<p>The default icon for each list item is <code>arrow-r</code>. To override this, set the <code>data-icon</code> attribute on the desired list item to the <a href="../buttons/buttons-icons.html">name of a standard icon</a>.  To prevent icons from appearing altogether, set the <code>data-icon</code> attribute to &quot;false&quot;.</p>
+<pre>
+<code>
+&lt;li data-icon=&quot;info&quot;&gt;&lt;a href="#"&gt;Notices&lt;/a&gt;&lt;/li&gt;
+&lt;li data-icon=&quot;alert&quot;&gt;&lt;a href="#"&gt;Alerts&lt;/a&gt;&lt;/li&gt;
+&lt;li data-icon=&quot;false&quot;&gt;&lt;a href="#"&gt;All Notifications&lt;/a&gt;&lt;/li&gt;
+</code>
+</pre>
+		<ul data-role="listview" data-inset="true" data-icon="false">
+			<li data-role="list-divider">Divider</li>
+			<li data-icon="info"><a href="index.html">Notices</a></li>
+			<li data-icon="alert"><a href="index.html">Alerts</a></li>
+			<li data-icon="false"><a href="index.html">All Notifications</a></li>
+		</ul>
+		
 		<h2>Theming split buttons</h2>
 		
-		<p>For split lists which a second button, the framework default to "b" for the theme swatch (blue in the default theme)  Here is a default split list:</p>
+		<p>For split lists which a second button, the framework default to &quot;b&quot; for the theme swatch (blue in the default theme)  Here is a default split list:</p>
 		
 		<ul data-role="listview" data-inset="true">
 			<li>

--- a/themes/default/jquery.mobile.forms.select.css
+++ b/themes/default/jquery.mobile.forms.select.css
@@ -22,7 +22,7 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 .ui-selectmenu-screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%;  z-index: 99; }
 .ui-screen-hidden, .ui-selectmenu-list .ui-li .ui-icon { display: none; }
 .ui-selectmenu-list .ui-li .ui-icon { display: block; }
-.ui-selectmenu-placeholder { display: none; }
+.ui-li.ui-selectmenu-placeholder { display: none; }
 
 .min-width-480px label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
 .min-width-480px .ui-select { width: 60%; display: inline-block; }


### PR DESCRIPTION
Documentation for multiple select functionality and list icon theming.

Also fixed a CSS specificity bug where the display:block declaration on `.ui-li` was overriding the display:none declaration for the placeholder class `.ui-selectmenu-placeholder`.
