### PR TITLE
fix for Issue 850 navbar still broken. active element is not styled properly after transition.

### DIFF
--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -34,7 +34,7 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 		
 		$navbar.delegate("a", "click",function(event){
 			$navbtns.removeClass( "ui-btn-active" );
-			$( this ).addClass( "ui-btn-active" );
+			$('li.' + this.parentNode.className + ' a').addClass( "ui-btn-active" );
 		});	
 	}
 });


### PR DESCRIPTION
This is a proposed change for adding the class ui-btn-active for each page instead of just the last element clicked. Right now it only works if you click the page you're on.

https://github.com/jquery/jquery-mobile/issues/issue/850/#comment_712107
