### PR TITLE
Interrupt change page

### DIFF
--- a/tests/unit/navigation/navigation_core.js
+++ b/tests/unit/navigation/navigation_core.js
@@ -2,7 +2,25 @@
  * mobile navigation unit tests
  */
 (function($){
-	var changePageFn = $.mobile.changePage;
+	var changePageFn = $.mobile.changePage,
+	
+		//TODO centralize class names?
+		transitionTypes = "in out fade slide flip reverse pop",
+		
+		isTransitioning = function(page){
+			return $.grep(transitionTypes.split(" "), function(className, i){
+				return page.hasClass(className)
+			}).length > 0;
+		},
+		
+		isTransitioningIn = function(page){
+			return page.hasClass("in") && isTransitioning(page);
+		},
+		
+		isTransitioningOut = function(page){
+			return page.hasClass("out") && isTransitioning(page);
+		};
+		
 	module('jquery.mobile.navigation.js', {
 		teardown: function(){
 			$.mobile.changePage = changePageFn;
@@ -203,6 +221,18 @@
 			start();
 			ok(called == 1, "change page should be called once");
 		}, 500);
+	});
+	
+	test( "changePage will interrupt current transition if another occurs before it completes", function(){
+		var firstPage = $("#foo"),
+			secondPage = $("#bar");
+		
+		$.mobile.changePage(firstPage);
+		ok(isTransitioningIn(firstPage), "first page begins transition in");
+		$.mobile.changePage(secondPage);
+		
+		ok(isTransitioningOut(firstPage), "first page is now transitioning out");
+		ok(isTransitioningIn(secondPage), "second page is now transitioning in");
 	});
 	
 })(jQuery);

--- a/tests/unit/navigation/navigation_transitions.js
+++ b/tests/unit/navigation/navigation_transitions.js
@@ -5,19 +5,6 @@
 	var perspective = "ui-mobile-viewport-perspective",
 			transitioning = "ui-mobile-viewport-transitioning",
 			animationCompleteFn = $.fn.animationComplete,
-
-			//TODO centralize class names?
-			transitionTypes = "in out fade slide flip reverse pop",
-			
-			isTransitioning = function(page){
-				return $.grep(transitionTypes.split(" "), function(className, i){
-					return page.hasClass(className)
-				}).length > 0;
-			},
-			
-			isTransitioningIn = function(page){
-				return page.hasClass("in") && isTransitioning(page);
-			},
 			
 			//animationComplete callback queue
 			callbackQueue = [],
@@ -110,28 +97,6 @@
 		setTimeout(function(){
 			ok($("#no-trans").hasClass("slide"), "has slide class");
 			start();
-		},0);
-	});
-	
-	test( "changePage queues requests", function(){
-		var firstPage = $("#foo"),
-			secondPage = $("#bar");
-		
-		$.mobile.changePage(firstPage);
-		$.mobile.changePage(secondPage);
-		
-		stop();
-		setTimeout(function(){
-			ok(isTransitioningIn(firstPage), "first page begins transition");
-			ok(!isTransitioningIn(secondPage), "second page doesn't transition yet");
-			
-			finishPageTransition();
-			
-			setTimeout(function(){
-				ok(!isTransitioningIn(firstPage), "first page transition should be complete");
-				ok(isTransitioningIn(secondPage), "second page should begin transitioning");
-				start();
-			},0);
 		},0);
 	});
 	


### PR DESCRIPTION
Hello!   So.. jblas made the excellent suggestion in the case of simultaneous calls to $.mobile.changePage to simply skip to the last requested page instead of queuing the requests.  

https://github.com/jquery/jquery-mobile/commit/4ddc5c7dd5dae8b96016f9569fde785586c02e71#commitcomment-258792

I think this is a great idea.  And after living with the current implementation for a bit I've decided it would probably be best to make the change.  So here's my attempt at it.  This should not only provide a better user experience but ended up making the implementation cleaner.  Thanks!

ps This change accidentally also fixes the issues addressed in of https://github.com/jquery/jquery-mobile/pull/1045 and https://github.com/jquery/jquery-mobile/pull/1060.  Sorry hailtiki and martinkou! :(
