### PR TITLE
Fixed navigation between DOM/jQuery objects with changePage - checking for url change too fast

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -150,11 +150,6 @@
 			duplicateCachedPage = null,
 			back = (back !== undefined) ? back : ( urlStack.length > 1 && urlStack[ urlStack.length - 2 ].url === url );
 
-		//If we are trying to transition to the same page that we are currently on ignore the request.
-		if(urlStack.length > 1 && url === urlStack[urlStack.length -1].url && !toIsArray ) {
-			return;
-		}
-
 		if( $.type(to) === "object" && to.url ){
 			url = to.url,
 			data = to.data,
@@ -166,6 +161,13 @@
 				data = undefined;
 			}
 		}
+
+
+		//If we are trying to transition to the same page that we are currently on ignore the request.
+		if(urlStack.length > 1 && url === urlStack[urlStack.length -1].url && !toIsArray ) {
+			return;
+		}
+
 
 		//reset base to pathname for new request
 		if(base){ base.reset(); }


### PR DESCRIPTION
Checking the url of the 'to' argument in changePage happened before the function got a chance to populate it if the 'to' argument was an object.
