### PR TITLE
Add refresh link

### DIFF
--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -239,7 +239,14 @@
 			
 			href.replace(/^#/,'');
 			
-			changePage(href, transition, back, changeHashOnSuccess);			
+			// if the ref value is refresh, will ask to treat the href as a fresh page
+			var refresh = $this.is("[rel=refresh]");
+			if (refresh) {
+				var to = {url: href, type: 'get' };
+				changePage(to, transition, back, changeHashOnSuccess);
+			} else {
+				changePage(href, transition, back, changeHashOnSuccess);			
+			}	
 		}
 		event.preventDefault();
 	});


### PR DESCRIPTION
sometimes I need always do ajax request when I click a link.
Of course I could use the "rel=external" to tell the jquerymobile do a common request, but it will lost all of the url stack and the auto generated back button will lost too.

So I add a new value for rel attribute; when the rel value is equals 'refresh', it will always do an ajax request when user click it
