### PR TITLE
Fix operation of "back" controls when using JQM in iFrames

### DIFF
--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -55,7 +55,17 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 	
 	//close method goes back in history
 	close: function(){
-		window.history.back();
+			//get the #url of the previous page in history, or the first page if there is no previous
+			var url = $.mobile.urlHistory.getPrev().url;
+			if (url === null || url == "") url = $.mobile.firstPage.attr("data-url");
+			url = "#" + url;
+			
+			//get the transition last used, or default to "pop"
+			var transition = $.mobile.urlHistory.getActive().transition || "pop";
+			
+			// change the page using the reverse transition
+			$.mobile.changePage(url, transition , true, true, true);
+			return false;
 	}
 });
 })( jQuery );

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -710,7 +710,17 @@
 
 		//if there's a data-rel=back attr, go back in history
 		if( $this.is( ":jqmData(rel='back')" ) ){
-			window.history.back();
+		
+			//get the #url of the previous page in history, or the first page if there is no previous
+			var url = $.mobile.urlHistory.getPrev().url;
+			if (url === null || url == "") url = $.mobile.firstPage.attr("data-url");
+			url = "#" + url;
+			
+			//get the transition last used, or use default
+			var transition = $.mobile.urlHistory.getActive().transition || "slide";
+			
+			// change the page using the reverse transition
+			$.mobile.changePage(url, transition , true, true, true);
 			return false;
 		}
 


### PR DESCRIPTION
This is a fix for the history functions when viewing an JQM-enabled apps in an iframe - see issue 560 for more details.
