### PR TITLE
Fix for issue 1107: "navbar" fails when only one item in list

### DIFF
--- a/js/jquery.mobile.grid.js
+++ b/js/jquery.mobile.grid.js
@@ -13,7 +13,7 @@ $.fn.grid = function(options){
 	
 			
 		var $kids = $(this).children(),
-			gridCols = {a: 2, b:3, c:4, d:5},
+			gridCols = {a:2, b:3, c:4, d:5, e:1},
 			grid = o.grid,
 			iterator;
 			
@@ -32,12 +32,13 @@ $.fn.grid = function(options){
 		$(this).addClass('ui-grid-' + grid);
 	
 		$kids.filter(':nth-child(' + iterator + 'n+1)').addClass('ui-block-a');
-		$kids.filter(':nth-child(' + iterator + 'n+2)').addClass('ui-block-b');
-			
+		if(iterator > 1){	
+			$kids.filter(':nth-child(' + iterator + 'n+2)').addClass('ui-block-b');
+		}	
 		if(iterator > 2){	
 			$kids.filter(':nth-child(3n+3)').addClass('ui-block-c');
 		}	
-		if(iterator> 3){	
+		if(iterator > 3){	
 			$kids.filter(':nth-child(4n+4)').addClass('ui-block-d');
 		}	
 		if(iterator > 4){	

--- a/themes/default/jquery.mobile.grids.css
+++ b/themes/default/jquery.mobile.grids.css
@@ -8,6 +8,10 @@
 .ui-grid-a, .ui-grid-b, .ui-grid-c, .ui-grid-d { overflow: hidden; }
 .ui-block-a, .ui-block-b, .ui-block-c, .ui-block-d, .ui-block-e { margin: 0; padding: 0; border: 0; float: left; }
 
+/* grid a: 100 */
+.ui-grid-e .ui-block-a { width: 100%; }
+.ui-grid-e .ui-block-a { clear: left; }
+
 /* grid a: 50/50 */
 .ui-grid-a .ui-block-a, .ui-grid-a .ui-block-b { width: 50%; }
 .ui-grid-a .ui-block-a { clear: left; }


### PR DESCRIPTION
This was a problem with the grid plugin.  It assumed that there were at least two items in the grid.  
I added a case for a single item, and also added css for a single item.  

https://github.com/jquery/jquery-mobile/issues/1107
