### PR TITLE
Added "make" instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ Whenever this configuration becomes inconvenient, we can remove it, obviously it
 
 - when adding a js or css file, add it to the manifest in its directory and it'll be included in the request
 - As far as JS files go, jQuery.mobile.core.js is the starting point.
+
+How to build your own jQuery Mobile
+===================================
+
+Clone this repo and build the js and css files:
+
+    git clone git://github.com/jquery/jquery-mobile.git
+    cd jquery-mobile
+    make
+
+Two complete versions, one minified, one not, of jQuery Mobile js and css files will be created.
+


### PR DESCRIPTION
I wanted to build the latest jQuery Mobile to see if a bug I think I'm seeing is fixed in master.

Because I'm slow in the head, it wasn't immediately clear to me that all I had to do was clone and "make".

This doc patch adds instructions to do so to the README. I used the jQuery repo as my guide.
