### PR TITLE
Fix for #979: Allow custom data-urls to be set before $.mobile.initializePage

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -176,7 +176,9 @@
 
 			//add dialogs, set data-url attrs
 			$pages.add( "[data-role='dialog']" ).each(function(){
-				$(this).attr( "data-url", $(this).attr( "id" ));
+				if(typeof $(this).attr( "data-url") == "undefined") {
+	                $(this).attr( "data-url", $(this).attr( "id" ));
+	            }
 			});
 
 			//define first page in dom case one backs out to the directory root (not always the first page visited, but defined as fallback)


### PR DESCRIPTION
initializePage() should check if there are already data-urls set, which allows custom hashtags to contain additional parameters, for example.
Here's the fix I created as a pull request.
Unfortunately I don't know how to connect pull requests to issues, so I guess this will have to do. =)
See  #979 for details.

Cheers,
Bra1n
