### PR TITLE
$.fn.animationComplete() should always return jQuery result

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -55,6 +55,11 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			},
 			
 			"touchend mouseup": function( event ){
+				if ( input.is( ":disabled" ) )
+				{
+					event.preventDefault();
+					return;
+				}
 				label.removeData("movestart");
 				if( label.data("etype") && label.data("etype") !== event.type || label.data("moved") ){
 					label.removeData("etype").removeData("moved");

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -225,6 +225,7 @@
 		else{
 			// defer execution for consistency between webkit/non webkit
 			setTimeout(callback, 0);
+			return $(this);
 		}
 	};
 

--- a/tests/unit/checkboxradio/checkboxradio_core.js
+++ b/tests/unit/checkboxradio/checkboxradio_core.js
@@ -1,0 +1,27 @@
+/*
+ * mobile page unit tests
+ */
+module('jquery.mobile.forms.checkboxradio.js');
+
+test( "widget can be disabled and enabled", function(){
+	var input = $("#checkbox-1");
+	var button = input.parent().find(".ui-btn");
+
+	input.checkboxradio("disable");
+	input.checkboxradio("enable");
+	ok(!input.attr("disabled"), "start input as enabled");
+	ok(!input.parent().hasClass("ui-disabled"), "no disabled styles");
+	ok(!input.attr("checked"), "not checked before click");
+	button.trigger("mouseup");
+	ok(input.attr("checked"), "checked after click");
+	ok(button.hasClass("ui-btn-active"), "active styles after click");
+	button.trigger("mouseup");
+
+	input.checkboxradio("disable");
+	ok(input.attr("disabled"), "input disabled");
+	ok(input.parent().hasClass("ui-disabled"), "disabled styles");
+	ok(!input.attr("checked"), "not checked before click");
+	button.trigger("mouseup");
+	ok(!input.attr("checked"), "not checked after click");
+	ok(!button.hasClass("ui-btn-active"), "no active styles after click");
+});

--- a/tests/unit/checkboxradio/index.html
+++ b/tests/unit/checkboxradio/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Page Test Suite</title>
+
+	<script type="text/javascript" src="../../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.ui.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.media.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.support.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.event.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.hashchange.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.core.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.navigation.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.page.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.fixHeaderFooter.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.checkboxradio.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.textinput.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.select.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.buttonMarkup.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.button.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.slider.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.collapsible.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.controlGroup.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.fieldContain.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.listview.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.listview.filter.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.dialog.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.navbar.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.grid.js"></script>
+	<script type="text/javascript" src="../../../tests/jquery.testHelper.js"></script>
+
+
+	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
+	<script type="text/javascript" src="../../../external/qunit.js"></script>
+
+	<script type="text/javascript" src="checkboxradio_core.js"></script>
+</head>
+<body>
+
+<h1 id="qunit-header">jQuery Mobile Page Test Suite</h1>
+<h2 id="qunit-banner"></h2>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests">
+</ol>
+
+<div id="qunit-fixture">
+	<div data-role="page">
+		<div data-role="content">
+			<div data-role="fieldcontain">
+				<fieldset data-role="controlgroup">
+					<legend>Agree to the terms:</legend>
+					<input type="checkbox" name="checkbox-1" id="checkbox-1" class="custom" />
+					<label for="checkbox-1">I agree</label>
+					</fieldset>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/tests/unit/navigation/navigation_transitions.js
+++ b/tests/unit/navigation/navigation_transitions.js
@@ -134,5 +134,9 @@
 			},0);
 		},0);
 	});
+
+	test( "animationComplete return value", function(){
+		equals($("#foo").animationComplete()[0], $("#foo")[0]);
+	});
 	
 })(jQuery);

--- a/tests/unit/navigation/navigation_transitions.js
+++ b/tests/unit/navigation/navigation_transitions.js
@@ -136,7 +136,8 @@
 	});
 
 	test( "animationComplete return value", function(){
-		equals($("#foo").animationComplete()[0], $("#foo")[0]);
+		$.fn.animationComplete = animationCompleteFn;
+		equals($("#foo").animationComplete(function(){})[0], $("#foo")[0]);
 	});
 	
 })(jQuery);


### PR DESCRIPTION
Line 203 in jquery.mobile.fixHeaderFooter.js says....

```
    if( !alreadyVisible && !immediately ){
      el.animationComplete(function(){
        el.removeClass('in');
      }).addClass('in');
    }
```

Which implies animationComplete() should always return a jQuery result to allow chaining. However, animationComplete() has been defined as...

```
$.fn.animationComplete = function( callback ){
  if($.support.cssTransitions){
    return $(this).one('webkitAnimationEnd', callback);
  }
  else{
    // defer execution for consistency between webkit/non webkit
    setTimeout(callback, 0);
  }
};
```

The else case happens on browsers like Firefox and thus causes errors with fixHeaderFooter.js.
