### PR TITLE
fix for Issue 850 navbar active element is not styled properly after transition.

### DIFF
--- a/docs/toolbars/footer-persist-a.html
+++ b/docs/toolbars/footer-persist-a.html
@@ -63,7 +63,7 @@
 				</ul>
 	</div>
 	
-	<div data-role="footer" data-id="foo1" data-position="fixed">
+	<div data-role="footer" data-position="fixed">
 		<div data-role="navbar">
 			<ul>
 				<li><a href="footer-persist-a.html" class="ui-btn-active">Friends</a></li>

--- a/docs/toolbars/footer-persist-b.html
+++ b/docs/toolbars/footer-persist-b.html
@@ -91,7 +91,7 @@
 
 	</div>
 	
-	<div data-role="footer" data-id="foo1" data-position="fixed">
+	<div data-role="footer" data-position="fixed">
 		<div data-role="navbar">
 			<ul>
 				<li><a href="footer-persist-a.html">Friends</a></li>

--- a/docs/toolbars/footer-persist-c.html
+++ b/docs/toolbars/footer-persist-c.html
@@ -74,7 +74,7 @@
 	</ul>
 	</div>
 	
-	<div data-role="footer" data-id="foo1" data-position="fixed">
+	<div data-role="footer" data-position="fixed">
 		<div data-role="navbar">
 			<ul>
 				<li><a href="footer-persist-a.html">Friends</a></li>

--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -31,11 +31,6 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 				shadow:		false, 
 				iconpos:	iconpos
 			});
-		
-		$navbar.delegate("a", "click",function(event){
-			$navbtns.removeClass( "ui-btn-active" );
-			$( this ).addClass( "ui-btn-active" );
-		});	
 	}
 });
 })( jQuery );


### PR DESCRIPTION
I removed the part of jquery.mobile.navbar.js that was adding and removing the class of  .ui-btn-active.  The class is already being set correctly in the html.  I also removed the data-id attribute from the html.  This is no longer needed by jquery.mobile.fixHeaderFooter.js for a persistent header, but it's changing the .ui-btn-active class.  The next step for me (considering this change is accepted) will be to update the documentation accordingly and create a test for the active state, especially since this issue has already had so many regressions.
