### PR TITLE
Fix fixed header and footer when scrolling

### DIFF
--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -57,7 +57,7 @@ $.fixedToolbars = (function(){
 			.bind('scrollstop',function(event){
 				if( $(event.target).closest(ignoreTargets).length ){ return; }
 				scrollTriggered = false;
-				if (stateBefore == 'overlay') {
+				if (stateBefore == 'overlay' || stateBefore == 'inline') {
 					$.fixedToolbars.show();
 				}
 				stateBefore = null;


### PR DESCRIPTION
Hello!

I got this working on iPhone and Android. I think it is not such a great fix, but it works for me. It throws an error on a desktop computer browser.

I repair it adding a condition on the fixedHeaderFooter.js, since the scrolling always returned to me an inline class, not overlay.
