### PR TITLE
selectmenu 'options' accidental shadowing

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -123,7 +123,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		//expose to other methods
 		$.extend(self, {
 			select: select,
-			options: options,
+			optionElems: options,
 			selectID: selectID,
 			label: label,
 			buttonId:buttonId,
@@ -174,7 +174,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 
 			// index of option tag to be selected 
 			var newIndex = list.find( "li:not(.ui-li-divider)" ).index( this ),
-				option = self.options.eq( newIndex )[0];
+				option = self.optionElems.eq( newIndex )[0];
 			
 			// toggle selected status on the tag for multi selects
 			option.selected = isMultiple ? !option.selected : true;
@@ -292,7 +292,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		var self = this,
 			select = this.element,
 			isMultiple = this.isMultiple,
-			options = this.options = select.find("option"),
+			options = this.optionElems = select.find("option"),
 			selected = options.filter(":selected"),
 			
 			// return an array of all selected index's


### PR DESCRIPTION
The exposure of selectmenu.options (a list of the option elements) introduced by 9e6a3df6b11de575b994 masks a variable named options that contains the configuration parameters for the selectmenu widget, which causes configuration options to be ignored (such as hidePlaceholderMenuItems).  This renames the list of option elements optionsElems to gets configuration options back to working.
