### PR TITLE
Fix for issue 764

### DIFF
--- a/docs/_assets/css/jqm-docs.css
+++ b/docs/_assets/css/jqm-docs.css
@@ -10,3 +10,4 @@ p code { font-size:1.2em; font-weight:bold; }
 
 dt { font-weight: bold; margin: 2em 0 .5em; }
 dt code, dd code { font-size:1.3em; line-height:150%; }
+pre { white-space: pre; white-space: pre-wrap; word-wrap: break-word; }

--- a/themes/default/jquery.mobile.collapsible.css
+++ b/themes/default/jquery.mobile.collapsible.css
@@ -10,7 +10,7 @@
 .ui-collapsible-heading a span.ui-btn { position: absolute; left: 6px; top: 50%; margin: -12px 0 0 0; width: 20px; height: 20px; padding: 1px 0px 1px 2px; text-indent: -9999px; }
 .ui-collapsible-heading a span.ui-btn .ui-btn-inner { padding: 0; }
 .ui-collapsible-heading a span.ui-btn .ui-icon { left: 0; margin-top: -10px; }
-.ui-collapsible-heading-status { position:absolute; left:-99999px; }
+.ui-collapsible-heading-status { position:absolute; left:-9999px; }
 .ui-collapsible-content {  display: block; padding: 10px 0 10px 8px; }
 .ui-collapsible-content-collapsed { display: none; }
 

--- a/themes/default/jquery.mobile.forms.select.css
+++ b/themes/default/jquery.mobile.forms.select.css
@@ -4,7 +4,7 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
 */
 .ui-select { display: block; }
-.ui-select select { position: absolute; left: -99999px; top: -99999px; }
+.ui-select select { position: absolute; left: -9999px; top: -9999px; }
 .ui-select .ui-btn-icon-right .ui-btn-inner { padding-right: 45px; } 
 .ui-select .ui-btn-icon-right .ui-icon { right: 15px;  }
 
@@ -18,7 +18,7 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 .ui-selectmenu { position: absolute; padding: 0; z-index: 100 !important; width: 80%; max-width: 350px; padding: 6px; }
 .ui-selectmenu .ui-listview { margin: 0; }
 .ui-selectmenu .ui-btn.ui-li-divider { cursor: default; }
-.ui-selectmenu-hidden { top: -999999px; left: -99999px; }
+.ui-selectmenu-hidden { top: -9999px; left: -9999px; }
 .ui-selectmenu-screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%;  z-index: 99; }
 .ui-screen-hidden, .ui-selectmenu-list .ui-li .ui-icon { display: none; }
 .ui-selectmenu-list .ui-li .ui-icon { display: block; }

--- a/themes/default/jquery.mobile.navbar.css
+++ b/themes/default/jquery.mobile.navbar.css
@@ -7,7 +7,7 @@
 .ui-navbar ul, .ui-navbar-expanded ul { list-style:none; padding: 0; margin: 0; position: relative; display: block; border: 0;}
 .ui-navbar-collapsed ul { float: left; width: 75%; margin-right: -2px; }
 .ui-navbar-collapsed .ui-navbar-toggle { float: left; width: 25%; }
-.ui-navbar li.ui-navbar-truncate { position: absolute; left: -99999px; top: -99999px; }
+.ui-navbar li.ui-navbar-truncate { position: absolute; left: -9999px; top: -9999px; }
 .ui-navbar li .ui-btn, .ui-navbar .ui-navbar-toggle .ui-btn { display: block; font-size: 12px; text-align: center; margin: 0; outline: none; border-right-width: 0; }
 .ui-navbar li .ui-btn {  margin-right: -1px; }
 .ui-navbar li .ui-btn:last-child { margin-right: 0; }


### PR DESCRIPTION
So this issue exists in opera mini and opera desktop (at least in v11), but the fix for them is different.

For opera mini, the pre tag just needed some CSS to force word wrapping.  This is a bug in the doc's own css file, not in jquery mobile.  Perhaps this should be considered for inclusion in the main theme file, though?

For opera desktop, @miketaylr tipped me off to a bug in opera where if the border width and positioning value exceed 32767px, a wide horizontal scroll bar will appear.  Reducing left/top positioning values down to 9999 fixes it.  Weird stuff.
