### PR TITLE
Wider title for small selectmenu list

### DIFF
--- a/themes/default/jquery.mobile.forms.select.css
+++ b/themes/default/jquery.mobile.forms.select.css
@@ -32,3 +32,5 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 
 /* when no placeholder is defined in a multiple select, the header height doesn't even extend past the close button.  this shim's content in there */
 .ui-selectmenu .ui-header h1:after { content: '.'; visibility: hidden; }
+
+.ui-selectmenu .ui-header .ui-title { margin: 0.6em 46px 0.8em }


### PR DESCRIPTION
Issue I created:
https://github.com/jquery/jquery-mobile/issues/1176

The selectmenu title is quite narrow because it has a 90px margin on left and right which is inherited from .ui-header .ui-title -rule. I created a new rule specifically for selectmnu's title and decreased the margin to 46px. This way there's still enough room for the close button on multiple selects (with 10px margin on both sides of the button). The title is now 88px wider and can hold more text in it without truncating.
