### PR TITLE
Set min-height for grid block

### DIFF
--- a/tests/functional/gridlayout.html
+++ b/tests/functional/gridlayout.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<title>jQuery Mobile: Grid Layout</title>
+	<link rel="stylesheet"  href="../../themes/default/" />
+	<link rel="stylesheet" href="../../docs/_assets/css/jqm-docs.css" />
+	<script type="text/javascript" src="../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../js/"></script>
+	
+	<script>
+	$(function(){
+		$(".ui-grid-d a").bind("tap", function(e){
+			$(this).hide();
+			$("#log")
+				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"; message: grid '"+$(this).text()+"' hidden</li>")
+				.listview("refresh");
+			return false;
+		}).bind("click", false);
+		$("#showbtn").bind("tap", function(e){
+			$(".ui-grid-d a").show();
+			$("#log")
+				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"; message: show all buttons</li>")
+				.listview("refresh");
+		}).bind("click", false);
+	});	
+	</script>
+</head> 
+<body> 
+<div data-role="page" data-theme="b" id="jqm-home">
+	<div data-role="header">
+		<h1>Grid Layout</h1>
+	</div>
+	
+	<div data-role="content">
+		<p>Touch events on this page will log out below, prepending to the top as they arrive.</p>
+		
+		<div class="ui-grid-d">
+			<div class="ui-block-a">
+				<a data-role="button" id="btn1" data-theme="b">Button 1</a>
+			</div>
+			<div class="ui-block-b">
+				<a data-role="button" id="btn2" data-theme="b">Button 2</a>
+			</div>
+			<div class="ui-block-c">
+				<a data-role="button" id="btn3" data-theme="b">Button 3</a>
+			</div>
+			<div class="ui-block-d">
+				<a data-role="button" id="btn4" data-theme="b">Button 4</a>
+			</div>
+			<div class="ui-block-e">
+				<a data-role="button" id="btn5" data-theme="b">Button 5</a>
+			</div>
+		</div>
+		
+		<a data-role="button" id="showbtn">Show all button</a>
+		
+		<ul data-role="listview" id="log">
+			
+		</ul>
+
+	</div>
+</div>
+</body>
+</html>

--- a/themes/default/jquery.mobile.grids.css
+++ b/themes/default/jquery.mobile.grids.css
@@ -6,7 +6,7 @@
 
 /* content configurations. */
 .ui-grid-a, .ui-grid-b, .ui-grid-c, .ui-grid-d { overflow: hidden; }
-.ui-block-a, .ui-block-b, .ui-block-c, .ui-block-d, .ui-block-e { margin: 0; padding: 0; border: 0; float: left; }
+.ui-block-a, .ui-block-b, .ui-block-c, .ui-block-d, .ui-block-e { margin: 0; padding: 0; border: 0; float: left; min-height:1px;}
 
 /* grid a: 50/50 */
 .ui-grid-a .ui-block-a, .ui-grid-a .ui-block-b { width: 50%; }


### PR DESCRIPTION
Hide the content in grid block, the block disappeared totally and other blocks fill up the missed block area, that makes the grid layout mess.

My proposed solution is: add "min-height:1px;" style to every grid block. Even the content in block was hidden, the block still has 1px height to hold the position of the missed block.

An demo about this issue is added in commit, I put it in functional test because I think it maybe helpful for testing this issue.
