### PR TITLE
Fix issue 533 dialog on ipad

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -411,11 +411,13 @@
 
 	//click routing - direct to HTTP or Ajax, accordingly
 	$( "a" ).live( "click", function(event) {
-
-		if( !$.mobile.ajaxLinksEnabled ){ return; }
 		var $this = $(this),
-			//get href, remove same-domain protocol and host
-			href = $this.attr( "href" ).replace( location.protocol + "//" + location.host, ""),
+			isTargetDialog = $this.data("rel") === "dialog";
+		
+		if( !$.mobile.ajaxLinksEnabled && !isTargetDialog ){ return; }
+
+		//get href, remove same-domain protocol and host
+		var	href = $this.attr( "href" ).replace( location.protocol + "//" + location.host, ""),
 			//if target attr is specified, it's external, and we mimic _blank... for now
 			target = $this.is( "[target]" ),
 			//if it still starts with a protocol, it's external, or could be :mailto, etc
@@ -428,7 +430,7 @@
 
 		$activeClickedLink = $this.closest( ".ui-btn" ).addClass( $.mobile.activeBtnClass );
 
-		if( external || !$.mobile.ajaxLinksEnabled ){
+		if( external || (!$.mobile.ajaxLinksEnabled && !isTargetDialog) ){
 			//remove active link class if external
 			removeActiveLinkClass(true);
 

--- a/tests/unit/navigation/index.html
+++ b/tests/unit/navigation/index.html
@@ -93,5 +93,10 @@
 <div id="default-trans" data-role="page">
 	<a href="#no-trans"></a>
 </div>
+
+<div id="dialog-link" data-role="page">
+	<a id="dialog-link-anchor" href="dialog.html" data-rel="dialog"></a>
+</div>
+
 </body>
 </html>

--- a/tests/unit/navigation/navigation_core.js
+++ b/tests/unit/navigation/navigation_core.js
@@ -47,6 +47,22 @@ test( "changePage applys transition class to mobile viewport for default transit
 	ok($("body").hasClass(transitioning), "has transitioning class");
 });
 
+test( "Routing for dialogs with ajaxLinksEnabled false does not change href", function(){
+	var changePageFn = $.mobile.changePage;
+	var ajaxLinksEnabledVal = $.mobile.ajaxLinksEnabled;
+
+	try {
+		expect(1);
+		$.mobile.ajaxLinksEnabled = false;
+		$.mobile.changePage = function(){ ok(true, true, "changePage should be called when navigating to a dialog.") };
+		$("#dialog-link-anchor").click();
+	}
+	finally {
+		$.mobile.changePage = changePageFn;
+		$.mobile.ajaxLinksEnabled = ajaxLinksEnabledVal;
+	}
+});
+
 test( "explicit transition preferred for page navigation reversal (ie back)", function(){
 	$.fn.animationComplete = function(){};
 
@@ -108,3 +124,4 @@ test( "default transition is slide", function(){
 		start();
 	}, 900);
 });
+


### PR DESCRIPTION
I raised a question for issue #533 here: https://github.com/jquery/jquery-mobile/issues/533

If the intention is that dialogs will always be opened via ajax for local pages, then this commit will fix the issue.

Instead of returning from the click handler for anchor tags if ajaxLinksEnabled is false, we add a conditional check to see if the target page is a dialog.  If it is, then continue onto call changePage().

Test confirming functionality included.
