### PR TITLE
Fix for issue #849 - improper scaling of custom icons 

### DIFF
--- a/themes/default/jquery.mobile.theme.css
+++ b/themes/default/jquery.mobile.theme.css
@@ -751,10 +751,18 @@ a.ui-link-inherit {
 /* HD/"retina" sprite
 -----------------------------------------------------------------------------------------------------------*/
 
-@media screen and (-webkit-min-device-pixel-ratio: 2), screen and (max--moz-device-pixel-ratio: 2) {
-	.ui-icon {
-	background-image: url(images/icons-36-white.png);
-	background-size: 558px 18px;
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5),
+       only screen and (min--moz-device-pixel-ratio: 1.5),
+       only screen and (min-resolution: 240dpi) {
+	.ui-icon-plus, .ui-icon-minus, .ui-icon-delete, .ui-icon-arrow-r,
+	.ui-icon-arrow-l, .ui-icon-arrow-u, .ui-icon-arrow-d, .ui-icon-check,
+	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
+	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info {
+		background-image: url(images/icons-36-white.png);
+		-moz-background-size: 558px 18px;
+		-o-background-size: 558px 18px;
+		-webkit-background-size: 558px 18px;
+		background-size: 558px 18px;
 }
 	.ui-icon-black {
 	background-image: url(images/icons-36-black.png);


### PR DESCRIPTION
The quickest fix I could think of was targeting those styles only at the default jQuery Mobile icons, leaving the generic ui-icon class alone to avoid hitting custom icons. It might be cleaner (in the CSS at least) to apply a special class to UI elements using the default icons, and just select for that one class instead of this long list of classes.

I also adjusted the media query and added some vendor-prefixed properties. The altered media query hits high-res Android devices (which start at a pixel density of 1.5 and dpi of 240). The "only" keyword ensures the media query and its contents are ignored by older browsers.

The vendor prefixes provide better browser support. For example, early versions of the default Android browser only understand -webkit-background-size while older Fennec / Firefox Mobile versions need the -moz version of the property.
