### PR TITLE
Ability to control initial page initialization

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -57,6 +57,9 @@
 		gradeA: function(){
 			return $.support.mediaquery;
 		},
+		
+		//automatically initialize first pages or not.
+		autoInitialize: true,
 
 		//TODO might be useful upstream in jquery itself ?
 		keyCode: {
@@ -167,37 +170,44 @@
 			setTimeout(function() {
 				$.event.special.scrollstart.enabled = true;
 			}, 150 );
+		},
+		
+		// find and enhance the pages in the dom and transition to the first page.
+		initializePage: function(){
+			//find present pages
+			var $pages = $( "[data-role='page']" );
+
+			//add dialogs, set data-url attrs
+			$pages.add( "[data-role='dialog']" ).each(function(){
+				$(this).attr( "data-url", $(this).attr( "id" ));
+			});
+
+			//define first page in dom case one backs out to the directory root (not always the first page visited, but defined as fallback)
+			$.mobile.firstPage = $pages.first();
+
+			//define page container
+			$.mobile.pageContainer = $pages.first().parent().addClass( "ui-mobile-viewport" );
+
+			//cue page loading message
+			$.mobile.pageLoading();
+
+			// if hashchange listening is disabled or there's no hash deeplink, change to the first page in the DOM 
+			if( !$.mobile.hashListeningEnabled || !$.mobile.path.stripHash( location.hash ) ){
+				$.mobile.changePage( $.mobile.firstPage, false, true, false, true );
+			}
+			// otherwise, trigger a hashchange to load a deeplink
+			else {
+				$window.trigger( "hashchange", [ true ] );
+			}
 		}
 	});
 
 	//dom-ready inits
-	$(function(){
-		//find present pages
-		var $pages = $( "[data-role='page']" );
-		
-		//add dialogs, set data-url attrs
-		$pages.add( "[data-role='dialog']" ).each(function(){
-			$(this).attr( "data-url", $(this).attr( "id" ));
+	if($.mobile.autoInitialize){
+		$(function(){
+			$.mobile.initializePage();
 		});
-		
-		//define first page in dom case one backs out to the directory root (not always the first page visited, but defined as fallback)
-		$.mobile.firstPage = $pages.first();
-		
-		//define page container
-		$.mobile.pageContainer = $pages.first().parent().addClass( "ui-mobile-viewport" );
-		
-		//cue page loading message
-		$.mobile.pageLoading();
-		
-		// if hashchange listening is disabled or there's no hash deeplink, change to the first page in the DOM	
-		if( !$.mobile.hashListeningEnabled || !$.mobile.path.stripHash( location.hash ) ){
-			$.mobile.changePage( $.mobile.firstPage, false, true, false, true );
-		}
-		// otherwise, trigger a hashchange to load a deeplink
-		else {
-			$window.trigger( "hashchange", [ true ] );
-		}
-	});
+	}
 
 
 	//window load event

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -34,7 +34,7 @@
 		test( "loading the core library triggers mobilinit on the document", function(){
 			expect( 1 );
 
-			$(window.document).bind('mobileinit', function(event){
+			$(window.document).one('mobileinit', function(event){
 				ok(true);
 			});
 
@@ -144,6 +144,18 @@
 
 			stop();
 			$.testHelper.reloadLib(libName);
+		});
+		
+		test( "auto initialization does not occur when set to false", function(){
+			$(window.document).one('mobileinit', function(event){
+				$.mobile.autoInitialize = false;
+			});
+
+			$.testHelper.reloadLib(libName);
+			
+			ok($("html").hasClass("ui-mobile-rendering"), "Still in rendering state after library load.");
+			$.mobile.initializePage();
+			ok(!$("html").hasClass("ui-mobile-rendering"), "Rendered ok after call to initializePage");
 		});
 	});
 })(jQuery);


### PR DESCRIPTION
This code adds an option $.mobile.autoInitialize which if set to false will not initialize pages in the dom on dom ready.  It will default to true.

This is to satisfy use cases where the dom is still being manipulated after jQuery Mobile has been loaded, yet the application is not ready to open the initial page.

If $.mobile.autoInitialize has been set to false, the application including jQuery Mobile is required to call $.mobile.initializePage() when it is ready for jQuery Mobile to show the first page.
