### PR TITLE
tap event duplicating itself after each tap

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -81,7 +81,7 @@ $.event.special.tap = {
 				function clearTapHandlers() {
 					touching = false;
 					clearTimeout(timer);
-					$(this).unbind("vclick", clickHandler).unbind("vmousecancel", clearTapHandlers);
+					$this.unbind("vclick", clickHandler).unbind("vmousecancel", clearTapHandlers);
 				}
 				
 				function clickHandler(event) {


### PR DESCRIPTION
Go to /tests/functional/eventlogger.html under the project directory, and tap the screen. You'll find that the number of new tap messages generated for each tap increases by 1 for each tap in the past.

This bug is caused by clearTapHandlers() in jquery.mobile.event.js

```
            function clearTapHandlers() {
                touching = false;
                clearTimeout(timer);
                $(this).unbind("vclick", clickHandler).unbind("vmousecancel", clearTapHandlers);
            }
```

Because the "this" reference does not point to the DOM element with the tap event when clearTapHandlers() is called, the unbind() operation is ineffective.
