### PR TITLE
If 'input' element has id string with dots in it , code fails

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -14,7 +14,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			input = this.element,
 			//NOTE: Windows Phone could not find the label through a selector
 			//filter works though.
-			label = input.closest("form,fieldset,:jqmData(role='page')").find("label").filter("[for=" + input[0].id + "]"),
+			label = input.closest("form,fieldset,:jqmData(role='page')").find("label").filter("[for=\"" + input[0].id + "\"]"),
 			inputtype = input.attr( "type" ),
 			checkedicon = "ui-icon-" + inputtype + "-on",
 			uncheckedicon = "ui-icon-" + inputtype + "-off";

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -14,7 +14,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			input = this.element,
 			//NOTE: Windows Phone could not find the label through a selector
 			//filter works though.
-			label = input.closest("form,fieldset,:jqmData(role='page')").find("label").filter("[for=\"" + input[0].id + "\"]"),
+			label = input.closest("form,fieldset,:jqmData(role='page')").find("label").filter('[for="' + input[0].id + '"]'),
 			inputtype = input.attr( "type" ),
 			checkedicon = "ui-icon-" + inputtype + "-on",
 			uncheckedicon = "ui-icon-" + inputtype + "-off";

--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -32,7 +32,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 
 			selectID = select.attr( "id" ),
 
-			label = $( "label[for=\""+ selectID +"\"]" ).addClass( "ui-select" ),
+			label = $( 'label[for="'+ selectID +'"]' ).addClass( "ui-select" ),
 
 			//IE throws an exception at options.item() function when
 			//there is no selected item

--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -32,7 +32,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 
 			selectID = select.attr( "id" ),
 
-			label = $( "label[for="+ selectID +"]" ).addClass( "ui-select" ),
+			label = $( "label[for=\""+ selectID +"\"]" ).addClass( "ui-select" ),
 
 			//IE throws an exception at options.item() function when
 			//there is no selected item

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -28,7 +28,7 @@ $.widget( "mobile.slider", $.mobile.widget, {
 			selectClass = (cType == 'select') ? 'ui-slider-switch' : '',
 			controlID = control.attr('id'),
 			labelID = controlID + '-label',
-			label = $('[for='+ controlID +']').attr('id',labelID),
+			label = $('[for="'+ controlID +'"]').attr('id',labelID),
 			val = function(){
 				return (cType == 'input') ? parseFloat(control.val()) : control[0].selectedIndex;
 			},

--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -24,7 +24,7 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 		
 		themeclass = " ui-body-" + theme;
 		
-		$('label[for='+input.attr('id')+']').addClass('ui-input-text');
+		$('label[for="'+input.attr('id')+'"]').addClass('ui-input-text');
 		
 		input.addClass('ui-input-text ui-body-'+ o.theme);
 		


### PR DESCRIPTION
let say ID of an input is "x.y.z" then query
<input id="x.y.z" type="text" name="blah"/>

$("label[for=x.y.z]") GONNA FAIL

$("label[for=\"x.y.z\"]") GONNA WORK
