### PR TITLE
Url mapping for navigation

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -282,6 +282,25 @@
 	//enable cross-domain page support
 	$.mobile.allowCrossDomainPages = false;
 
+	$.mobile.urlMappings = {
+		// default mapping: matches all urls, does no transformations
+		all : {
+			// lowest priority
+			"priority" : 0,
+			// returns true if this mapping handles the specified url
+			"matches" : function(url) { return true; },
+
+			// rewrites the url before resolving, so nicer urls can be shown in the hash
+			"rewrite" : function(url) { return url; },
+
+			// data type for ajax retrieval
+			"dataType" : "html",
+
+			// applies a transforation to the retrieved data, for example json->html
+			"transform" : function(data) { return data; }
+		}
+	}
+
 	// changepage function
 	$.mobile.changePage = function( to, transition, reverse, changeHash, fromHashChange ){
 		//from is always the currently viewed page
@@ -531,12 +550,23 @@
 
 			$.mobile.pageLoading();
 
+			var urlMapping = $.mobile.urlMappings.all;
+			for(key in $.mobile.urlMappings) {
+				m = $.mobile.urlMappings[key];
+				if(m.matches(fileUrl) && m.priority > urlMapping.priority) {
+					urlMapping = m;
+				}
+			}
+
 			$.ajax({
-				url: fileUrl,
+				url: urlMapping.rewrite(fileUrl),
 				type: type,
 				data: data,
-				dataType: "html",
+				dataType: urlMapping.dataType,
 				success: function( html ) {
+
+					html = urlMapping.transform(html);
+
 					//pre-parse html to check for a data-url,
 					//use it as the new fileUrl, base path, etc
 					var all = $("<div></div>"),


### PR DESCRIPTION
I implemented an url mapping layer for navigation, basically to allow consuming a json url, but is generic enough to be useful for other situations.

There is a map of urlMappings, each with a priority, an url matcher function. Upon navigation, the mapping wich matches the target url with the highest mapping is selected.

Then, this mapping has methods for rewriting the url before making the (to hide potentially ugly restful urls, e.g. "#1234" -> "http://example.com/services/foo/bar/1234"

Also, upon retrieving the content there is a mapping method for converting e.g. from json to html.

Example usage:

$.mobile.urlMappings['browse'] = {
        "priority" : 10,
        "matches" : function(url) { return /b([0-9]+)/.test(url); },
        "rewrite" : function(url) { return 'http://example.com/items/' + /b([0-9]+)/.exec(url)[1]; + '.json'},
        "dataType" : "json",
        "transform" : function(result) { /\* generate and return html from json */ }
}
