### PR TITLE
Detach placeholder options when using nativeMenu and hidePlaceholderMenuItems is true

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -194,6 +194,17 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 						.removeClass( $.mobile.activeBtnClass );
 				});
 
+			// Hide placeholder items if desired
+			if( o.hidePlaceholderMenuItems ){
+				select.find( "option" ).each(function( i ){
+					var $this = $(this),
+					text = $this.text();
+					if( !this.getAttribute('value') || text.length == 0 || $this.jqmData('placeholder') ){
+						$this.detach();
+					}
+				});
+			}
+
 
 		} else {
 


### PR DESCRIPTION
This resolves Issue #1670 (selectmenu doesn't hide placeholder items when using nativeMenu)
