### PR TITLE
Fix for #1196. <base> href getting extra '/' added to it in some cases.

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -140,7 +140,7 @@
 		//existing base tag?
 		$base = $head.children("base"),
 		hostURL = location.protocol + '//' + location.host,
-		docLocation = path.get( hostURL + location.pathname ),
+		docLocation = (location.pathname == '/') ? hostURL : path.get( hostURL + location.pathname ),
 		docBase = docLocation;
 
 		if ($base.length){


### PR DESCRIPTION
I have a url like this:

www.example.com/#/foo/1/

When I go to it, the page's base HREF gets incorrectly set to:
<code>< base href="http://www.example.com//offer/1/" > </code>

Note the extra "/" in the URL after the docBase.

It looks like when docLocation is set here its screwing up if <code>location.pathname</code> is just "/":

<pre><code>$base = $head.children("base"),
hostURL = location.protocol + '//' + location.host,
docLocation = path.get( hostURL + location.pathname ),
docBase = docLocation;</code></pre>


It think changing <code>docLocation</code> to this is a solution:

<pre><code>docLocation = (location.pathname == '/') ? hostURL : path.get( hostURL + location.pathname ),</code></pre>
