### PR TITLE
$.mobile.changePage() incorrectly determines forward/back for fromHashChange=true

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -176,7 +176,9 @@
 
 			//add dialogs, set data-url attrs
 			$pages.add( "[data-role='dialog']" ).each(function(){
-				$(this).attr( "data-url", $(this).attr( "id" ));
+				if(typeof $(this).attr( "data-url") == "undefined") {
+	                $(this).attr( "data-url", $(this).attr( "id" ));
+	            }
 			});
 
 			//define first page in dom case one backs out to the directory root (not always the first page visited, but defined as fallback)

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -116,7 +116,7 @@
 			clearForward: function(){
 				urlHistory.stack = urlHistory.stack.slice( 0, urlHistory.activeIndex + 1 );
 			},
-			
+
 			//disable hashchange event listener internally to ignore one change
 			//toggled internally when location.hash is updated to match the url of a successful page load
 			ignoreNextHashChange: true
@@ -277,12 +277,15 @@
 			pageTransitionQueue.unshift(arguments);
 			return;
 		}
-		
+
 		isPageTransitioning = true;
 
 		// if the changePage was sent from a hashChange event
 		// guess if it came from the history menu
 		if( fromHashChange ){
+
+			// determine new page index
+			var newActiveIndex = null;
 
 			// check if url is in history and if it's ahead or behind current page
 			$.each( urlHistory.stack, function( i ){
@@ -294,9 +297,12 @@
 					//forward set to opposite of back
 					forward = !back;
 					//reset activeIndex to this one
-					urlHistory.activeIndex = i;
+					newActiveIndex = i;
 				}
 			});
+
+			// save new page index
+			urlHistory.activeIndex = ( newActiveIndex != null ? newActiveIndex : urlHistory.activeIndex );
 
 			//if it's a back, use reverse animation
 			if( back ){
@@ -350,13 +356,13 @@
 			if( url.indexOf( "&" + $.mobile.subPageUrlKey ) > -1 ){
 				to = $( "[data-url='" + url + "']" );
 			}
-			
+
 			if( from ){
 				//set as data for returning to that spot
 				from.data( "lastScroll", currScroll);
 				//trigger before show/hide events
 				from.data( "page" )._trigger( "beforehide", { nextPage: to } );
-			}	
+			}
 			to.data( "page" )._trigger( "beforeshow", { prevPage: from || $("") } );
 
 			function loadComplete(){
@@ -376,7 +382,7 @@
 				removeActiveLinkClass();
 
 				//jump to top or prev scroll, sometimes on iOS the page has not rendered yet.  I could only get by this with a setTimeout, but would like to avoid that.
-				$.mobile.silentScroll( to.data( "lastScroll" ) ); 
+				$.mobile.silentScroll( to.data( "lastScroll" ) );
 
 				reFocus( to );
 
@@ -386,7 +392,7 @@
 				}
 				//trigger pageshow, define prevPage as either from or empty jQuery obj
 				to.data( "page" )._trigger( "show", null, { prevPage: from || $("") } );
-				
+
 				//set "to" as activePage
 				$.mobile.activePage = to;
 
@@ -394,7 +400,7 @@
 				if (duplicateCachedPage != null) {
 				    duplicateCachedPage.remove();
 				}
-				
+
 				//remove initial build class (only present on first pageshow)
 				$html.removeClass( "ui-mobile-rendering" );
 
@@ -438,7 +444,7 @@
 					from.add( to ).removeClass("out in reverse " + transition );
 					if( from ){
 						from.removeClass( $.mobile.activePageClass );
-					}	
+					}
 					loadComplete();
 					removeContainerClasses();
 				});
@@ -447,7 +453,7 @@
 			    $.mobile.pageLoading( true );
 			    if( from ){
 					from.removeClass( $.mobile.activePageClass );
-				}	
+				}
 				to.addClass( $.mobile.activePageClass );
 				loadComplete();
 			}
@@ -490,7 +496,7 @@
 		if ( to.length && !isFormRequest ) {
 			if( fileUrl && base ){
 				base.set( fileUrl );
-			}			
+			}
 			enhancePage();
 			transitionPages();
 		} else {
@@ -611,10 +617,10 @@
 	$( "a" ).live( "click", function(event) {
 
 		var $this = $(this),
-		
+
 			//get href, if defined, otherwise fall to null #
 			href = $this.attr( "href" ) || "#",
-			
+
 			//get href, remove same-domain protocol and host
 			url = path.clean( href ),
 
@@ -695,7 +701,7 @@
 		var to = path.stripHash( location.hash ),
 			//transition is false if it's the first page, undefined otherwise (and may be overridden by default)
 			transition = $.mobile.urlHistory.stack.length === 0 ? false : undefined;
-			
+
 		//if listening is disabled (either globally or temporarily), or it's a dialog hash
 		if( !$.mobile.hashListeningEnabled || !urlHistory.ignoreNextHashChange ||
 				urlHistory.stack.length > 1 && to.indexOf( dialogHashKey ) > -1 && !$.mobile.activePage.is( ".ui-dialog" )


### PR DESCRIPTION
Hi,
consider this example:
I have an HTML document with 2 internal pages and 1 internal dialog, for example "Page1", "Page2" and "Dialog". They are all linked together and I start on "Page1":

```
    <div id="page1" data-role="page">
        <div data-role="header" data-backbtn="false">
            <h1>Page 1</h1>
        </div>
        <div data-role="content">
            <a href="#page2" data-transition="slideup" data-role="button">Page 2</a>
            <a href="#dialog" data-role="button" data-transition="pop" data-rel="dialog">Dialog</a>
        </div>
    </div>

    <div id="page2" data-role="page">
        <div data-role="header" data-backbtn="false">
            <h1>Page 2</h1>
        </div>
        <div data-role="content">
            <a href="#page1" data-transition="slideup" data-role="button">Page 2</a>
            <a href="#dialog" data-role="button" data-transition="pop" data-rel="dialog">Dialog</a>
        </div>
    </div>

    <div id="dialog" data-role="dialog">
        <div data-role="header" data-position="inline">
            <h1>Dialog</h1>
        </div>
        <div data-role="content">Random Words!</div>
    </div>
```

Now, if you click on "dialog", the dialog will open with a "pop" transition and close (correctly) with another "pop" transition, this time reversed. (back = true) But if you click on "Page 2", then "Page 1", then "Page 2" again and finally click on "Dialog", it will open a dialog with a "pop" transition, but closes it with a "slideup" transition!

Here's the reason:
Currently, the urlHistory.stack determines the direction of a fromHashChange transition (like a closing dialog) by iterating over the stack, looking for the last occurrence of the new page. When it finds it, it compares that page's index to the activeIndex (urlIndex < activeIndex = back, urlIndex > activeIndex = forward), then sets the activeIndex to the urlIndex and continues. The problem here is, with a stack of [Page1,Page2,Page1,Page2,Dialog], an activeIndex=4 and url="Page2", it will overwrite activeIndex twice:

```
i = 0 -> url = Page1 // do nothing
i = 1 -> url = Page2 -> back = 1 < 4 //true -> activeIndex = 1
i = 2 -> url = Page1 // do nothing
i = 3 -> url = Page2 -> back = 3 < 1 //false(!!) -> activeIndex = 3
i = 4 -> url = Dialog // do nothing
```

Result: back = false, forward = true
Expected result: back = true, forward = false

This mostly screws up dialog closing transitions and sometimes history.back() transitions. I committed a fix to my local fork - I hope it's useful. This is my first time working with Git, sorry if anything is wrong. (yeah I know, I removed some whitespace in the commit:/)

Cheers,
Bra1n
