### PR TITLE
Scroll bug with Collapsible

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -56,9 +56,8 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 			
 			if( !collapsibleParent.length ){
 				collapsibleHeading
-					.find('a:eq(0)')	
-				                 .find('.ui-btn-inner')
-				                        .addClass('ui-corner-all');
+				     .find('.ui-btn-inner')
+				          .addClass('ui-corner-all');
 			}
 			else {
 				if( collapsibleContain.jqmData('collapsible-last') ){

--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -57,9 +57,8 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 			if( !collapsibleParent.length ){
 				collapsibleHeading
 					.find('a:eq(0)')	
-					.addClass('ui-corner-all')
-						.find('.ui-btn-inner')
-						.addClass('ui-corner-all');
+				                 .find('.ui-btn-inner')
+				                        .addClass('ui-corner-all');
 			}
 			else {
 				if( collapsibleContain.jqmData('collapsible-last') ){

--- a/themes/default/jquery.mobile.collapsible.css
+++ b/themes/default/jquery.mobile.collapsible.css
@@ -4,7 +4,7 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
 */
 .ui-collapsible-contain { margin: .5em 0; }
-.ui-collapsible-heading { font-size: 16px; display: block; margin: 0 -8px; padding: 0; border-width: 0 0 1px 0; position: relative; }
+.ui-collapsible-heading { font-size: 16px; display: block; margin: 0 0px; padding: 0; border-width: 0 0 1px 0; position: relative; }
 .ui-collapsible-heading a { text-align: left; margin: 0;  }
 .ui-collapsible-heading a .ui-btn-inner { padding-left: 40px; }
 .ui-collapsible-heading a span.ui-btn { position: absolute; left: 6px; top: 50%; margin: -12px 0 0 0; width: 20px; height: 20px; padding: 1px 0px 1px 2px; text-indent: -9999px; }


### PR DESCRIPTION
On an iPod 3G iOS 4.1, collapsible headings were causing overflow and horizontal scroll.  Fixed the css to remove the -8px margin and removed the ui-corner-all class from the heading.  Tested in Google Chrome and on iPod.
