### PR TITLE
Small typo in "Current browser support" link

### DIFF
--- a/docs/about/platforms.html
+++ b/docs/about/platforms.html
@@ -38,7 +38,7 @@
 				
 				<p>Since jQuery Mobile is built on the jQuery core, all pages should also work great on most recent versions of desktop browsers too - Firefox, Chrome, Safari, Internet Explorer, Opera, etc.</p>
 				
-				<p>For more information about browser support, view the <a href="https://github.com/jquery/jquery-mobile/wiki/Current-development-status-">current browser support status and known issues</a> and the project's target <a href="http://jquerymobile.com/gbs/" rel="external"><strong>graded browser matrix</strong>.</p>
+				<p>For more information about browser support, view the <a href="https://github.com/jquery/jquery-mobile/wiki/Current-development-status">current browser support status and known issues</a> and the project's target <a href="http://jquerymobile.com/gbs/" rel="external"><strong>graded browser matrix</strong>.</p>
 				
 
 						


### PR DESCRIPTION
Fixing a really small typo in "Current browser support" link at Alpha 4 post.
