### PR TITLE
Dynamically insert thumbnail item at 0-index position doesn't update all style after listview refresh

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -29,7 +29,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 			$list.addClass( "ui-listview-inset ui-corner-all ui-shadow" );
 		}
 
-		this._itemApply( $list, $list );
+		this._itemApply( $list, $list.find("li") );
 		
 		this.refresh( true );
 
@@ -44,7 +44,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 
 		item.find( "p, dl" ).addClass( "ui-li-desc" );
 
-		$list.find( "li" ).find( ">img:eq(0), >:first>img:eq(0)" ).addClass( "ui-li-thumb" ).each(function() {
+		item.find( "img:eq(0)" ).addClass( "ui-li-thumb" ).each(function() {
 			$( this ).closest( "li" ).addClass( $(this).is( ".ui-li-icon" ) ? "ui-li-has-icon" : "ui-li-has-thumb" );
 		});
 

--- a/tests/functional/dynamicInsetList.html
+++ b/tests/functional/dynamicInsetList.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<title>jQuery Mobile: Grid Layout</title>
+	<link rel="stylesheet"  href="../../themes/default/" />
+	<link rel="stylesheet" href="../../docs/_assets/css/jqm-docs.css" />
+	<script type="text/javascript" src="../../js/jquery.js"></script>
+	<script type="text/javascript" src="../../js/"></script>
+	
+	<script>
+	$('#jqm-home').live('pagebeforeshow', function(event, ui){
+		tpl = '<li role="option" id="option%s"><a>Option %s</a></li>';
+
+		$('#test').prepend(tpl.replace(/%s/g, '0.5'));
+		$('#option2').before(tpl.replace(/%s/g, '1.5'));
+		$('#option2').after(tpl.replace(/%s/g, '2.5'));
+		$('#test').append(tpl.replace(/%s/g, '3.5'));
+		$('#test').listview("refresh");
+
+		$("li[id!='option2']").bind("tap click", function(e){
+			$(this).remove();
+			$("#log")
+				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"; message: grid '"+$(this).text()+"' hidden</li>")
+				.listview("refresh");
+		}).bind("tap click", false);
+	});	
+	</script>
+</head> 
+<body> 
+<div data-role="page" data-theme="b" id="jqm-home">
+	<div data-role="header">
+		<h1>Dynamic Inset List</h1>
+	</div>
+	
+	<div data-role="content">
+		<p>Touch events on this page will log out below, prepending to the top as they arrive.</p>
+		
+		<p>Option *.5s are dynamicly inserted when 'pagebeforeshow' event invoked. Click options to remove it.</p>
+		
+		<div data-role="listview" data-inset="true" id="test">
+			<li role="option" id="option1"><a>Option 1</a></li>
+			<li role="option" id="option2"><a href="#">Option 2</a></li>
+			<li role="option" id="option3"><a href="#">Option 3</a></li>
+		</div>
+		
+		<ul data-role="listview" id="log">
+			
+		</ul>
+
+	</div>
+</div>
+</body>
+</html>

--- a/tests/functional/dynamicInsetList.html
+++ b/tests/functional/dynamicInsetList.html
@@ -21,7 +21,7 @@
 		$('#test').append(tpl.replace(/%s/g, '3.5').replace(/%img/g, 'album-xx.jpg'));
 		$('#test').listview("refresh");
 
-		$("li[id!='option2']").bind("tap click", function(e){
+		$("li").bind("tap click", function(e){
 			$(this).remove();
 			$("#log")
 				.prepend("<li>"+ e.type +" event; target: "+ e.target.nodeName +"; message: grid '"+$(this).text()+"' hidden</li>")

--- a/tests/functional/dynamicInsetList.html
+++ b/tests/functional/dynamicInsetList.html
@@ -10,12 +10,15 @@
 	
 	<script>
 	$('#jqm-home').live('pagebeforeshow', function(event, ui){
-		tpl = '<li role="option" id="option%s"><a>Option %s</a></li>';
+		tpl = '<li role="option" id="option%s"><a href="#">';
+		tpl += '<img src="../../docs/lists/images/%img"/>';
+		tpl += '<h3>Option %s</h3>';
+		tpl += '<p>Option %s</p></a></li>';
 
-		$('#test').prepend(tpl.replace(/%s/g, '0.5'));
-		$('#option2').before(tpl.replace(/%s/g, '1.5'));
-		$('#option2').after(tpl.replace(/%s/g, '2.5'));
-		$('#test').append(tpl.replace(/%s/g, '3.5'));
+		$('#test').prepend(tpl.replace(/%s/g, '0.5').replace(/%img/g, 'album-bb.jpg'));
+		$('#option2').before(tpl.replace(/%s/g, '1.5').replace(/%img/g, 'album-p.jpg'));
+		$('#option2').after(tpl.replace(/%s/g, '2.5').replace(/%img/g, 'album-ws.jpg'));
+		$('#test').append(tpl.replace(/%s/g, '3.5').replace(/%img/g, 'album-xx.jpg'));
 		$('#test').listview("refresh");
 
 		$("li[id!='option2']").bind("tap click", function(e){
@@ -38,11 +41,23 @@
 		
 		<p>Option *.5s are dynamicly inserted when 'pagebeforeshow' event invoked. Click options to remove it.</p>
 		
-		<div data-role="listview" data-inset="true" id="test">
-			<li role="option" id="option1"><a>Option 1</a></li>
-			<li role="option" id="option2"><a href="#">Option 2</a></li>
-			<li role="option" id="option3"><a href="#">Option 3</a></li>
-		</div>
+		<ul data-role="listview" data-inset="true" id="test">
+			<li role="option" id="option1"><a href="#">
+				<img src="../../docs/lists/images/album-hc.jpg" />
+				<h3>Option 1</h3>
+				<p>Option 1</p>
+			</a></li>
+			<li role="option" id="option2"><a href="#">
+				<img src="../../docs/lists/images/album-ok.jpg" />
+				<h3>Option 2</h3>
+				<p>Option 2</p>
+			</a></li>
+			<li role="option" id="option3"><a href="#">
+				<img src="../../docs/lists/images/album-rh.jpg" />
+				<h3>Option 3</h3>
+				<p>Option 3</p>
+			</a></li>
+		</ul>
 		
 		<ul data-role="listview" id="log">
 			


### PR DESCRIPTION
Dynamically insert thumbnail item at the top of listview, then call listview('refresh'), not all styles applied to the inserted item (for me, 'ui-li-thumb' and 'ui-li-has-thumb' class not applied).

After some investigation, I found some codes in '_itemApply' of 'jquery.mobile.listview.js' doesn't work for first dynamically added item. 

The commits including 2 file changes, one is a functional test that can reproduce this issue, another is my solution to this issue.
