### PR TITLE
Fix for issue #890: missing -moz-linear-gradient parameters in theme CSS 

### DIFF
--- a/themes/default/jquery.mobile.theme.css
+++ b/themes/default/jquery.mobile.theme.css
@@ -259,7 +259,7 @@
 	color: 					#3E3E3E;
 	font-weight: bold;
 	text-shadow: 0 1px 1px 	#fff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#f0f0f0,
 							#e9eaeb);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -279,7 +279,7 @@
 	color: 					#333333;
 	text-shadow: 0 1px 0 	#fff;
 	background: 			#f0f0f0;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#eeeeee, 
 							#dddddd);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -310,7 +310,7 @@
 	cursor: pointer;
 	text-shadow: 0 1px 1px #f6f6f6;
 	text-decoration: none;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#fefefe, 
 							#eeeeee);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -329,7 +329,7 @@
 	color: 					#101010;
 	text-decoration: none;
 	text-shadow: 0 1px 1px 	#fff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#ededed, 
 							#dadada);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -346,7 +346,7 @@
 	font-weight: bold;
 	color: 					#111111;
 	text-shadow: 0 1px 1px 	#ffffff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#eeeeee, 
 							#fdfdfd);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -372,7 +372,7 @@
 	background: 			#bbb;
 	color: 					#333;
 	text-shadow: 0 1px 0 #eee;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#ddd, 
 							#bbb);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -433,7 +433,7 @@
 	cursor: pointer;
 	text-shadow: 0 1px 1px 	#fff;
 	text-decoration: none;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#fdfdfd, 
 							#eeeeee);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -450,7 +450,7 @@
 	font-weight: bold;
 	color: 					#111;
 	text-shadow: 0 1px 1px 	#ffffff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#eeeeee, 
 							#ffffff);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -464,7 +464,7 @@
 	font-weight: bold;
 	color: 					#111;
 	text-shadow: none;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#cccccc, 
 							#eeeeee);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -487,7 +487,7 @@
 	background: 			#fadb4e;
 	color: 					#333;
 	text-shadow: 0 1px 0 	#fff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#fceda7, 
 							#fadb4e);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -514,7 +514,7 @@
 	color: 					#333333;
 	text-shadow: 0 1px 0 	#fff;
 	background: 			#faeb9e;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#fff, 
 							#faeb9e);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -545,7 +545,7 @@
 	text-shadow: 0 1px 1px 	#fe3;
 	text-decoration: none;
 	text-shadow: 0 1px 0 	#fff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#fceda7, 
 							#fadb4e);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -563,7 +563,7 @@
 	color: 					#111;
 	text-decoration: none;
 	text-shadow: 0 1px 1px 	#fff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#fcf0b5, 
 							#fbe26f);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -581,7 +581,7 @@
 	font-weight: bold;
 	color: 					#111;
 	text-shadow: 0 1px 1px 	#ffffff;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#fadb4e, 
 							#fceda7);
 	background-image: -webkit-gradient(linear,left top,left bottom,
@@ -618,7 +618,7 @@ a.ui-link-inherit {
 	cursor: pointer;
 	text-shadow: 0 -1px 1px #145072;
 	text-decoration: none;
-	background-image: -moz-linear-gradient(, 
+	background-image: -moz-linear-gradient(top, 
 							#85bae4, 
 							#5393c5);
 	background-image: -webkit-gradient(linear,left top,left bottom,


### PR DESCRIPTION
Fixes flat-looking buttons in Firefox.
