### PR TITLE
Fix for issue #1244: default cursor on listview dividers

### DIFF
--- a/themes/default/jquery.mobile.listview.css
+++ b/themes/default/jquery.mobile.listview.css
@@ -25,6 +25,7 @@ ol.ui-listview .ui-li-jsnumbering:before { content: "" !important; } /* to avoid
 
 .ui-li-aside { float: right; width: 50%; text-align: right; margin: .3em 0; }
 .min-width-480px .ui-li-aside { width: 45%; }
+.ui-li-divider { cursor: default; }
 .ui-li-has-alt .ui-btn-inner { padding-right: 95px; }
 .ui-li-count { position: absolute; font-size: 11px; font-weight: bold; padding: .2em .5em; top: 50%; margin-top: -.9em; right: 38px; }
 .ui-li-divider .ui-li-count { right: 10px; }


### PR DESCRIPTION
This is a fix for issue #1244: https://github.com/jquery/jquery-mobile/issues/1244

I tested select-lists and divided lists. Everything seems to work!
