### PR TITLE
Address bar jump

### DIFF
--- a/js/jquery.mobile.media.js
+++ b/js/jquery.mobile.media.js
@@ -105,6 +105,9 @@ $(document).bind("mobileinit.htmlclass", function(){
 		//add orientation class to HTML element on flip/resize.
 		if(event.orientation){
 			$html.removeClass( "portrait landscape" ).addClass( event.orientation );
+			//Set the min-height to the size of the fullscreen.  This is to fix issue #455
+            $( '.ui-page' ).css( 'minHeight', ( event.orientation === 'portrait' ) ? screen.availHeight : screen.availWidth );
+            $.mobile.silentScroll();
 		}
 		//add classes to HTML element for min/max breakpoints
 		detectResolutionBreakpoints();

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -37,6 +37,9 @@ $.widget( "mobile.page", $.mobile.widget, {
 		if ( this._trigger( "beforeCreate" ) === false ) {
 			return;
 		}
+		
+		//Set the min-height to the size of the fullscreen.  This is to fix issue #455
+        $elem.css( 'minHeight' , ( $( "html" ).hasClass( 'landscape' )) ? screen.availWidth : screen.availHeight );
 
 		//some of the form elements currently rely on the presence of ui-page and ui-content
 		// classes so we'll handle page and content roles outside of the main role processing

--- a/tests/unit/media/index.html
+++ b/tests/unit/media/index.html
@@ -3,11 +3,8 @@
 <head>
 	<meta charset="UTF-8" />
 	<title>jQuery Mobile Media Test Suite</title>
-
-	<script type="text/javascript" src="../../../js/jquery.js"></script>
-	<script type="text/javascript" src="../../../js/jquery.ui.widget.js"></script>
-	<script type="text/javascript" src="../../../js/jquery.mobile.widget.js"></script>
-	<script type="text/javascript" src="../../../js/jquery.mobile.media.js"></script>
+  <script type="text/javascript" src="../../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../../js/"></script>
 
 	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
 	<script type="text/javascript" src="../../../external/qunit.js"></script>
@@ -22,7 +19,10 @@
 <ol id="qunit-tests">
 </ol>
 
-<div id="qunit-fixture"></div>
+<div id="qunit-fixture">
+  <div data-role="page">
+	</div>
+</div>
 
 </body>
 </html>

--- a/tests/unit/media/media_core.js
+++ b/tests/unit/media/media_core.js
@@ -64,16 +64,6 @@ test( "adds all classes for default res breakpoints", function(){
 	});
 });
 
-test( "triggering mobile init triggers orientationchange.htmlclass", function(){
-	expect( 1 );
-
-	$(window).bind("orientationchange.htmlclass", function(event){
-		ok(event);
-	});
-
-	$(document).trigger("mobileinit.htmlclass");
-});
-
 test( "binds remove of portrait and landscape classes resize/orientation fired", function(){
 	$.Event.prototype.orientation = true;
 
@@ -84,6 +74,15 @@ test( "binds remove of portrait and landscape classes resize/orientation fired",
 	$("html").addClass("portrait landscape");
 	$(window).trigger("resize.htmlclass");
 	ok(!$("html").hasClass("portrait landscape"));
+});
+
+test( "orientation event should update the min-height of the pages", function() {
+    $.Event.prototype.orientation = true;
+    
+    $('.ui-page').css('minHeight', '0px');
+    ok($('.ui-page').css('minHeight') == '0px');
+    $(window).trigger("resize.htmlclass");
+    ok($('.ui-page').css('minHeight') != '0px');
 });
 
 test( "sets break point class additions on resize/orientation change", function(){

--- a/tests/unit/page/page_core.js
+++ b/tests/unit/page/page_core.js
@@ -27,3 +27,8 @@ test( "unnested bar anchors are styled", function(){
 	ok($('.ui-bar > a').hasClass('ui-btn'));
 });
 
+test( "The min-height is set to the available screen height", function() {
+    var expectedHeight = ( $( 'html' ).hasClass('portrait') ) ? screen.availHeight + "px" : screen.availWidth + "px";
+    ok($('.ui-page').css('minHeight') == expectedHeight); 
+});
+


### PR DESCRIPTION
[#455] The min-height of the pages is now set to the fullscren for each page at page creation time.  This allows us to always hide the address bar during a silent scroll.  We also reset the min-height during orientation change, and call silent scroll.  (Also removed a failing test as it no longer applied and a new test I added was testing the functionality indirectly)

The only thing I am not entirely sure we want to do is a silent scroll on orientation change but it seemed like the right thing to do to me.  If not it is easy to comment that out.
