### PR TITLE
Fix issue 581 page title

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -164,9 +164,9 @@
 		$.mobile.startPage = $.mobile.activePage = $pages.first();
 		
 		// set the data-page-title attribute based upon the title of the first page to load
-		var $title = $("title");
-		if( $title && $title.text() ){
-			$.mobile.startPage.data('page-title', $title.text().trim()) 
+		var title = window.document.title;
+		if( title ){
+			$.mobile.startPage.data('page-title', title.trim()) 
 		};
 		
 		//set page container

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -162,7 +162,13 @@
 
 		//set up active page
 		$.mobile.startPage = $.mobile.activePage = $pages.first();
-
+		
+		// set the data-page-title attribute based upon the title of the first page to load
+		var $title = $("title");
+		if( $title && $title.text() ){
+			$.mobile.startPage.data('page-title', $title.text().trim()) 
+		};
+		
 		//set page container
 		$.mobile.pageContainer = $.mobile.startPage.parent().addClass('ui-mobile-viewport');
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -215,7 +215,7 @@
 
 			function updatePageTitle(){
 				if( to.data('page-title') ) {
-					document.title = to.data('page-title');
+					window.document.title = to.data('page-title');
 				}
 			};
 			
@@ -344,7 +344,7 @@
 					
 					// get the title of the page we are transitioning to we can update the location.title later
 					var $title = all.find('title:eq(0)');
-					var toPageTitle = ($title && $title.text()) ? $title.text().trim() : '';
+					var toPageTitle = ($title && $title.text()) ? $title.text().trim() : false;
 					if (toPageTitle) { to.attr("data-page-title", toPageTitle) };
 					
 					//rewrite src and href attrs to use a base url

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -213,11 +213,17 @@
 			from.data("page")._trigger("beforehide", {nextPage: to});
 			to.data("page")._trigger("beforeshow", {prevPage: from});
 
+			function updatePageTitle(){
+				if( to.data('page-title') ) {
+					document.title = to.data('page-title');
+				}
+			};
+			
 			function loadComplete(){
 				$.mobile.pageLoading( true );
 
 				reFocus( to );
-
+				updatePageTitle();
 				if( changeHash !== false && url ){
 					path.set(url, (back !== true));
 				}
@@ -335,7 +341,12 @@
 					//workaround to allow scripts to execute when included in page divs
 					all.get(0).innerHTML = html;
 					to = all.find('[data-role="page"], [data-role="dialog"]').first();
-
+					
+					// get the title of the page we are transitioning to we can update the location.title later
+					var $title = all.find('title:eq(0)');
+					var toPageTitle = ($title && $title.text()) ? $title.text().trim() : '';
+					if (toPageTitle) { to.attr("data-page-title", toPageTitle) };
+					
 					//rewrite src and href attrs to use a base url
 					if( !$.support.dynamicBaseTag ){
 						var newPath = path.get( fileUrl );


### PR DESCRIPTION
 Fix for issue: https://github.com/jquery/jquery-mobile/issues/issue/581

```
+ Add a data-page-title attribute to the page div that will be used to set the documents title.  This will be set explicitly for first page and ajax loaded pages.  This can be set by author for pre-existi

+ In the transitionPages() function look to see if the page we are transitioning to has a data-page-title set.  If it does, set the document.title
```
