### PR TITLE
$.fn.animationComplete should always return jQuery result to allow chaining

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -225,6 +225,7 @@
 		else{
 			// defer execution for consistency between webkit/non webkit
 			setTimeout(callback, 0);
+			return $(this);
 		}
 	};
 

--- a/tests/unit/navigation/navigation_transitions.js
+++ b/tests/unit/navigation/navigation_transitions.js
@@ -134,5 +134,10 @@
 			},0);
 		},0);
 	});
+
+	test( "animationComplete return value", function(){
+		$.fn.animationComplete = animationCompleteFn;
+		equals($("#foo").animationComplete(function(){})[0], $("#foo")[0]);
+	});
 	
 })(jQuery);


### PR DESCRIPTION
Line 203 in jquery.mobile.fixHeaderFooter.js says..

```
    if( !alreadyVisible && !immediately ){
      el.animationComplete(function(){
        el.removeClass('in');
      }).addClass('in');
    }
```

Which implies animationComplete() should return always el. However, animationComplete()'s definition in jquery.mobile.navigation.js is saying otherwise:

```
$.fn.animationComplete = function( callback ){
  if($.support.cssTransitions){
    return $(this).one('webkitAnimationEnd', callback);
  }
  else{
    // defer execution for consistency between webkit/non webkit
    setTimeout(callback, 0);
  }
};
```

The else clause is executed in Mozilla browsers such as Firefox. This causes errors with fixHeaderFooter's logic since jQuery Mobile is calling addClass('in') on an undefined object.
