### PR TITLE
Default dialog transition to pop

### DIFF
--- a/docs/api/globalconfig.html
+++ b/docs/api/globalconfig.html
@@ -87,7 +87,7 @@ $(document).bind("mobileinit", function(){
 	<dd>jQuery Mobile will automatically handle form submissions through Ajax, when possible.</dd>
 
 	<dt>defaultTransition (<em>string</em>, default: 'slide'):</dt> 
-	<dd>Set the default transition for page changes that use Ajax. Set to 'none' for no transitions by default.</dd>
+	<dd>Set the default transition for page changes that use Ajax. The default transition for dialog presentation is 'pop'. Set to 'none' for no transitions by default.</dd>
 	
 	<dt>loadingMessage (<em>string</em>, default: "loading"):</dt> 
 	<dd>Set the text that appears when a page is loading. If set to false, the message will not appear at all.</dd>

--- a/docs/pages/docs-dialogs.html
+++ b/docs/pages/docs-dialogs.html
@@ -30,7 +30,7 @@
 
 			
 			<h2>Transitions</h2>
-			<p>Since the dialog is a standard "page", it will open with the standard slide transition that's applied to all pages.  And like all pages, you can specify any page transition you want on the dialog by adding the <code>data-transition</code> attribute to the link. To make it feel more dialog-like, we recommend specifying a transition of "pop", "slideup" or "flip".</p>
+			<p>By default, the dialog will open with a 'pop' transition.  Like all pages, you can specify any page transition you want on the dialog by adding the <code>data-transition</code> attribute to the link. To make it feel more dialog-like, we recommend specifying a transition of "pop", "slideup" or "flip".</p>
 			
 <code>
 &lt;a href=&quot;foo.html&quot; data-rel=&quot;dialog&quot; data-transition=&quot;pop&quot;&gt;Open dialog&lt;/a&gt;

--- a/experiments/ui-datepicker/index.html
+++ b/experiments/ui-datepicker/index.html
@@ -3,33 +3,54 @@
 	<head>
 	<meta charset="utf-8" /> 
 	<title>jQuery Mobile Framework - Datepicker</title> 
-	<link rel="stylesheet"  href="../../themes/default" /> 
-	<script type="text/javascript" src="../../js/"></script>
-	
+	<link rel="stylesheet"  href="../../themes/default" />	
+	<link rel="stylesheet" href="../../docs/_assets/css/jqm-docs.css" />
+	<script type="text/javascript" src="../../js/"></script>	
 </head> 
 <body> 
 
 <div data-role="page">
 	<link rel="stylesheet"  href="jquery.ui.datepicker.css" /> 
+	<!-- style overrides -->
+	<style type="text/css">
+	.ui-datepicker-calendar th { padding-top: .3em; padding-bottom: .3em; }
+	.ui-datepicker-calendar th span, .ui-datepicker-calendar span.ui-state-default { opacity: .3; }
+	.ui-datepicker-calendar td a { padding-top: .5em; padding-bottom: .5em; }
+	</style>
+	
 	<script type="text/javascript" src="jQuery.ui.datepicker.js"></script>
 	<script type="text/javascript">
 		$(function(){
-			/*  datepicker workaround */
-			$('input[type=date]').hide().after( $('<div />').datepicker() );
-			$('.ui-datepicker-header').addClass('ui-body-c ui-corner-top').removeClass('ui-corner-all');
-			$('.ui-datepicker-prev').buttonMarkup({iconpos: 'notext', icon: 'arrow-l', shadow: true, corners: true});
-			$('.ui-datepicker-next').buttonMarkup({iconpos: 'notext', icon: 'arrow-r', shadow: true, corners: true});
-			$('.ui-datepicker-calendar thead').remove();
-			$('.ui-datepicker-calendar .ui-btn-text span').attr('class','');
-			$('.ui-datepicker-calendar td').addClass('ui-btn-up-c');
-			$('.ui-datepicker-calendar a').buttonMarkup({corners: false, shadow: false});
-			/* // datepicker workaround */
+		
+		  /*  datepicker workaround - update markup and classes for Mobile */
+			var updateDatepicker = function(){
+  			$('.ui-datepicker-header').addClass('ui-body-c ui-corner-top').removeClass('ui-corner-all');
+  			$('.ui-datepicker-prev, .ui-datepicker-next').attr('href', '#');
+  			$('.ui-datepicker-prev').buttonMarkup({iconpos: 'notext', icon: 'arrow-l', shadow: true, corners: true});
+  			$('.ui-datepicker-next').buttonMarkup({iconpos: 'notext', icon: 'arrow-r', shadow: true, corners: true});
+  			$('.ui-datepicker-calendar th').addClass('ui-bar-c');
+  			$('.ui-datepicker-calendar td').addClass('ui-body-c');
+  			$('.ui-datepicker-calendar a').buttonMarkup({corners: false, shadow: false}); 
+  			$('.ui-datepicker-calendar a.ui-state-active').addClass('ui-btn-active'); // selected date
+  			$('.ui-datepicker-calendar a.ui-state-highlight').addClass('ui-btn-up-e'); // today's date
+        $('.ui-datepicker-calendar .ui-btn').each(function(){
+          var el = $(this), text = el.find('.ui-btn-text');
+          el.html(text.text()); // remove extra button markup - necessary for date value to be interpreted correctly
+        });
+			};
+			
+      /* create the datepicker as usual */
+		  $('input[type=date]').after( $('<div />').datepicker({ altField: '#date', showOtherMonths: true }) );
+		    
+		  /* update the datepicker when it loads, or whenever it's clicked (required because it's redrawn) */
+		  updateDatepicker(); // if you show the datepicker on input focus, call updateDatepicker on the focus event instead
+		  $('.ui-datepicker').click(updateDatepicker);
+
 		});
 	</script>
 	
 	<div data-role="header">
-		<h1>Datepicker Styled for mobile</h1>
-		
+		<h1>Datepicker Styled for mobile</h1>		
 	</div>
 	
 	<div data-role="content">
@@ -38,7 +59,7 @@
 		<form action="#" method="get">
 			
 			<div data-role="fieldcontain">
-	     	    <label for="date">Date Input (non-functional):</label>
+	     	    <label for="date">Date Input:</label>
 	     	    <input type="date" name="date" id="date" value=""  />
 			</div>
 		

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -175,7 +175,7 @@
 
 		function defaultTransition(){
 			if(transition === undefined){
-				transition = $.mobile.defaultTransition;
+				transition = ( nextPageRole && nextPageRole === 'dialog' ) ? 'pop' : $.mobile.defaultTransition;
 			}
 		}
 

--- a/tests/unit/navigation/index.html
+++ b/tests/unit/navigation/index.html
@@ -50,7 +50,7 @@
 <!-- NOTE body must be used in place of main otherwise transition behaviour fails -->
 
 <style>
-	[data-role='page'] {
+	[data-role='page'], [data-role='dialog'] {
 	  position: absolute;
 	  top: -10000px;
 	  left: -10000px;
@@ -93,5 +93,14 @@
 <div id="default-trans" data-role="page">
 	<a href="#no-trans"></a>
 </div>
+
+<div id="default-trans-dialog" data-role="page">
+	<a href="#no-trans-dialog" data-rel="dialog"></a>
+</div>
+
+<div id="no-trans-dialog" data-role="page">
+</div>
+
+
 </body>
 </html>

--- a/tests/unit/navigation/navigation_core.js
+++ b/tests/unit/navigation/navigation_core.js
@@ -108,3 +108,17 @@ test( "default transition is slide", function(){
 		start();
 	}, 900);
 });
+
+test( "default transition is pop for a dialog", function(){
+	stop();
+	setTimeout(function(){
+		//guarantee that we check only the newest changes
+		removePageTransClasses();
+
+		$("#default-trans-dialog > a").click();
+
+		ok($("#no-trans-dialog").hasClass("pop"), "expected the pop class to be present but instead was " + $("#no-trans-dialog").attr('class'));
+
+		start();
+	}, 900);
+});


### PR DESCRIPTION
Minor change to make default transition more appropriate for dialogs.  When presenting a dialog, default to pop.  Everything else uses slide (i.e., status quo).
