### PR TITLE
Attribute data-filtered=false on nodes to exclude text in data-filter lists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 cache/
 combined/
 combine/
+.idea
+*.iml
+*.ipr
+*.iws
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ combine/
 *.iml
 *.ipr
 *.iws
-
+jquery.mobile-*.css
+jquery.mobile-*.js

--- a/js/jquery.mobile.listview.filter.js
+++ b/js/jquery.mobile.listview.filter.js
@@ -41,12 +41,19 @@ $( ":jqmData(role='listview')" ).live( "listviewcreate", function() {
 							}
 							// New bucket!
 							childItems = false;
-						} else if (item.text().toLowerCase().indexOf( val ) === -1) {
-							item.hide();
-						} else {
-							// There's a shown item in the bucket
-							childItems = true;
-						}
+                        } else {
+                            var c = item.children();
+                            if(c.length && c.filter(':not([data-filtered=false])').text().toLowerCase().indexOf( val ) === -1) {
+                                // list is complex - takes text from child elements and do not include direct childs having data-filtered attribute to false
+                                item.hide();
+                            } else if (item.text().toLowerCase().indexOf( val ) === -1) {
+                                // list is simple - take all text directly
+                                item.hide();
+                            } else {
+                                // There's a shown item in the bucket
+                                childItems = true;
+                            }
+                        }
 					}
 				}
 			})


### PR DESCRIPTION
FEAT - enabled to add attribute data-filtered=false to direct child elements on list where data-filter is true so that the filter does not test potential text contained within these childs 

Example, when list items are like this:

```
<li><h3>{firstname} {lastname}</h3><span data-filtered="false">chat</span></li>
```
