### PR TITLE
Resolve issue #1514

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -577,7 +577,7 @@
 							newPageTitle = html.match( /<title[^>]*>([^<]*)/ ) && RegExp.$1,
 
 							// TODO handle dialogs again
-							pageElemRegex = new RegExp( ".*(<[^>]+\\bdata-" + $.mobile.ns + "role=[\"']?page[\"']?[^>]*>).*" ),
+							pageElemRegex = new RegExp( "(<[^>]+\\bdata-" + $.mobile.ns + "role=[\"']?page[\"']?[^>]*>)" ),
 							dataUrlRegex = new RegExp( "\\bdata-" + $.mobile.ns + "url=[\"']?([^\"'>]*)[\"']?" );
 
 					// data-url must be provided for the base tag so resource requests can be directed to the


### PR DESCRIPTION
Remove greedy matches from start and end of regex - there's no need for them, and they cause immense slowdown (on the order of 3-4 seconds on medium-size pages loaded via ajax).
