### PR TITLE
Decoupling Navbar State from Button "active" State

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -30,6 +30,9 @@
 		//class used for "active" button state, from CSS framework
 		activeBtnClass: "ui-btn-active",
 
+		//class for active navbar button state
+		activeNavClass: "ui-nav-active",
+
 		//automatically handle clicks and form submissions through Ajax, when same-domain
 		ajaxEnabled: true,
 

--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -30,11 +30,12 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 				corners:	false, 
 				shadow:		false, 
 				iconpos:	iconpos
-			});
+			})
+			.addClass('ui-btn-nav');
 		
 		$navbar.delegate("a", "vclick",function(event){
-			$navbtns.not( ".ui-state-persist" ).removeClass( $.mobile.activeBtnClass );
-			$( this ).addClass( $.mobile.activeBtnClass );
+			$navbtns.not( ".ui-state-persist" ).removeClass( $.mobile.activeNavClass );
+			$( this ).addClass( $.mobile.activeNavClass );
 		});	
 	}
 });

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -731,7 +731,7 @@
 	$( document).bind( "vclick", function(event){
 		var link = findClosestLink(event.target);
 		if (link){
-			$(link).closest( ".ui-btn" ).not( ".ui-disabled" ).addClass( $.mobile.activeBtnClass );
+			$(link).closest( ".ui-btn" ).not( ".ui-disabled, .ui-btn-nav" ).addClass( $.mobile.activeBtnClass );
 		}
 	});
 

--- a/themes/default/jquery.mobile.theme.css
+++ b/themes/default/jquery.mobile.theme.css
@@ -603,7 +603,7 @@ a.ui-link-inherit {
 /* Active class used as the "on" state across all themes
 -----------------------------------------------------------------------------------------------------------*/
 
-.ui-btn-active {
+.ui-btn-active, .ui-nav-active {
 	border: 1px solid 		#155678;
 	background: 			#4596ce;
 	font-weight: bold;

--- a/themes/valencia/jquery.mobile.theme.css
+++ b/themes/valencia/jquery.mobile.theme.css
@@ -613,7 +613,7 @@ a.ui-link-inherit {
 }
 
 /* Active class used as the "on" state across all themes */
-.ui-btn-active {
+.ui-btn-active, .ui-nav-active {
   font-weight: bold;
   cursor: pointer;
   text-decoration: none;


### PR DESCRIPTION
Rather than using `ui-btn-active`, navbar widgets use `ui-nav-active`; allowing state to be easily managed by the application and retaining the toggle functionality of `ui-btn`s.
