### PR TITLE
Typo in jquery.mobile.forms.checkboxradio.js

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -45,7 +45,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				var oe = event.originalEvent.touches[0];
 				if( label.data("movestart") ){
 					if( Math.abs( label.data("movestart")[0] - oe.pageX ) > 10 ||
-						Math.abs( abel.data("movestart")[1] - oe.pageY ) > 10 ){
+						Math.abs( label.data("movestart")[1] - oe.pageY ) > 10 ){
 							label.data("moved", true);
 						}
 				}


### PR DESCRIPTION
Line 44 in checkboxradio widget's file says...
            "touchmove": function( event ){
                var oe = event.originalEvent.touches[0];
                if( label.data("movestart") ){
                    if( Math.abs( label.data("movestart")[0] - oe.pageX ) > 10 ||
                        Math.abs( abel.data("movestart")[1] - oe.pageY ) > 10 ){
                            label.data("moved", true);
                        }
                }
                else{
                    label.data("movestart", [ parseFloat( oe.pageX ), parseFloat( oe.pageY ) ]);
                }
            },

The Math.abs( abel.data... ) line contains a typo and causes JavaScript errors in Mobile Safari whenever a user touches and then drags a checkbox item. The error can be noticed in two ways.. First, if you touch and drag a checkbox item, it is still toggled when your finger leaves the screen, which isn't supposed to happen. Second, if you enable Mobile Safari's debug console, you'll see a lot of error messages on that line.
