### PR TITLE
Fix for issue 509 textarea autogrow

### DIFF
--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -10,7 +10,7 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 		theme: null
 	},
 	_create: function(){
-		var input = this.element,
+		var $input = this.element,
 			o = this.options,
 			theme = o.theme,
 			themeclass;
@@ -24,19 +24,19 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 		
 		themeclass = " ui-body-" + theme;
 		
-		$('label[for='+input.attr('id')+']').addClass('ui-input-text');
+		$('label[for='+$input.attr('id')+']').addClass('ui-input-text');
 		
-		input.addClass('ui-input-text ui-body-'+ o.theme);
+		$input.addClass('ui-input-text ui-body-'+ o.theme);
 		
-		var focusedEl = input;
+		var focusedEl = $input;
 		
 		//"search" input widget
-		if( input.is('[type="search"],[data-type="search"]') ){
-			focusedEl = input.wrap('<div class="ui-input-search ui-shadow-inset ui-btn-corner-all ui-btn-shadow ui-icon-search'+ themeclass +'"></div>').parent();
+		if( $input.is('[type="search"],[data-type="search"]') ){
+			focusedEl = $input.wrap('<div class="ui-input-search ui-shadow-inset ui-btn-corner-all ui-btn-shadow ui-icon-search'+ themeclass +'"></div>').parent();
 			var clearbtn = $('<a href="#" class="ui-input-clear" title="clear text">clear text</a>')
 				.click(function(){
-					input.val('').focus();
-					input.trigger('change'); 
+					$input.val('').focus();
+					$input.trigger('change'); 
 					clearbtn.addClass('ui-input-clear-hidden');
 					return false;
 				})
@@ -44,7 +44,7 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 				.buttonMarkup({icon: 'delete', iconpos: 'notext', corners:true, shadow:true});
 			
 			function toggleClear(){
-				if(input.val() == ''){
+				if($input.val() == ''){
 					clearbtn.addClass('ui-input-clear-hidden');
 				}
 				else{
@@ -53,13 +53,13 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 			}
 			
 			toggleClear();
-			input.keyup(toggleClear);	
+			$input.keyup(toggleClear);	
 		}
 		else{
-			input.addClass('ui-corner-all ui-shadow-inset' + themeclass);
+			$input.addClass('ui-corner-all ui-shadow-inset' + themeclass);
 		}
 				
-		input
+		$input
 			.focus(function(){
 				focusedEl.addClass('ui-focus');
 			})
@@ -68,22 +68,33 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 			});	
 			
 		//autogrow
-		if ( input.is('textarea') ) {
+		if ( $input.is('textarea') ) {
 			var extraLineHeight = 15,
 				keyupTimeoutBuffer = 100,
-				keyup = function() {
-					var scrollHeight = input[0].scrollHeight,
-						clientHeight = input[0].clientHeight;
+				resizeCheck = function() {
+					var scrollHeight = $input[0].scrollHeight,
+						clientHeight = $input[0].clientHeight;
 					if ( clientHeight < scrollHeight ) {
-						input.css({ height: (scrollHeight + extraLineHeight) });
+						$input.css({ height: (scrollHeight + extraLineHeight) });
 					}
 				},
 				keyupTimeout;
-			input.keyup(function() {
+			$input.keyup(function() {
 				clearTimeout( keyupTimeout );
-				keyupTimeout = setTimeout( keyup, keyupTimeoutBuffer );
+				keyupTimeout = setTimeout( resizeCheck, keyupTimeoutBuffer );
 			});
-		}
+			// Issue 509: the browser is not giving scrollHeight properly until after this function has run, adding in a setTimeout
+			// so we can properly access the scrollHeight
+      if ( $input.text().trim() ) {
+              setTimeout( function() {
+                // we want the textarea to show up as the correct size on load, so we remove the transition
+                $input.addClass( 'transition-none' );
+                resizeCheck();
+                // we need to delay the removing of the transition-none class otherwise the transition still takes place
+                setTimeout( function() { $input.removeClass( 'transition-none' ); }, 0 );
+              }, 0 );
+      }
+    };
 	},
 	
 	disable: function(){

--- a/tests/unit/forms/form_textinput.js
+++ b/tests/unit/forms/form_textinput.js
@@ -1,0 +1,17 @@
+/*
+ * mobile forms.textinput unit tests
+ */
+
+(function($) {
+  module('jquery.mobile.forms.textinput.js');
+  
+  asyncTest( "textareas should autogrow to fit their initial text", 1, function(){
+    setTimeout(function() {
+      var textAreaWithText = $('#textAreaWithLargeText')[0];
+      ok( (textAreaWithText.clientHeight >= textAreaWithText.scrollHeight), "TextArea should autogrow to fit initial text.");      
+      start();
+    }, 100);
+  });
+
+})(jQuery);
+

--- a/tests/unit/forms/index.html
+++ b/tests/unit/forms/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	
+	<title>jQuery Mobile Forms Test Suite</title>
+
+	<link rel="stylesheet"  href="../../../themes/default" />
+	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
+
+	<script type="text/javascript" src="../../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../../js/"></script>
+	<script type="text/javascript" src="../../jquery.testHelper.js"></script>
+	<script type="text/javascript" src="../../../external/qunit.js"></script>
+	<script type="text/javascript" src="form_textinput.js"></script>
+	
+</head>
+<body>
+<style>
+	[data-role='page'] {
+	  position: absolute;
+	  top: -10000px;
+	  left: -10000px;
+	}
+
+	/* maintain styling */
+	.ui-mobile-viewport {
+	  margin: 8px;
+	}
+</style>
+
+<h1 id="qunit-header">jQuery Mobile Forms Test Suite</h1>
+<h2 id="qunit-banner"></h2>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests">
+</ol>
+
+<div data-role="page" id='textarea-fixture'>
+	<div data-role="header" data-position="inline">
+		<h1>TextArea Fixture</h1>
+	</div>
+	<div data-role="content">
+	  <form action="#" method="get">		
+      <div data-role="fieldcontain">
+        <label for="textarea">Textarea:</label>
+        <textarea cols="40" rows="8" name="textarea" id="textAreaWithLargeText">
+          rafter of turkeys
+          pod of whales
+          mob of kangaroos
+          troop of monkeys
+       	</textarea>
+      </div>
+    </form>
+	</div>
+</div>
+  
+</body>
+</html>

--- a/themes/default/jquery.mobile.transitions.css
+++ b/themes/default/jquery.mobile.transitions.css
@@ -262,3 +262,9 @@ Built by David Kaneda and maintained by Jonathan Stark.
         opacity: 0;
     }
 }
+
+.transition-none {
+  -webkit-transition: none !important;
+  -o-transition: none !important;
+  -moz-transition: none !important; 
+}


### PR DESCRIPTION
This is a proposed fix for https://github.com/jquery/jquery-mobile/issues/#issue/509

Unfortunately, because of the way the browser runs its transition I had to use setTimeout with value of 0 in order to get the correct end user experience.  Open to suggestions on how to make this better.

Added Qunit to verify that the textArea is sized appropriately when it has default text that grows beyond the default height.

Cleaned up input to be $input while in the file as well.
