### PR TITLE
Automated home button creation

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -739,6 +739,13 @@
 			return;
 		}
 
+		//if there's a data-rel=home attr, go back home
+		if( $this.is( ":jqmData(rel='home')" ) ){
+			$.mobile.path.set("");
+			preventClickDefault = stopClickPropagation = true;
+			return;
+		}
+
 		//prevent # urls from bubbling
 		//path.get() is replaced to combat abs url prefixing in IE
 		if( url.replace(path.get(), "") == "#"  ){

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -9,8 +9,11 @@
 $.widget( "mobile.page", $.mobile.widget, {
 	options: {
 		backBtnText: "Back",
+		homeBtnText: "Home",
 		addBackBtn: true,
+		addHomeBtn: true,
 		backBtnTheme: null,
+		homeBtnTheme: null,
 		degradeInputs: {
 			color: false,
 			date: false,
@@ -87,6 +90,20 @@ $.widget( "mobile.page", $.mobile.widget, {
 						backBtn.attr( "data-"+ $.mobile.ns +"theme", o.backBtnTheme );
 					}
 				}
+
+				// auto-add home btn on pages beyond first view
+				if ( o.addHomeBtn && role === "header" &&
+						$( ".ui-page" ).length > 1 &&
+						!rightbtn && $this.jqmData( "homebtn" ) !== false ) {
+
+					var homeBtn = $( "<a href='#' class='ui-btn-right' data-"+ $.mobile.ns +"rel='home' data-"+ $.mobile.ns +"icon='home' data-iconpos='notext' alt='"+o.HomeBtnText+"'></a>" ).prependTo( $this );
+					
+					//if theme is provided, override default inheritance
+					if( o.homeBtnTheme ){
+						homeBtn.attr( "data-"+ $.mobile.ns +"theme", o.homeBtnTheme );
+					}
+				}
+
 
 				//page title
 				$this.children( "h1, h2, h3, h4, h5, h6" )


### PR DESCRIPTION
With this simple patches a home (no text, just icon) link is added to the header automatically when the right button is available, configurable the same way you do to the back button.

I liked the demo pages and noticed the home button was always hardcoded into the html.

The way I implemented it was by setting the path back to "" which simply clears everything after the # in the url, making it suitable for back button as well.
