### PR TITLE
Fixed #470 - Multiple Footers when using data-position=fixed and data-id=[someid]  

### DIFF
--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -66,7 +66,7 @@ $.fixedToolbars = (function(){
 		//function to return another footer already in the dom with the same data-id
 		function findStickyFooter(el){
 			var thisFooter = el.find('[data-role="footer"]');
-			return $( '.ui-footer[data-id="'+ thisFooter.data('id') +'"]:not(.ui-footer-duplicate)' ).not(thisFooter);
+			return $( '.ui-footer[data-id="'+ thisFooter.data('id') +'"]:not(.ui-footer-duplicate)' ).not(thisFooter)[0];
 		}
 		
 		//before page is shown, check for duplicate footer


### PR DESCRIPTION
The incorrect footer was getting the .ui-footer-duplicate by adding the [0] as was suggested in the comments to the issue, it resolves the problem and the correct footer is then displayed.
