### PR TITLE
Fix for calendar widget creating multiple calendars in multi-page HTML

### DIFF
--- a/experiments/ui-datepicker/jquery.ui.datepicker.mobile.js
+++ b/experiments/ui-datepicker/jquery.ui.datepicker.mobile.js
@@ -48,7 +48,7 @@
 		
 	//bind to pagecreate to automatically enhance date inputs	
 	$( ".ui-page" ).live( "pagecreate", function(){		
-		$( "input[type='date'], input:jqmData(type='date')" ).each(function(){
+		$( "input[type='date'], input:jqmData(type='date')", this ).each(function(){
 			$(this).after( $( "<div />" ).datepicker({ altField: "#" + $(this).attr( "id" ), showOtherMonths: true }) );
 		});	
 	});


### PR DESCRIPTION
The each callback in the pagecreate method was creating multiple calendars when used with a multi-page html file because it was not scoped to the current page but instead to the entire document.
