### PR TITLE
Resolves Issue1688

### DIFF
--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -31,8 +31,8 @@ $.widget( "mobile.page", $.mobile.widget, {
 
 	_create: function() {
 		var $elem = this.element,
-			o = this.options;
-
+			o = this.options,
+			factory= this;
 		this.keepNative = ":jqmData(role='none'), :jqmData(role='nojs')" + (o.keepNative ? ", " + o.keepNative : "");
 
 		if ( this._trigger( "beforeCreate" ) === false ) {
@@ -49,7 +49,7 @@ $.widget( "mobile.page", $.mobile.widget, {
 		$elem.find( ":jqmData(role='nojs')" ).addClass( "ui-nojs" );
 
 		// pre-find data els
-		var $dataEls = $elem.find( ":jqmData(role)" ).andSelf().each(function() {
+		var $dataEls = $elem.find( ":jqmData(role)" ).andSelf().each( function() {
 			var $this = $( this ),
 				role = $this.jqmData( "role" ),
 				theme = $this.jqmData( "theme" );
@@ -74,17 +74,24 @@ $.widget( "mobile.page", $.mobile.widget, {
 					rightbtn = $headeranchors.eq( 1 ).addClass( "ui-btn-right" ).length;
 				}
 
-				// auto-add back btn on pages beyond first view
-				if ( o.addBackBtn && role === "header" &&
-						$( ".ui-page" ).length > 1 &&
-						$elem.jqmData( "url" ) !== $.mobile.path.stripHash( location.hash ) &&
-						!leftbtn && $this.jqmData( "backbtn" ) !== false ) {
+				// Back button reckoning on pages beyond first view and header position is available
+				if ( role === "header" && 
+						$( ".ui-page" ).length > 1 && 
+						!leftbtn && 
+						$elem.jqmData( "url" ) !== $.mobile.path.stripHash( location.hash ) ) {
 
-					var backBtn = $( "<a href='#' class='ui-btn-left' data-"+ $.mobile.ns +"rel='back' data-"+ $.mobile.ns +"icon='arrow-l'>"+ o.backBtnText +"</a>" ).prependTo( $this );
-					
-					//if theme is provided, override default inheritance
-					if( o.backBtnTheme ){
-						backBtn.attr( "data-"+ $.mobile.ns +"theme", o.backBtnTheme );
+					var elemBackBtnSpec = $this.jqmData( "backbtn" );
+
+					//if specified globally and not overridden, or on the page element via data-add-back-btn="true", then add the back btn 
+					if ( o.addBackBtn  ) {
+						if ( elemBackBtnSpec !== false ) {
+							factory._addBackButton( $this );
+						}	
+					} else {
+						// alternately, the header element may specify a back button
+						if ( elemBackBtnSpec === true ) {
+							factory._addBackButton( $this );
+						}
 					}
 				}
 
@@ -124,7 +131,7 @@ $.widget( "mobile.page", $.mobile.widget, {
 		});
 
 		//enhance form controls
-  	this._enhanceControls();
+		this._enhanceControls();
 
 		//links in bars, or those with  data-role become buttons
 		$elem.find( ":jqmData(role='button'), .ui-bar > a, .ui-header > a, .ui-footer > a" )
@@ -206,7 +213,16 @@ $.widget( "mobile.page", $.mobile.widget, {
 		nonNativeControls
 			.filter( "select:not(:jqmData(role='slider'))" )
 			.selectmenu();
+	},
+	_addBackButton: function( target ) {
+		var o = this.options, 
+			backBtn = $( "<a href='#' class='ui-btn-left' data-"+ $.mobile.ns +"rel='back' data-"+ $.mobile.ns +"icon='arrow-l'>"+ o.backBtnText +"</a>" ).prependTo( target );
+		//if theme is provided, override default inheritance
+		if( o.backBtnTheme ){
+			backBtn.attr( "data-"+ $.mobile.ns +"theme", o.backBtnTheme );
+		}
 	}
 });
 
 })( jQuery );
+

--- a/tests/unit/page/index.html
+++ b/tests/unit/page/index.html
@@ -25,20 +25,21 @@
 </ol>
 
 <div id="qunit-fixture">
-	<div  data-nstest-role="page">
-		<div  data-nstest-role="header">
+	<div data-nstest-role="page">
+		<div data-nstest-role="header">
 			<div>
 				<a href="foo">foo</a>
 			</div>
 			<a href="foo">foo</a>
 		</div><!-- /header -->
 
-		<div  data-nstest-role="footer">
+		<div data-nstest-role="footer">
 			<div>
 				<a href="foo">foo</a>
 			</div>
 
 			<a href="foo">foo</a>
+			<a id="secondPage" href="#page-with-backbtn">next page</a>
 		</div><!-- /header -->
 
 		<div class="ui-bar">
@@ -49,5 +50,11 @@
 			<a href="foo">foo</a>
 		</div>
 	</div>
+	<div id="page-with-backbtn" data-nstest-role="page">
+		<div data-nstest-role="header" data-nstest-backbtn="true">
+			<h3>Header Title</h3>
+		</div><!-- /header -->
+	</div>
+</div>
 </body>
 </html>

--- a/tests/unit/page/page_core.js
+++ b/tests/unit/page/page_core.js
@@ -45,4 +45,16 @@
 
 		ok(!typeAttributeRegex.test( "<inputtype=\"range\"" ), "requires preceding space" );
 	});
+
+	asyncTest( "subsequent page with backbtn spec has a back button", function(){
+		$.testHelper.sequence([
+			// transition to the second page
+			function(){ $("#secondPage").click(); },
+			function(){
+				ok( $( "[data-nstest-rel='back']" ).length === 1 );
+				start();
+			}
+		], 1000);
+	});
+
 })(jQuery);


### PR DESCRIPTION
Resolves issue 1688 -- `data-backbtn="true"` is now respected on `data-role="header"` containers.  This provides symmetry for the `data-backbtn="false"` directive which is used to override auto-generated back buttons.

Includes a new related unit test for the page widget.
