### PR TITLE
Root index.html:  Adding a back button to every subsequent demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
 	<link rel="stylesheet" href="docs/_assets/css/jqm-docs.css" />
 	<script src="js/jquery.js"></script>
 	<script src="js/"></script>
+	<script>
+		// Add a back button to every subsequent page created by the page widget.
+		$.mobile.page.prototype.option( { addBackBtn: true } );
+	</script>
 	<script src="experiments/themeswitcher/jquery.mobile.themeswitcher.js"></script>
 	<script src="docs/_assets/js/jqm-docs.js"></script>
 </head> 


### PR DESCRIPTION
Root index.html:  Adding a back button to every subsequent page in the jQuery Mobile demos.

Rationale: even though we don't add a back button by default anymore, back buttons increase the usability of the jQuery Mobile demos since these play for new users who don't "get" the mobile model yet.

Signed-off-by: Steven Black steveb@stevenblack.com
