### PR TITLE
Extra testcase to avoid breaking the search filter with dividers expected behaviour in future refactorings 

### DIFF
--- a/tests/unit/listview/listview_core.js
+++ b/tests/unit/listview/listview_core.js
@@ -252,4 +252,19 @@
 			start();
 		}, 1000);
 	});
+	
+	asyncTest( "Dividers are hidden when preceding hidden rows and shown when preceding shown rows", function () {
+		// wait for the page to become active/enhanced
+		setTimeout(function(){
+			$('.ui-page-active input').val('at');
+			$('.ui-page-active input').trigger('change');
+		}, 500);
+
+		setTimeout(function() {
+			same($('.ui-page-active li[data-role=list-divider][style^="display: none;"]').length, 2);
+			same($('.ui-page-active li[data-role=list-divider][style^="display: none;"] + li:not([data-role=list-divider])[style^="display: none;"]').length, 2);
+			same($('.ui-page-active li[data-role=list-divider]:not([style^="display: none;"]) + li:not([data-role=list-divider]):not([style^="display: none;"])').length, 2);
+			start();
+		}, 1000);
+	});
 })(jQuery);


### PR DESCRIPTION
The expected behaviour for filtered lists with dividers implies that dividers are shown when preceding shown buckets and hidden when preceding hidden buckets.

This test case checks that.
