### PR TITLE
Fix an alert(false) on app init when $.mobile.loadingMessage is set to false

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -34,10 +34,6 @@
 	//will not appear if $.mobile.loadingMessage is false
 	var $loader = $.mobile.loadingMessage ?		$( "<div class='ui-loader ui-body-a ui-corner-all'>" + "<span class='ui-icon ui-icon-loading spin'></span>" + "<h1>" + $.mobile.loadingMessage + "</h1>" + "</div>" )	: undefined;
 
-	if(typeof $loader === "undefined"){
-		alert($.mobile.loadingMessage);
-	}
-
 	$.extend($.mobile, {
 		// turn on/off page loading message.
 		pageLoading: function ( done ) {


### PR DESCRIPTION
The documentation says:

**loadingMessage (string, default: "loading"):**
Set the text that appears when a page is loading. If set to false, the message will not appear at all.

If you set this setting to false, you'll get an alert() popup with "false" message.
