### PR TITLE
#1635 Collapsible not triggering resize event

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -87,6 +87,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 							.find('a:eq(0), .ui-btn-inner')
 							.addClass('ui-corner-bottom');
 					}
+				        $(window).trigger('resize');
 				}						
 				
 			})
@@ -105,7 +106,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 							.find('a:eq(0), .ui-btn-inner')
 							.removeClass('ui-corner-bottom');
 					}
-					
+				        $(window).trigger('resize');
 				}
 			})
 			.trigger(o.collapsed ? 'collapse' : 'expand');

--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -87,7 +87,6 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 							.find('a:eq(0), .ui-btn-inner')
 							.addClass('ui-corner-bottom');
 					}
-				        $(window).trigger('resize');
 				}						
 				
 			})
@@ -106,7 +105,6 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 							.find('a:eq(0), .ui-btn-inner')
 							.removeClass('ui-corner-bottom');
 					}
-				        $(window).trigger('resize');
 				}
 			})
 			.trigger(o.collapsed ? 'collapse' : 'expand');

--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -128,8 +128,10 @@ $.fixedToolbars = (function(){
 		
 		$.fixedToolbars.show(true, this);	
 	});
+        //When a collapsiable is hidden or shown we need to trigger the fixed toolbar to reposition itself (#1635)
+        $('.ui-collapsible-contain').live('collapse',showEventCallback);
+        $('.ui-collapsible-contain').live('expand',showEventCallback);
 
-	
 	// element.getBoundingClientRect() is broken in iOS 3.2.1 on the iPad. The
 	// coordinates inside of the rect it returns don't have the page scroll position
 	// factored out of it like the other platforms do. To get around this,


### PR DESCRIPTION
I fixed the bug where a resize event was not triggered when collapsible items were collapsed and expanded. Issue #1635

The bug can be seen here:
http://jsbin.com/ayosu3/7/edit

Things look a little choppy with this patch but I think that is a problem with how the fixed headers and footers refresh after a resize event.
