### PR TITLE
Fix for issue #900: buttons with rel attribute set to external don't show active state 

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -604,7 +604,7 @@
 			// TODO: deprecated - remove at 1.0
 			!$.mobile.ajaxLinksEnabled ){
 			//remove active link class if external (then it won't be there if you come back)
-			removeActiveLinkClass(true);
+			window.setTimeout(function() {removeActiveLinkClass(true);}, 200);
 
 			//deliberately redirect, in case click was triggered
 			if( hasTarget ){


### PR DESCRIPTION
This has a side-effect in Mobile Firefox: it causes the active state to be visible on buttons with rel="external" while it remains missing on other buttons (issue #898).
