### PR TITLE
Wrong regular expression in $.mobile.changePage ajax request.

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -517,7 +517,7 @@
 
 					//pre-parse html to check for a data-url,
 					//use it as the new fileUrl, base path, etc
-					var redirectLoc = / data-url="(.*)"/.test( html ) && RegExp.$1;
+					var redirectLoc = / data-url="([^"]*)"/.test( html ) && RegExp.$1;
 
 					if( redirectLoc ){
 						if(base){


### PR DESCRIPTION
Regular expression / data-url="(.*)"/ doesn't stop at the end of the attribute
but the last quotes in the HTML.

I have replaced wildcard . with [^"] to fetch only the attribute content.
