### PR TITLE
listview: Allow tall list items to optionally disable automatic positioning of their image

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -34,7 +34,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 			.addClass( "ui-btn-up-" + ($list.jqmData( "counttheme" ) || this.options.countTheme) + " ui-btn-corner-all" ).end()
 		.find( "h1, h2, h3, h4, h5, h6" ).addClass( "ui-li-heading" ).end()
 		.find( "p, dl" ).addClass( "ui-li-desc" ).end()
-		.find("img:first-child:eq(0)").addClass( "ui-li-thumb" ).each(function() {
+		.find("img:first-child:eq(0)").not(".ui-li-custom").addClass( "ui-li-thumb" ).each(function() {
 			item.addClass( $(this).is( ".ui-li-icon" ) ? "ui-li-has-icon" : "ui-li-has-thumb" );
 		}).end()
 		.find( ".ui-li-aside" ).each(function() {


### PR DESCRIPTION
This patch allows images in list views to add class 'ui-li-custom' and they will not be automatically positioned.

I would like my icons in a list view item to be middle aligned rather than absolutely positioned at the top.

I'm new to JQuery (and Github and CSS) so it's quite possible there's a better way to do this. Thanks for your consideration.
