### PR TITLE
Resolve issue #1551

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -614,9 +614,6 @@
 							var thisAttr = $( this ).is( "[href]" ) ? "href" : "src",
 								thisUrl = $( this ).attr( thisAttr );
 
-							//if full path exists and is same, chop it - helps IE out
-							thisUrl = thisUrl.replace( location.protocol + "//" + location.host + location.pathname, "" );
-
 							if( ! /^(\w+:|#|\/)/.test( thisUrl ) ) {
 								$( this ).attr( thisAttr, newPath + thisUrl );
 							}


### PR DESCRIPTION
Remove a string replacement which claims to be for IE's benefit but which doesn't even run in IE - only runs in Firefox < 4, where it breaks some images.
