### PR TITLE
Adding and removing list items without needing to call refresh() every time

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -169,6 +169,23 @@ $.widget( "mobile.listview", $.mobile.widget, {
 			self = this,
 			dividertheme = $list.data( "dividertheme" ) || o.dividerTheme;
 
+		// Insert item to cache.
+		if ( index >= this._listItems.length )
+			this._listItems.push( item );
+		else if ( index < 1 )
+			this._listItems.unshift( item );
+		else
+			this._listItems.splice( index, 0, item );
+
+		// Add the list item to DOM if it's not added.
+		if ( item.parent()[0] != $list[0] )
+		{
+			if ( index >= this._listItems.length - 1 )
+				$list.append( item );
+			else
+				this._listItems[ index + 1 ].before( item );
+		}
+
 		item.attr({ "role": "option", "tabindex": "-1" });
 		if ( index < 1 )
 			item.attr( "tabindex", "0" );
@@ -235,13 +252,6 @@ $.widget( "mobile.listview", $.mobile.widget, {
 			itemClass += " ui-li-static ui-btn-up-" + itemTheme;
 		}
 		
-		if ( index >= this._listItems.length )
-			this._listItems.push( item );
-		else if ( index < 1 )
-			this._listItems.unshift( item );
-		else
-			this._listItems.splice( index, 0, item );
-
 		if( o.inset ){
 			if ( index === 0 ) {
 					// Add corner style for the new top list item.
@@ -313,12 +323,15 @@ $.widget( "mobile.listview", $.mobile.widget, {
 		item.remove();
 
 		// Fix the top and bottom corner styles.
-		if ( this._listItems.length > 0 )
+		if ( this.options.inset )
 		{
-			if ( index < 1 )
-				this._addCorners( this._listItems[0], 0x01 );
-			if ( index >= this._listItems.length )
-				this._addCorners( this._listItems[ this._listItems.length - 1 ], 0x02 );
+			if ( this._listItems.length > 0 )
+			{
+				if ( index < 1 )
+					this._addCorners( this._listItems[0], 0x01 );
+				if ( index >= this._listItems.length )
+					this._addCorners( this._listItems[ this._listItems.length - 1 ], 0x02 );
+			}
 		}
 	},
 
@@ -379,7 +392,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 
 		var parent = list.parent(),
 				title = $.trim(parent.contents()[ 0 ].nodeValue) || parent.find('a:first').text(),
-				id = parentId + "&" + $.mobile.subPageUrlKey + "=" + self._idStringEscape(title + " " + ( ++this._subpageCount ) ),
+				id = parentId + "&" + $.mobile.subPageUrlKey + "=" + self._idStringEscape(title + " " + ( this._subpageCount++ ) ),
 				theme = list.data( "theme" ) || o.theme,
 				countTheme = list.data( "counttheme" ) || parentList.data( "counttheme" ) || o.countTheme,
 				newPage = list.wrap( "<div data-role='page'><div data-role='content'></div></div>" )

--- a/tests/unit/listview/index.html
+++ b/tests/unit/listview/index.html
@@ -190,5 +190,26 @@
 	</div>
 </div>
 
+<!-- Dynamic list item addition and deletion -->
+<div data-role="page" id="dynamic-add-delete">
+	<div data-role="header" data-position="inline">
+		<h1>Dynamic Add and Delete</h1>
+	</div>
+	<div data-role="content">
+		<ul data-role="listview" data-position="inline" data-inset="true">
+		</ul>
+	</div>
+</div>
+
+<div data-role="page" id="dynamic-add-delete-no-inset">
+	<div data-role="header" data-position="inline">
+		<h1>Dynamic Add and Delete</h1>
+	</div>
+	<div data-role="content">
+		<ul data-role="listview">
+		</ul>
+	</div>
+</div>
+
 </body>
 </html>

--- a/tests/unit/listview/listview_core.js
+++ b/tests/unit/listview/listview_core.js
@@ -267,4 +267,96 @@
 			start();
 		}, 1000);
 	});
+
+	module( "Add and Delete List Items", {
+		setup: function(){
+			location.href = location.href.split('#')[0] + "#dynamic-add-delete";
+		}
+	});
+
+	asyncTest( "Correct corner styles on item insertion", function() {
+		// wait for the page to become active/enhanced
+		setTimeout(function(){
+			var $list = $(".ui-page-active ul");
+			same($list.find("li").length, 0, "list should start empty");
+			$list.listview("push", $("<li>b is for batman</li>"));
+			same($list.find("li").length, 1, "one item added");
+
+			var $batman = $list.find("li:first");
+			ok($batman.hasClass("ui-corner-top ui-corner-bottom"), "both top and bottom styles on lone item");
+
+			$list.listview("push", $("<li>c is for catwoman</li>"));
+			var $catwoman = $list.find("li:last");
+			same($list.find("li").length, 2, "two items added");
+			ok($catwoman.hasClass("ui-corner-bottom"), "bottom item should have bottom style");
+			ok($batman.hasClass("ui-corner-top"), "top item should retain top style");
+			ok(!$batman.hasClass("ui-corner-bottom"), "top item should lose bottom style");
+
+			$list.listview("insert", $("<li>a is for aquaman</li>"), 0);
+			var $aquaman = $list.find("li:first");
+			same($list.find("li").length, 3, "three items added");
+			same($aquaman.prev("li").length, 0, "insertion order check");
+			ok($aquaman.hasClass("ui-corner-top"), "top item should acquire top style");
+			ok(!$batman.hasClass("ui-corner-top") && !$batman.hasClass("ui-corner-bottom"), "middle item should lose all corner styles");
+			ok($catwoman.hasClass("ui-corner-bottom"), "bottom item should retain bottom styles");
+			start();
+		}, 500);
+	});
+
+	asyncTest( "Correct corner styles on item deletion", function() {
+		// wait for the page to become active/enhanced
+		setTimeout(function(){
+			var $list = $(".ui-page-active ul");
+			same($list.find("li").length, 3, "three items should have been added");
+
+			var $aquaman = $list.find("li:first"),
+				$batman = $list.find("li:eq(1)"),
+				$catwoman = $list.find("li:last");
+
+			$list.listview("pop");
+			same($catwoman.parent().length, 0, "removed the last item");
+			ok($batman.hasClass("ui-corner-bottom"), "new bottom item acquires bottom styles");
+			ok(!$batman.hasClass("ui-corner-top"), "new bottom item has no top styles");
+			ok($aquaman.hasClass("ui-corner-top"), "top item retains top styles");
+
+			$list.listview("pop", 0);
+			same($aquaman.parent().length, 0, "removed the first item");
+			same($list.find("li").length, 1, "one item left in list");
+			ok($batman.hasClass("ui-corner-bottom ui-corner-top"), "lone item acquires both top and bottom styles");
+
+			start();
+		}, 500);
+	});
+
+	asyncTest( "Correct insertion orders and deletion", function() {
+		location.href = location.href.split('#')[0] + "#dynamic-add-delete-no-inset";
+
+		// wait for the page to become active/enhanced
+		setTimeout(function(){
+			var $list = $(".ui-page-active ul"),
+				$aquaman = $("<li>a is for aquaman</li>"),
+				$batman = $("<li>b is for batman</li>"),
+				$catwoman = $("<li>c is for catwoman</li>");
+
+			$list.listview("insert", $catwoman, 0);
+			$list.listview("insert", $aquaman, 0);
+			$list.listview("insert", $batman, 1);
+
+			same($aquaman.next("li")[0], $batman[0], "correct ordering 1");
+			same($batman.next("li")[0], $catwoman[0], "correct ordering 2");
+			ok(!$aquaman.hasClass("ui-corner-top"), "no top styles inserting to no-inset list");
+			ok(!$catwoman.hasClass("ui-corner-bottom"), "no bottom styles inserting to no-inset list");
+
+			$list.listview("remove", $batman);
+			same($batman.parent().length, 0, "deleted the correct item");
+
+			$list.listview("push", $batman);
+			same($catwoman.next("li")[0], $batman[0], "inserting already initialized items work");
+
+			$list.listview("remove", $aquaman);
+			ok(!$catwoman.hasClass("ui-corner-top"), "no top styles removing from no-inset list");
+
+			start();
+		}, 500);
+	});
 })(jQuery);


### PR DESCRIPTION
The currently accepted way for dynamically adding list items, which calls refresh() for every list item added (http://jquerymobile.com/demos/1.0a3/docs/lists/docs-lists.html), is quite bad for performance when the list has more than a few items and also when the programmer isn't aware of the underlying complexity it implies (e.g. if he inserts and refreshes the items one-by-one)

A more fool-proof way to do it would be to provide insert() and remove() methods that works reasonably fast without needing the programming to be aware of refresh()'s performance implications. This patch provides four functions:
1. insert(listItem, index) - inserts a list item at the specified index
2. push(listItem) - inserts a list item at the bottom of the list
3. pop(index) - removes a list item at the specified index, or from the bottom if no index specified
4. remove(listItem) - removes the specified list item
