### PR TITLE
fix for issue 1530: Page title is changing when I use popup select menu ( Dropdown)

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -458,7 +458,7 @@
 				}
 
 				//if title element wasn't found, try the page div data attr too
-				var newPageTitle = to.jqmData( "title" ) || to.find( ".ui-header .ui-title" ).text();
+				var newPageTitle = to.jqmData( "title" ) || to.find( ":jqmData(role='header') .ui-title" ).text();
 				if( !!newPageTitle && pageTitle === document.title ) {
 					pageTitle = newPageTitle;
 				}


### PR DESCRIPTION
Replace .ui-header with :jqmData(role="header") when copying h1.ui-title to the title element, so that it does not mistakenly take the title from select's placeholder option.
