### PR TITLE
tap event fires multiple times for each physical tap on iPhone

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -63,20 +63,7 @@ $.event.special.tap = {
 			$this = $( thisObject );
 		
 		$this
-			.bind( "mousedown touchstart", function( event ) {
-				if ( event.which && event.which !== 1 ||
-					//check if event fired once already by a device that fires both mousedown and touchstart (while supporting both events)
-					$this.data( "prevEvent") && $this.data( "prevEvent") !== event.type ) {
-					return false;
-				}
-				
-				//save event type so only this type is let through for a temp duration, 
-				//allowing quick repetitive taps but not duplicative events 
-				$this.data( "prevEvent", event.type );
-				setTimeout(function(){
-					$this.removeData( "prevEvent" );
-				}, 800);
-				
+			.bind( touchStartEvent, function( event ) {
 				var moved = false,
 					touching = true,
 					origTarget = event.target,
@@ -111,9 +98,9 @@ $.event.special.tap = {
 				$(window).one("scroll", moveHandler);
 				
 				$this
-					.bind( "mousemove touchmove", moveHandler )
-					.one( "mouseup touchend", function( event ) {
-						$this.unbind( "mousemove touchmove", moveHandler );
+					.bind( touchMoveEvent, moveHandler )
+					.one( touchStopEvent, function( event ) {
+						$this.unbind( touchMoveEvent, moveHandler );
 						$(window).unbind("scroll", moveHandler);
 						clearTimeout( timer );
 						touching = false;

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -55,6 +55,11 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			},
 			
 			"touchend mouseup": function( event ){
+				if ( input.is( ":disabled" ) )
+				{
+					event.preventDefault();
+					return;
+				}
 				label.removeData("movestart");
 				if( label.data("etype") && label.data("etype") !== event.type || label.data("moved") ){
 					label.removeData("etype").removeData("moved");

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -225,6 +225,7 @@
 		else{
 			// defer execution for consistency between webkit/non webkit
 			setTimeout(callback, 0);
+			return $(this);
 		}
 	};
 

--- a/tests/functional/duplicatetap.html
+++ b/tests/functional/duplicatetap.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8" />
-	<title>jQuery Mobile: Event Logger</title>
+	<title>jQuery Mobile: Duplicate Tap Events Test Case</title>
 	<link rel="stylesheet"  href="../../themes/default/" />
 	<link rel="stylesheet" href="../../docs/_assets/css/jqm-docs.css" />
 	
@@ -35,7 +35,7 @@
 
 	<script>
 	$( document )
-		.bind("tap taphold swipe swipeleft swiperight scrollstart scrollstop orientationchange",function( e ){
+		.bind("tap",function( e ){
 			$("#log")
 				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"</li>")
 				.listview("refresh");
@@ -46,11 +46,13 @@
 <body> 
 <div data-role="page" data-theme="b" id="jqm-home">
 	<div data-role="header">
-		<h1>Event Logger</h1>
+		<h1>Duplicate Tap Events Test Case</h1>
 	</div>
 	
 	<div data-role="content">
-		<p>Touch events on this page will log out below, prepending to the top as they arrive.</p>
+		<p>Run this test case on an iPhone or other mobile devices - tap on the
+		screen, hold for about 1 sec. There should be no duplicate tap event
+		printouts.</p>
 		
 		<ul data-role="listview" id="log">
 			

--- a/tests/unit/checkboxradio/checkboxradio_core.js
+++ b/tests/unit/checkboxradio/checkboxradio_core.js
@@ -1,0 +1,27 @@
+/*
+ * mobile page unit tests
+ */
+module('jquery.mobile.forms.checkboxradio.js');
+
+test( "widget can be disabled and enabled", function(){
+	var input = $("#checkbox-1");
+	var button = input.parent().find(".ui-btn");
+
+	input.checkboxradio("disable");
+	input.checkboxradio("enable");
+	ok(!input.attr("disabled"), "start input as enabled");
+	ok(!input.parent().hasClass("ui-disabled"), "no disabled styles");
+	ok(!input.attr("checked"), "not checked before click");
+	button.trigger("mouseup");
+	ok(input.attr("checked"), "checked after click");
+	ok(button.hasClass("ui-btn-active"), "active styles after click");
+	button.trigger("mouseup");
+
+	input.checkboxradio("disable");
+	ok(input.attr("disabled"), "input disabled");
+	ok(input.parent().hasClass("ui-disabled"), "disabled styles");
+	ok(!input.attr("checked"), "not checked before click");
+	button.trigger("mouseup");
+	ok(!input.attr("checked"), "not checked after click");
+	ok(!button.hasClass("ui-btn-active"), "no active styles after click");
+});

--- a/tests/unit/checkboxradio/index.html
+++ b/tests/unit/checkboxradio/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Page Test Suite</title>
+
+	<script type="text/javascript" src="../../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.ui.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.widget.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.media.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.support.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.event.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.hashchange.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.core.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.navigation.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.page.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.fixHeaderFooter.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.checkboxradio.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.textinput.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.select.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.buttonMarkup.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.button.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.forms.slider.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.collapsible.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.controlGroup.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.fieldContain.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.listview.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.listview.filter.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.dialog.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.navbar.js"></script>
+	<script type="text/javascript" src="../../../js/jquery.mobile.grid.js"></script>
+	<script type="text/javascript" src="../../../tests/jquery.testHelper.js"></script>
+
+
+	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
+	<script type="text/javascript" src="../../../external/qunit.js"></script>
+
+	<script type="text/javascript" src="checkboxradio_core.js"></script>
+</head>
+<body>
+
+<h1 id="qunit-header">jQuery Mobile Page Test Suite</h1>
+<h2 id="qunit-banner"></h2>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests">
+</ol>
+
+<div id="qunit-fixture">
+	<div data-role="page">
+		<div data-role="content">
+			<div data-role="fieldcontain">
+				<fieldset data-role="controlgroup">
+					<legend>Agree to the terms:</legend>
+					<input type="checkbox" name="checkbox-1" id="checkbox-1" class="custom" />
+					<label for="checkbox-1">I agree</label>
+					</fieldset>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/tests/unit/navigation/navigation_transitions.js
+++ b/tests/unit/navigation/navigation_transitions.js
@@ -134,5 +134,10 @@
 			},0);
 		},0);
 	});
+
+	test( "animationComplete return value", function(){
+		$.fn.animationComplete = animationCompleteFn;
+		equals($("#foo").animationComplete(function(){})[0], $("#foo")[0]);
+	});
 	
 })(jQuery);


### PR DESCRIPTION
Run the following test case on an iOS device's Safari - must be a real iOS device, not iPhone Simulator:
http://tixxme.com/~martinkou-public/jquery-mobile/tests/functional/duplicatetap.html

Try to tap on the screen a few times, you'll get some log items. Now, tap and hold for about 1 second on some of the log items. Pretty soon, you'll see the tap event is being fired multiple times for each tap you made.

The problem comes from how the event module hooks the tap event. It says..

```
    $this
        .bind( "mousedown touchstart", function( event ) {
            if ( event.which && event.which !== 1 ||
                //check if event fired once already by a device that fires both mousedown and touchstart (while supporting both events)
                $this.data( "prevEvent") && $this.data( "prevEvent") !== event.type ) {
                return false;
            }
```

Even though there's some logic to prevent the firing of duplicate events, the logic is not foolproof. The logic depends on a 800ms timeout to detect a duplicate event and ignore it. Now, the problem with this scheme is that the mousedown event isn't fired until the touchend happened - as documented by Quirksmode:
http://www.quirksmode.org/blog/archives/2010/02/the_touch_actio.html

What this means is, a user can start a touch, hold for more than 800ms to avoid the timer, end the touch - and he'll get 2 touchend event handlers registered for supposedly one tap event. Worse, since the second touchend event handler is actually registered after the touch end event ended (it's registered by the mousedown handler which happens after touchend) - the user will get a surprise tap event firing for his next touchend event.

The fix is to use the detected touchStartEvent/touchStopEvent/touchMoveEvent strings for event binding instead. Also, I've noticed the functional test cases for testing jQuery Mobile events are not complete, so I've completed them as well.
