### PR TITLE
data not being passed during beforehide and beforeshow events

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -355,9 +355,9 @@
 				//set as data for returning to that spot
 				from.data( "lastScroll", currScroll);
 				//trigger before show/hide events
-				from.data( "page" )._trigger( "beforehide", { nextPage: to } );
+				from.data( "page" )._trigger( "beforehide", null, { reverse: typeof reverse !== "undefined", nextPage: to } );
 			}	
-			to.data( "page" )._trigger( "beforeshow", { prevPage: from || $("") } );
+			to.data( "page" )._trigger( "beforeshow", null, { reverse: typeof reverse !== "undefined", prevPage: from || $("") } );
 
 			function loadComplete(){
 


### PR DESCRIPTION
The data is not being passed during the triggering of the beforehide and beforeshow events. This occurs in the transitionPages event. This is due to the data being passed as the event, inserting a null before the data object in the function call corrects this issue. Also added a reverse variable to indicate the direction of the transition.
