### PR TITLE
Update functional tests: bind click event to objects

### DIFF
--- a/tests/functional/addrbar.html
+++ b/tests/functional/addrbar.html
@@ -11,13 +11,13 @@
 	
 	<script>
 	$(function(){
-	$( "a" ).bind("tap",function( e ){
+	$( "a" ).bind("tap click",function( e ){
 			$("#log")
 				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"</li>")
 				.listview("refresh");
 			return false;
 		})
-		.bind("click", false);
+		.bind("tap click", false);
 	});	
 	</script>
 	

--- a/tests/functional/gridlayout.html
+++ b/tests/functional/gridlayout.html
@@ -10,19 +10,19 @@
 	
 	<script>
 	$(function(){
-		$(".ui-grid-d a").bind("tap", function(e){
+		$(".ui-grid-d a").bind("tap click", function(e){
 			$(this).hide();
 			$("#log")
 				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"; message: grid '"+$(this).text()+"' hidden</li>")
 				.listview("refresh");
 			return false;
-		}).bind("click", false);
-		$("#showbtn").bind("tap", function(e){
+		}).bind("tap click", false);
+		$("#showbtn").bind("tap click", function(e){
 			$(".ui-grid-d a").show();
 			$("#log")
 				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"; message: show all buttons</li>")
 				.listview("refresh");
-		}).bind("click", false);
+		}).bind("tap click", false);
 	});	
 	</script>
 </head> 


### PR DESCRIPTION
In jquerymobile 1.0a4, functional tests are not working in chrome of a PC. It seems tap event not triggered when user clicked mouse in a PC.

This commit update the tests, binding click event to the objects that already binded tap event.
It works on my PC with chrome.
