### PR TITLE
jquery.mobile.support.js: Whitespace changes only. Bring code up to jQuer

### DIFF
--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -4,74 +4,74 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) and GPL (GPL-LICENSE.txt) licenses.
 * Note: Code is in draft form and is subject to change 
 */
-(function($, undefined ) {
+( function( $, undefined  ) {
 
-
-
-var fakeBody = $( "<body>" ).prependTo( "html" ),
-	fbCSS = fakeBody[0].style,
-	vendors = ['webkit','moz','o'],
+var fakeBody = $( "<body>"  ).prependTo( "html" ),
+	fbCSS = fakeBody[ 0 ].style,
+	vendors = [ "webkit", "moz", "o" ],
 	webos = "palmGetResource" in window, //only used to rule out scrollTop 
 	bb = window.blackberry; //only used to rule out box shadow, as it's filled opaque on BB
 
-//thx Modernizr
-function propExists( prop ){
-	var uc_prop = prop.charAt(0).toUpperCase() + prop.substr(1),
-		props   = (prop + ' ' + vendors.join(uc_prop + ' ') + uc_prop).split(' ');
-	for(var v in props){
-		if( fbCSS[ v ] !== undefined ){
+// thx Modernizr
+function propExists( prop  ){
+	var uc_prop = prop.charAt( 0 ).toUpperCase() + prop.substr( 1 ),
+		props   = ( prop + " " + vendors.join( uc_prop + " " ) + uc_prop ).split( " " );
+	for( var v in props ){
+		if( fbCSS[ v ] !== undefined  ){
 			return true;
 		}
 	}
-};
+}
 
-//test for dynamic-updating base tag support (allows us to avoid href,src attr rewriting)
+// test for dynamic-updating base tag support ( allows us to avoid href,src attr rewriting )
 function baseTagTest(){
-	var fauxBase = location.protocol + '//' + location.host + location.pathname + "ui-dir/",
-		base = $("head base"),
+	var fauxBase = location.protocol + "//" + location.host + location.pathname + "ui-dir/",
+		base = $( "head base" ),
 		fauxEle = null,
-		href = '';
-	if (!base.length) {
-		base = fauxEle = $("<base>", {"href": fauxBase}).appendTo("head");
+		href = "";
+	if ( !base.length ) {
+		base = fauxEle = $( "<base>", { "href": fauxBase} ).appendTo( "head" );
 	}
 	else {
-		href = base.attr("href");
+		href = base.attr( "href" );
 	}
-	var link = $( "<a href='testurl'></a>" ).prependTo( fakeBody ),
-		rebase = link[0].href;
-	base[0].href = href ? href : location.pathname;
-	if (fauxEle) {
+	var link = $( "<a href='testurl'></a>"  ).prependTo( fakeBody  ),
+		rebase = link[ 0 ].href;
+	base[ 0 ].href = href ? href : location.pathname;
+	if ( fauxEle ) {
 		fauxEle.remove();
 	}
-	return rebase.indexOf(fauxBase) === 0;
-};
+	return rebase.indexOf( fauxBase ) === 0;
+}
 
 
-//non-UA-based IE version check by James Padolsey, modified by jdalton - from http://gist.github.com/527683
-//allows for inclusion of IE 6+, including Windows Mobile 7
+// non-UA-based IE version check by James Padolsey, modified by jdalton - from http://gist.github.com/527683
+// allows for inclusion of IE 6+, including Windows Mobile 7
 $.mobile.browser = {};
-$.mobile.browser.ie = (function() {
-    var v = 3, div = document.createElement('div'), a = div.all || [];
-    while (div.innerHTML = '<!--[if gt IE '+(++v)+']><br><![endif]-->', a[0]); 
+$.mobile.browser.ie = ( function() {
+    var v = 3, 
+	div = document.createElement( "div" ), 
+	a = div.all || [];
+    while ( div.innerHTML = "<!--[if gt IE " + ( ++v ) + "]><br><![endif]-->", a[ 0 ] ); 
     return v > 4 ? v : !v;
-}());
+}() );
 
 $.extend( $.support, {
 	orientation: "orientation" in window,
 	touch: "ontouchend" in document,
 	cssTransitions: "WebKitTransitionEvent" in window,
 	pushState: !!history.pushState,
-	mediaquery: $.mobile.media('only all'),
-	cssPseudoElement: !!propExists('content'),
-	boxShadow: !!propExists('boxShadow') && !bb,
-	scrollTop: ("pageXOffset" in window || "scrollTop" in document.documentElement || "scrollTop" in fakeBody[0]) && !webos,
+	mediaquery: $.mobile.media( "only all" ),
+	cssPseudoElement: !!propExists( "content" ),
+	boxShadow: !!propExists( "boxShadow" ) && !bb,
+	scrollTop: ( "pageXOffset" in window || "scrollTop" in document.documentElement || "scrollTop" in fakeBody[ 0 ] ) && !webos,
 	dynamicBaseTag: baseTagTest(),
-	eventCapture: ("addEventListener" in document) // This is a weak test. We may want to beef this up later.
-});
+	eventCapture: ( "addEventListener" in document ) // This is a weak test. We may want to beef this up later.
+} );
 
 fakeBody.remove();
 
-//for ruling out shadows via css
-if( !$.support.boxShadow ){ $('html').addClass('ui-mobile-nosupport-boxshadow'); }
+// for ruling out shadows via css
+if( !$.support.boxShadow  ){ $( "html" ).addClass( "ui-mobile-nosupport-boxshadow" ); }
 
-})( jQuery );
+} )( jQuery  );


### PR DESCRIPTION
jquery.mobile.support.js: Whitespace changes only. Bring code up to jQuery coding standards in anticipation of adding Opera Mini feature detection. Passes jsHint except for the James Padolsey/ jdalton non-UA-based IE version check, which is OK. All tests pass.

Signed-off-by: Steven Black steveb@stevenblack.com
