### PR TITLE
jQuery Mobile: Fixed for the second issue in #1422 - IE7 locks up in infinite JS resize events

### DIFF
--- a/js/jquery.mobile.media.js
+++ b/js/jquery.mobile.media.js
@@ -64,30 +64,42 @@ function detectResolutionBreakpoints(){
 		newHtmlClassList = [],
 		finalClasses = "";
 
-	newHtmlClassList = $html.attr('className').split(/\s+/);
-	
-	allBreakpointClasses = (minPrefix + resolutionBreakpoints.join(unit + " " + minPrefix) + unit + " " +
-		maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix) + unit).split(/\s+/);
-	
-	$.each(allBreakpointClasses, function (i, breakpointClassName) {
-		var loc = jQuery.inArray(breakpointClassName, newHtmlClassList);
-		if (loc != -1) newHtmlClassList.splice(loc,1);
-	});
-	
-	$.each(resolutionBreakpoints,function( i, breakPoint ){
-		if( currWidth >= breakPoint ){
- 	 	minBreakpoints.push( minPrefix + breakPoint + unit );
-		}
-		if( currWidth <= breakPoint ){
- 	 	maxBreakpoints.push( maxPrefix + breakPoint + unit );
+	// Get classes, strip any existing resolution breakpoint classes
+	newHtmlClassList = $html.attr( 'className' ).split(/\s+/);
+
+	allBreakpointClasses = ( minPrefix + resolutionBreakpoints.join( unit + " " + minPrefix ) + unit + " " +
+		maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix ) + unit ).split(/\s+/);
+
+	$.each( allBreakpointClasses, function ( i, breakpointClassName ) {
+		var loc = jQuery.inArray( breakpointClassName, newHtmlClassList );
+		if ( loc !== -1 ) {
+			newHtmlClassList.splice( loc, 1 );
 		}
 	});
-	
-	if( minBreakpoints.length ){ breakpointClasses = minBreakpoints.join(" "); }
-	if( maxBreakpoints.length ){ breakpointClasses += " " + maxBreakpoints.join(" "); }
-	
-	finalClasses = newHtmlClassList.join(" ") + " " + breakpointClasses;
-	if ($html.attr('className') != finalClasses) $html.attr('className', finalClasses);
+
+	// Calculate new resolution breakpoint classes for window size
+	$.each(resolutionBreakpoints,function( i, breakPoint ) {
+		if ( currWidth >= breakPoint ) {
+			minBreakpoints.push( minPrefix + breakPoint + unit );
+		}
+		if ( currWidth <= breakPoint ) {
+			maxBreakpoints.push( maxPrefix + breakPoint + unit );
+		}
+	});
+
+	if ( minBreakpoints.length ) { 
+		breakpointClasses = minBreakpoints.join( " " );
+	}
+	if ( maxBreakpoints.length ) { 
+		breakpointClasses += " " + maxBreakpoints.join( " " );
+	}
+
+	// Compose new class list, compare with current class assignment and assign only if necessary
+	// Fixes #1422 - IE7 infinite event loop - changing className fires resize event, which calls this f(x)
+	finalClasses = newHtmlClassList.join( " " ) + " " + breakpointClasses;
+	if ( $html.attr( 'className' ) !== finalClasses ) { 
+		$html.attr( 'className', finalClasses );
+	}
 };
 
 /* $.mobile.addResolutionBreakpoints method:

--- a/js/jquery.mobile.media.js
+++ b/js/jquery.mobile.media.js
@@ -59,24 +59,35 @@ function detectResolutionBreakpoints(){
 		minBreakpoints = [],
 		maxBreakpoints = [],
 		unit = "px",
-		breakpointClasses;
+		breakpointClasses = "",
+		allBreakpointClasses = "",
+		newHtmlClassList = [],
+		finalClasses = "";
 
-	$html.removeClass( minPrefix + resolutionBreakpoints.join(unit + " " + minPrefix) + unit + " " +
-		maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix) + unit );
-
+	newHtmlClassList = $html.attr('className').split(/\s+/);
+	
+	allBreakpointClasses = (minPrefix + resolutionBreakpoints.join(unit + " " + minPrefix) + unit + " " +
+		maxPrefix + resolutionBreakpoints.join( unit + " " + maxPrefix) + unit).split(/\s+/);
+	
+	$.each(allBreakpointClasses, function (i, breakpointClassName) {
+		var loc = jQuery.inArray(breakpointClassName, newHtmlClassList);
+		if (loc != -1) newHtmlClassList.splice(loc,1);
+	});
+	
 	$.each(resolutionBreakpoints,function( i, breakPoint ){
 		if( currWidth >= breakPoint ){
-			minBreakpoints.push( minPrefix + breakPoint + unit );
+ 	 	minBreakpoints.push( minPrefix + breakPoint + unit );
 		}
 		if( currWidth <= breakPoint ){
-			maxBreakpoints.push( maxPrefix + breakPoint + unit );
+ 	 	maxBreakpoints.push( maxPrefix + breakPoint + unit );
 		}
 	});
-
+	
 	if( minBreakpoints.length ){ breakpointClasses = minBreakpoints.join(" "); }
-	if( maxBreakpoints.length ){ breakpointClasses += " " +  maxBreakpoints.join(" "); }
-
-	$html.addClass( breakpointClasses );
+	if( maxBreakpoints.length ){ breakpointClasses += " " + maxBreakpoints.join(" "); }
+	
+	finalClasses = newHtmlClassList.join(" ") + " " + breakpointClasses;
+	if ($html.attr('className') != finalClasses) $html.attr('className', finalClasses);
 };
 
 /* $.mobile.addResolutionBreakpoints method:


### PR DESCRIPTION
Fixed for the second issue in #1422 - IE7 locks up in infinite JS resize events when the window is sufficiently small ( <? 320px). 

The fix is to change how the detectResolutionBreakpoints function adds and removes classes from $html. The problem is that removing and adding those class names triggers the resize event again, resulting in infinite resize events. The solution is to come up with a new way to change the class names - by copying them off $html, adding and removing them locally in a variable, then checking to see if the class names have changed and applying the changed className string. 
