### PR TITLE
Don't enhance hidden fields with textinput()

### DIFF
--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -171,7 +171,7 @@ $.widget( "mobile.page", $.mobile.widget, {
 
 		this.element
 			.find( "input, textarea" )
-			.not( "[type='radio'], [type='checkbox'], button, [type='button'], [type='submit'], [type='reset'], [type='image']" )
+			.not( "[type='radio'], [type='checkbox'], button, [type='button'], [type='submit'], [type='reset'], [type='image'], [type='hidden']" )
 			.not(this.keepNative)
 			.textinput();
 


### PR DESCRIPTION
When the `textinput()` enhancement is called, there is a selector for types _not_ to perform the enhancement on, including such non-text inputs as checkboxes and buttons.  Hidden inputs, not being in that list, were getting enhanced with `textinput()`.  That of course doesn't have any particular negative repercussions other than wasting time enhancing a form element with functionality that will never be seen or used.
