### PR TITLE
Bug fix: allow multiple images in a <li> tag when rendering a listview.

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -128,7 +128,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 
 		item.find( "p, dl" ).addClass( "ui-li-desc" );
 
-		$list.find( "li" ).find( "img:eq(0)" ).addClass( "ui-li-thumb" ).each(function() {
+		$list.find( "li" ).children( "img:eq(0)" ).addClass( "ui-li-thumb" ).each(function() {
 			$( this ).closest( "li" )
 				.addClass( $(this).is( ".ui-li-icon" ) ? "ui-li-has-icon" : "ui-li-has-thumb" );
 		});


### PR DESCRIPTION
Only apply thumb style if <img> tag is on the first level. This fixes the problem when you want multiple images on each <li> element, like a 5 star rating for each element for example.

Now to add multiple images you just have to put them in a div inside the li. And if you want to add a thumbnail you just put the img tag right after the li.
