### PR TITLE
Orientation fix

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -172,8 +172,7 @@ $.event.special.swipe = {
  */
 (function($) {
 	var $win				= $(window);
-	var nativeOrientation	= (window.orientation !== undefined
-								? true : false);
+	var nativeOrientation	= (('orientation' in window) && ('orientationchange' in window));
 
 	/* orientation functions set by either setupNative() or setupNonNative()
 	 * depending on whether or not the current browser natively supports

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -178,7 +178,7 @@ $.event.special.swipe = {
 			// will bind to the event using DOM methods.
 			if ( $.support.orientation ) { return false; }
 			
-			// Because the orientationchange event doesn't exist, si
+			// Because the orientationchange event doesn't exist, simulate the
 			// event by testing window dimensions on resize.
 			win.bind( "resize", simulateOrientationChange);
 		},
@@ -217,7 +217,7 @@ $.event.special.swipe = {
 			win.trigger( "orientationchange" );
 		}
 	};
-
+	
 	// Get the current page orientation. This method is exposed publicly, should it
 	// be needed, as jQuery.event.special.orientationchange.orientation()
 	special_event.orientation = orientationByRatio = function() {

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -37,7 +37,7 @@ function baseTagTest(){
 };
 
 $.extend( $.support, {
-	orientation: ($.type(window.orientation) === 'number'),
+	orientation: (('orientation' in window) && ('orientationchange' in window)),
 	touch: "ontouchend" in document,
 	cssTransitions: "WebKitTransitionEvent" in window,
 	pushState: !!history.pushState,

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -37,7 +37,7 @@ function baseTagTest(){
 };
 
 $.extend( $.support, {
-	orientation: (('orientation' in window) && ('orientationchange' in window)),
+	orientation: ($.type(window.orientation) === 'number'),
 	touch: "ontouchend" in document,
 	cssTransitions: "WebKitTransitionEvent" in window,
 	pushState: !!history.pushState,

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -37,7 +37,7 @@ function baseTagTest(){
 };
 
 $.extend( $.support, {
-	orientation: "orientation" in window,
+	orientation: (('orientation' in window) && ('orientationchange' in window)),
 	touch: "ontouchend" in document,
 	cssTransitions: "WebKitTransitionEvent" in window,
 	pushState: !!history.pushState,

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -37,7 +37,7 @@ function baseTagTest(){
 };
 
 $.extend( $.support, {
-	orientation: (('orientation' in window) && ('orientationchange' in window)),
+	orientation: (('orientation' in window) && ('onorientationchange' in window)),
 	touch: "ontouchend" in document,
 	cssTransitions: "WebKitTransitionEvent" in window,
 	pushState: !!history.pushState,


### PR DESCRIPTION
The 'orientationchange' event does not report the proper value for several devices that we've tested -- the Nexus One, Droid in particular.

These devices seem to trigger an 'orientationchange' event **before** the window is resized to reflect the new orientation.

The existing orientation handling code will report the exact opposite orientation after the initial 'orientationchange'.

This patch fixes this by creating two separate orientation handlers -- one for browsers that natively support orientation and a second that basically uses the current code.

If the browser has native orientation support, then map between device-specific orientation values (in degrees) and a more easily used textual value (i.e. 'portrait', 'landscape').  The mapping is based upon an initial, baseline measure of the window ratio compared to the reported orientation which is performed once the DOM is reported ready and the window size measure can be trusted.

If there is not native orientation support in the browser, fall back to a window ratio measure initiated on window resize.
