### PR TITLE
Fixed yet another duplicate tap event bug.

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -81,7 +81,7 @@ $.event.special.tap = {
 				function clearTapHandlers() {
 					touching = false;
 					clearTimeout(timer);
-					$(this).unbind("vclick", clickHandler).unbind("vmousecancel", clearTapHandlers);
+					$this.unbind("vclick", clickHandler).unbind("vmousecancel", clearTapHandlers);
 				}
 				
 				function clickHandler(event) {


### PR DESCRIPTION
Line 81 of jquery.mobile.event.js says...

```
            function clearTapHandlers() {
                touching = false;
                clearTimeout(timer);
                $(this).unbind("vclick", clickHandler).unbind("vmousecancel", clearTapHandlers);
            }
```

The unbind line doesn't actually work because the this object at the moment clearTapHandlers() is called is not the DOM element with the tap event.
