### PR TITLE
Fix for issue #1036 select menu partially drawn offscreen

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -405,8 +405,8 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		if( this.options.disabled || this.options.nativeMenu ){ return; }
 
 		var self = this,
-			menuHeight = self.list.outerHeight(),
-			menuWidth = self.list.outerWidth(),
+			menuHeight = self.list.parent().outerHeight(),
+			menuWidth = self.list.parent().outerWidth(),
 			scrollTop = $(window).scrollTop(),
 			btnOffset = self.button.offset().top,
 			screenHeight = window.innerHeight,
@@ -455,6 +455,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 			var roomtop = btnOffset - scrollTop,
 				roombot = scrollTop + screenHeight - btnOffset,
 				halfheight = menuHeight / 2,
+				maxwidth = parseFloat(self.list.parent().css('max-width')),
 				newtop,newleft;
 				
 				if( roomtop > menuHeight / 2 && roombot > menuHeight / 2 ){
@@ -465,8 +466,18 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 					newtop = roomtop > roombot ? scrollTop + screenHeight - menuHeight - 30 : scrollTop + 30;
 				}
 				
-				newleft = self.button.offset().left + self.button.outerWidth() / 2 - menuWidth / 2;
-				
+				if (menuWidth < maxwidth) {
+					newleft = (screenWidth - menuWidth) / 2;
+				} else {
+					newleft = self.button.offset().left + self.button.outerWidth() / 2 - menuWidth / 2;
+					// 30px tolerance off the edges
+					if (newleft < 30) {
+						newleft = 30;
+					} else if ((newleft + menuWidth) > screenWidth) {
+						newleft = screenWidth - menuWidth - 30;
+					}
+				}
+
 
 			self.listbox
 				.append( self.list )


### PR DESCRIPTION
This is a fix for issue #1036: https://github.com/jquery/jquery-mobile/issues/issue/1036

The select menu is now always rendered in the viewport of the browser and not partially offscreen when the select button is close to the left or right edge of the viewport.

Also contains a little fix for the calculation of the width and height of the select menu. This was done without taking into account the (black) shadow border around the select menu.

This is my first patch ever, so be gentle... (I hope I have done it the right way).
