### PR TITLE
Added support for the slider to step for step values under 1 

### DIFF
--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -114,7 +114,11 @@ $.widget( "mobile.slider", $.mobile.widget, {
 							self.refresh( self.beforeStart === 0 ? 1 : 0 );
 						}
 						var curval = val();
-						var snapped = Math.round( curval / (max - min) * 100 );
+						if (step >= 1) {
+						  var snapped = Math.round( curval / (max - min) * 100 );
+						} else {
+						  var snapped = Math.round( curval / (max - min) * (100*1/step)) / (1/step);
+						}
 						handle
 							.addClass("ui-slider-handle-snapping")
 							.css("left", snapped + "%")
@@ -208,6 +212,7 @@ $.widget( "mobile.slider", $.mobile.widget, {
 					|| data.pageX > this.slider.offset().left + this.slider.width() + tol ) {
 				return;
 			}
+			
 			percent = Math.round( ((data.pageX - this.slider.offset().left) / this.slider.width() ) * 100 );
 		} else {
 			if ( val == null ) {
@@ -219,8 +224,7 @@ $.widget( "mobile.slider", $.mobile.widget, {
 		if ( isNaN(percent) ) { return; }
 		if ( percent < 0 ) { percent = 0; }
 		if ( percent > 100 ) { percent = 100; }
-
-		var newval = Math.round( (percent / 100) * (max - min) ) + min;
+		var newval = ( (percent / 100) * (max - min) ) + min;
 		if ( newval < min ) { newval = min; }
 		if ( newval > max ) { newval = max; }
 

--- a/themes/default/jquery.mobile.forms.slider.css
+++ b/themes/default/jquery.mobile.forms.slider.css
@@ -4,7 +4,7 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
 */
 label.ui-slider { display: block; }
-input.ui-slider-input, .min-width-480px input.ui-slider-input { display: inline-block; width: 50px; }
+input.ui-slider-input, .min-width-480px input.ui-slider-input { display: inline-block; width: 70px; }
 select.ui-slider-switch { display: none; }
 div.ui-slider { position: relative; display: inline-block; overflow: visible; height: 15px; padding: 0; margin: 0 2% 0 20px; top: 4px; width: 66%; }
 a.ui-slider-handle { position: absolute; z-index: 10;  top: 50%; width: 28px; height: 28px; margin-top: -15px; margin-left: -15px; }


### PR DESCRIPTION
The slider only supported stepping by integers because of the use of Math.round, even with data-step being a floating point value under 1. 

I added support for percentages that are floating point values if the stepping is under one. I just changed the master stylesheet to make the input box width wider, but a new class could be added when stepping is under 1. 
