### PR TITLE
Bug 733: Search box crashes on HTC Evo

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -619,7 +619,7 @@
 
 		$.mobile.changePage({
 				url: url,
-				type: type,
+				type: ( type ? type : 'get' ),
 				data: $(this).serialize()
 			},
 			undefined,


### PR DESCRIPTION
When a form element is missing the method attribute, jQuery mobile crashes the default browser on Android devices. Although it is not valid to omit the attribute, the browser does not crash when the same test case does not load jQuery mobile. I added in the default method of GET when it is missing.

Original issue: https://github.com/jquery/jquery-mobile/issues/733#issue/733
