### PR TITLE
Fixed: List view tests fail when reloading the test page because of the hash left in the previous run

### DIFF
--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -3,6 +3,8 @@
  */
 
 (function( $ ) {
+	window.location.hash = "";
+	
 	$.testHelper = {
 		excludeFileProtocol: function(callback){
 			var message = "Tests require script reload and cannot be run via file: protocol";


### PR DESCRIPTION
This time with the right commit.

This just clears window.location.hash before running tests to avoid failing tests when reloading test pages.

The hash left by the test run caused some tests to fail when reloading the page.
