### PR TITLE
Add left/right styles for footer buttons 

### DIFF
--- a/themes/default/jquery.mobile.core.css
+++ b/themes/default/jquery.mobile.core.css
@@ -40,9 +40,9 @@
 
 .ui-header, .ui-footer { display: block; }
 .ui-page .ui-header, .ui-page .ui-footer { position: relative; }
-.ui-header .ui-btn-left { position: absolute; left: 10px; top: .4em;  }
+.ui-header .ui-btn-left, .ui-footer .ui-btn-left { position: absolute; left: 10px; top: .4em;  }
+.ui-header .ui-btn-right, .ui-footer .ui-btn-right { position: absolute; right: 10px; top: .4em; }
 .ui-header .ui-title, .ui-footer .ui-title { text-align: center; font-size: 16px; display: block; margin: .6em 90px .8em;  padding: 0;  text-overflow: ellipsis; overflow: hidden; white-space: nowrap; outline: 0 !important; }
-.ui-header .ui-btn-right { position: absolute; right: 10px; top: .4em; }
 
 /*content area*/
 .ui-content { border-width: 0; overflow: visible; overflow-x: hidden; padding: 15px; }


### PR DESCRIPTION
Buttons in footers have a really bad positioning, this commit adds the same styling from the header buttons to the footer ones
