### PR TITLE
Native-select-menu deactivation when scolling

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -172,6 +172,9 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 					//ensure button isn't clicked
 					e.stopPropagation();
 				})
+				.bind("touchmove", function( e ){
+					button.removeClass( $.mobile.activeBtnClass );
+				})
 				.bind( "focus mouseover", function(){
 					button.trigger( "mouseover" );
 				})


### PR DESCRIPTION
The button is activated on touchstart, but if the user starts scolling the page the select menu button receiving touchmove event should deactivate itself.
