### PR TITLE
Fixes issue #700: pagebeforehide return 'undefined' for ui.nextPage

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -371,9 +371,9 @@
 				//set as data for returning to that spot
 				from.data( "lastScroll", currScroll);
 				//trigger before show/hide events
-				from.data( "page" )._trigger( "beforehide", { nextPage: to } );
+				from.data( "page" )._trigger( "beforehide", null, { nextPage: to } );
 			}
-			to.data( "page" )._trigger( "beforeshow", { prevPage: from || $("") } );
+			to.data( "page" )._trigger( "beforeshow", null, { prevPage: from || $("") } );
 
 			function loadComplete(){
 


### PR DESCRIPTION
This commit passes a null (event) second parameter to the internal _trigger method for page 'beforeshow' and 'beforehide' methods, mimicking the 'hide' and 'show' event triggers.

Without this additional parameter, the data being passed (ui.nextPage & ui.prevPage) will never be passed to the element.trigger call and thus 'ui' will always be an empty jQ object when these two events are triggered.
