### PR TITLE
Removed alert(false) that appeared on first load when loadingMessage=false

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -34,10 +34,6 @@
 	//will not appear if $.mobile.loadingMessage is false
 	var $loader = $.mobile.loadingMessage ?		$( "<div class='ui-loader ui-body-a ui-corner-all'>" + "<span class='ui-icon ui-icon-loading spin'></span>" + "<h1>" + $.mobile.loadingMessage + "</h1>" + "</div>" )	: undefined;
 
-	if(typeof $loader === "undefined"){
-		alert($.mobile.loadingMessage);
-	}
-
 	$.extend($.mobile, {
 		// turn on/off page loading message.
 		pageLoading: function ( done ) {
@@ -46,11 +42,6 @@
 			} else {
 				if( $.mobile.loadingMessage ){
 					var activeBtn = $( "." + $.mobile.activeBtnClass ).first();
-
-
-					if(typeof $loader === "undefined"){
-						 alert($.mobile.loadingMessage);
-					}
 
 					$loader
 						.appendTo( $.mobile.pageContainer )


### PR DESCRIPTION
Removed alert(false) that appeared on first load when the loading dialog is disabled (loadingMessage = false).

I don't know what those 2 alerts where doing there and it actually took me a while to realize where the alert was coming from :)
