### PR TITLE
$.mobile.removePage() & Issue #1554 fix

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -728,6 +728,23 @@
 		duplicateCachedPage: undefined,
 		pageContainer: undefined
 	};
+	
+	//remove page(s) from the DOM
+	//removes all pages passed by selector or reference EXCEPT the active page and the root/origin page.
+	$.mobile.removePage = function( selector ) {
+		var toRemove;
+		if ( typeof selector !== "string" ) {
+			toRemove= jQuery( selector );
+		} else {
+			// by url, id, class, or other user-supplied selector
+			var toRemove= $( ":jqmData(url='" + selector + "'), " + selector );
+		}
+		if ( toRemove.length ) {
+			// remove only pages that aren't currently active, nor origin.
+			toRemove.filter( ":jqmData(role=page)" ).not( ".ui-page-active, :jqmData(url='" + $.mobile.urlHistory.stack[0].url + "')" ).remove();
+		}
+	};
+	
 
 /* Event Bindings - hashchange, submit, and click */
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -736,8 +736,15 @@
 		if ( typeof selector !== "string" ) {
 			toRemove= jQuery( selector );
 		} else {
-			// by url, id, class, or other user-supplied selector
-			var toRemove= $( ":jqmData(url='" + selector + "'), " + selector );
+			//by data-url...
+			try {
+				//there are failure cases to trap, for example when selector= ":jqmData(url='anything')", a plausible passed-in parameter.
+				toRemove= $( ":jqmData(url='" + selector + "')");
+			} catch( e ) {
+				toRemove= $();
+			}
+			//... and/or id, class, or other user-supplied selector
+			toRemove.add( selector );
 		}
 		if ( toRemove.length ) {
 			// remove only pages that aren't currently active, nor origin.

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -755,6 +755,14 @@
 
 /* Event Bindings - hashchange, submit, and click */
 
+	//data-cache="false" on pages -- invoke $.mobile.removePage()
+	$( document ).bind( "pagehide", function( event, data ) {
+		var hiddenPage= $( event.target );
+		if ( hiddenPage.jqmData( "cache" ) === false ) {
+ 			$.mobile.removePage( hiddenPage );
+		}
+    });
+
 	//bind to form submit events, handle with Ajax
 	$( "form" ).live('submit', function( event ) {
 		var $this = $( this );

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -11,6 +11,7 @@ $.widget( "mobile.page", $.mobile.widget, {
 		backBtnText: "Back",
 		addBackBtn: false,
 		backBtnTheme: null,
+		cache: true,
 		degradeInputs: {
 			color: false,
 			date: false,
@@ -104,6 +105,9 @@ $.widget( "mobile.page", $.mobile.widget, {
 
 			} else if ( role === "page" ) {
 				$this.addClass( "ui-body-" + (theme || "c") );
+				if ( o.cache === false ) {
+					$this.attr( "data-"+ $.mobile.ns +"cache", "false" )
+				}
 			}
 
 			switch(role) {

--- a/tests/unit/navigation/index.html
+++ b/tests/unit/navigation/index.html
@@ -223,6 +223,27 @@
 
 </div>
 
+<div id="removePageTest-first" data-nstest-role="page">
+  <a href="#removePageTest-second" data-nstest-transition="slideup" data-nstest-role="button" >
+		Page 2
+	</a>
+</div>
+
+<div id="removePageTest-second" data-nstest-role="page">
+	<a href="#removePageTest-third" data-nstest-transition="slideup" data-nstest-role="button" >
+		Page 3
+	</a>
+</div>
+
+<div id="removePageTest-third" data-nstest-role="page">
+  <a href="#removePageTest-first" data-nstest-transition="slideup" data-nstest-role="button">
+		Page 1
+	</a>
+  <a href="#removePageTest-second" data-nstest-transition="slideup" data-nstest-role="button">
+		Page 2
+	</a>
+</div>
+
 <div data-nstest-role="page" id="pathing-tests-reset">
 	<div class="reset-value">page didn't change!</div>
 </div>

--- a/tests/unit/navigation/index.html
+++ b/tests/unit/navigation/index.html
@@ -236,12 +236,12 @@
 </div>
 
 <div id="removePageTest-third" data-nstest-role="page">
-  <a href="#removePageTest-first" data-nstest-transition="slideup" data-nstest-role="button">
-		Page 1
+	<a href="#removePageTest-fourth" data-nstest-transition="slideup" data-nstest-role="button">
+		Page 4
 	</a>
-  <a href="#removePageTest-second" data-nstest-transition="slideup" data-nstest-role="button">
-		Page 2
-	</a>
+</div>
+
+<div id="removePageTest-fourth" data-nstest-role="page" data-nstest-cache="false">
 </div>
 
 <div data-nstest-role="page" id="pathing-tests-reset">

--- a/tests/unit/navigation/navigation_core.js
+++ b/tests/unit/navigation/navigation_core.js
@@ -422,4 +422,46 @@
 			}
 		], 1000);
 	});
+	
+	//$.mobile.removePage() tests.   This test REMOVES PAGES so best keep this last.
+	asyncTest( "$.mobile.removePage() tests", function(){
+
+		$.testHelper.openPage("#removePageTest-first");
+
+		$.testHelper.sequence([
+			function(){ $("#removePageTest-first a:first").click(); },
+			function(){ $("#removePageTest-second a:first").click(); },
+			function(){
+				
+				// how many pages are we starting with
+				var numPages= $( ":jqmData(role='page')" ).length,
+					numElements= $("*").length;
+				
+				//passing nothing to $.mobile.removePage()
+				$.mobile.removePage();
+				same( numElements, numElements= $("*").length, "Passing nothing to $.mobile.removePage() does nothing");
+				
+				//passing nonsense to $.mobile.removePage()
+				$.mobile.removePage( "qwuyetshets");
+				same( numElements, numElements= $("*").length, "Passing nonsense to $.mobile.removePage() does nothing");
+
+				//passing unrelated selectors to $.mobile.removePage()
+				$.mobile.removePage( "a" );
+				same( numElements, numElements= $("*").length, "Passing unrelated but valid string selectors to $.mobile.removePage() does nothing");
+				
+				//passing unrelated jQuery collections to $.mobile.removePage()
+				$.mobile.removePage( $("a") );
+				same( numPages, numPages= $( ":jqmData(role='page')" ).length, "Passing unrelated jQuery collections to $.mobile.removePage() does nothing");
+				
+				//try deleting the active page
+				$.mobile.removePage(".ui-page-active");
+				same( numPages, numPages= $( ":jqmData(role='page')" ).length, "$.mobile.removePage() doesn\'t remove the active page");
+
+				//try deleting the home page
+				$.mobile.removePage( $.mobile.urlHistory.stack[0].url );
+				same( numPages, numPages= $( ":jqmData(role='page')" ).length, "$.mobile.removePage() doesn\'t remove the home page");
+
+				start();
+			}], 1000);
+	});
 })(jQuery);

--- a/tests/unit/navigation/navigation_core.js
+++ b/tests/unit/navigation/navigation_core.js
@@ -432,7 +432,6 @@
 			function(){ $("#removePageTest-first a:first").click(); },
 			function(){ $("#removePageTest-second a:first").click(); },
 			function(){
-				
 				// how many pages are we starting with
 				var numPages= $( ":jqmData(role='page')" ).length,
 					numElements= $("*").length;
@@ -460,8 +459,14 @@
 				//try deleting the home page
 				$.mobile.removePage( $.mobile.urlHistory.stack[0].url );
 				same( numPages, numPages= $( ":jqmData(role='page')" ).length, "$.mobile.removePage() doesn\'t remove the home page");
-
+			},
+			//testing data-cache="false"
+			function() { $("#removePageTest-third a:first").click(); },
+			// transition back past the dialog
+			function() { window.history.back(); },
+			function() {
+				same(  $("#removePageTest-fourth").length, 0, "page with data-cache=\"false\" does not persist in the DOM" );
 				start();
-			}], 1000);
+		}], 1000);
 	});
-})(jQuery);
+})( jQuery );


### PR DESCRIPTION
$.mobile.removePage() is a standalone function to scrub pages from the DOM.  

Includes unit tests.

**Subsequently**: Resolved Issue #1554 into the same branch, same pull.
