### PR TITLE
Added ui-disabled class to disabled buttons

### DIFF
--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -48,6 +48,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 				});
 			});
 		}
+		this.refresh();
 			
 	},
 
@@ -61,6 +62,15 @@ $.widget( "mobile.button", $.mobile.widget, {
 		this.element.attr("disabled", true);
 		this.button.addClass("ui-disabled").attr("aria-disabled", true);
 		return this._setOption("disabled", true);
+	},
+
+	refresh: function(){
+		if( this.element.attr('disabled') ){
+			this.disable();
+		}
+		else{
+			this.enable();
+		}
 	}
 });
 })( jQuery );


### PR DESCRIPTION
I created a refresh() method to be consistent with other widgets.  It checks if the underlying button is disabled and calls enable() or disable().   The refresh() method is called from _create.
