### PR TITLE
Fix for issue #968: click event not passed to underlying inputs

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -66,11 +66,13 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				label.data( "etype", event.type );
 				self._cacheVals();
 				input.attr( "checked", inputtype === "radio" && true || !input.is( ":checked" ) );
-				self._updateAll();
 				event.preventDefault();
 			},
 			
-			click: false
+			click: function( event ) {
+                input.trigger("click");
+                event.preventDefault();
+            }
 			
 		});
 		
@@ -80,8 +82,9 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 					this._cacheVals();
 				},
 				
-				click: function(){
+				click: function( event ){
 					self._updateAll();
+                    event.preventDefault();
 				},
 
 				focus: function() { 

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -66,13 +66,12 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				label.data( "etype", event.type );
 				self._cacheVals();
 				input.attr( "checked", inputtype === "radio" && true || !input.is( ":checked" ) );
+				self._updateAll();
+				input.trigger("click");
 				event.preventDefault();
 			},
 			
-			click: function( event ) {
-                input.trigger("click");
-                event.preventDefault();
-            }
+			click: false
 			
 		});
 		
@@ -83,8 +82,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				},
 				
 				click: function( event ){
-					self._updateAll();
-                    event.preventDefault();
+					event.preventDefault();
 				},
 
 				focus: function() { 


### PR DESCRIPTION
This is a fix for issue #968: https://github.com/jquery/jquery-mobile/issues/issue/968

When a radio or checkbox is touched/clicked there is no click() event triggered. This fix triggers the click event and prevents multiple click events. The order of events is: first the change() event is triggered, then the click() event. See commit message for more information.
