### PR TITLE
A few minor fixes for tap events, selectmenu and changePage.

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -70,6 +70,10 @@ $.event.special.tap = {
 				
 				var moved = false,
 					touching = true,
+					/* :XXX: Needed to avoid triggering a 'tap' when the
+					 *       start target differs from the stop target.
+					 */
+					origTarget = event.target,
 					origPos = [ event.pageX, event.pageY ],
 					originalType,
 					timer;
@@ -97,7 +101,10 @@ $.event.special.tap = {
 						clearTimeout( timer );
 						touching = false;
 						
-						if ( !moved ) {
+						/* :XXX: ONLY trigger a 'tap' event if the start target
+						 * 		 is the same as the stop target.
+						 */
+						if ( !moved && (origTarget == event.target)) {
 							originalType = event.type;
 							event.type = "tap";
 							$.event.handle.call( thisObject, event );

--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -172,8 +172,12 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 			if( !$(event.target).is("a") ){ return; }
 
 			// index of option tag to be selected 
+			/* :XXX: If we use 'options' from the current closure, then when
+			 *       the list is re-built, we won't have access to the new set
+			 *       of options.
+			 */
 			var newIndex = list.find( "li:not(.ui-li-divider)" ).index( this ),
-				option = options.eq( newIndex )[0];
+				option = select.find('option').eq( newIndex )[0];
 			
 			// toggle selected status on the tag for multi selects
 			option.selected = isMultiple ? !option.selected : true;

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -196,7 +196,12 @@
 
 			// ensure a transition has been set where pop is undefined
 			defaultTransition();
-		} else {
+		/* :XXX: Only push the url/transition onto the urlStack if a
+         *       destination URL was identified AND 'changeHash' is not
+         *       explicitly false.  Otherwise, the urlStack could become
+         *       cluttered with empty urls, causing history navigation issues.
+		 */
+		} else if( changeHash !== false && url ) {
 			// If no transition has been passed
 			defaultTransition();
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -170,8 +170,14 @@
 		//reset base to pathname for new request
 		if(base){ base.reset(); }
 
-		//kill the keyboard
-		$( window.document.activeElement ).add(':focus').blur();
+		/* kill the keyboard
+		 *
+		 * :XXX: This CAN fail, and when it does, the failure shouldn't
+		 *       terminate changePage().
+		 */
+		try {
+			$( window.document.activeElement ).add(':focus').blur();
+		} catch(e) {};
 
 		function defaultTransition(){
 			if(transition === undefined){


### PR DESCRIPTION
- $.mobile.changePage() should only update the urlStack if a destination URL was identified AND changeHash is not explicitly 'false'. 
- In changePage(), window.document.activeElement MAY be unavailable.  If so, the code to "kill the keyboard" should NOT cause changePage() to fail completely.  The quick solution is to surround it with a try/catch. 
- When a selectmenu is re-built via refresh, the new options are no longer available to the list items click delegate closure via the cached 'options' variable.  Need to do a full find to ensure access to the current set of options. 
- Avoid triggering a 'tap' event if the event target on touchStop differs from the original touchStart target. 
