### PR TITLE
jquery.mobile.dialog.js: up to jQuery coding standards

### DIFF
--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -4,57 +4,56 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) and GPL (GPL-LICENSE.txt) licenses.
 * Note: Code is in draft form and is subject to change
 */
-(function($, undefined ) {
+( function( $, undefined ) {
 $.widget( "mobile.dialog", $.mobile.widget, {
 	options: {
 		closeBtnText: "Close"
 	},
-	_create: function(){
+	_create: function() {
 		var self = this,
 			$el = self.element;
 		
 		/* class the markup for dialog styling */	
 		this.element			
 			//add ARIA role
-			.attr("role","dialog")
-			.addClass('ui-page ui-dialog ui-body-a')
+			.attr( "role", "dialog" )
+			.addClass( "ui-page ui-dialog ui-body-a" )
 			.find( ":jqmData(role=header)" )
-			.addClass('ui-corner-top ui-overlay-shadow')
+			.addClass( "ui-corner-top ui-overlay-shadow" )
 				.prepend( "<a href='#' data-" + $.mobile.ns + "icon='delete' data-" + $.mobile.ns + "rel='back' data-" + $.mobile.ns + "iconpos='notext'>"+ this.options.closeBtnText +"</a>" )
 			.end()
-			.find('.ui-content:not([class*="ui-body-"])')
-				.addClass('ui-body-c')
+			.find( '.ui-content:not([class*="ui-body-"])' )
+				.addClass( 'ui-body-c' )
 			.end()
 			.find( ".ui-content,:jqmData(role='footer')" )
 				.last()
-				.addClass('ui-corner-bottom ui-overlay-shadow');
+				.addClass( "ui-corner-bottom ui-overlay-shadow" );
 		
 		/* bind events 
 			- clicks and submits should use the closing transition that the dialog opened with
 			  unless a data-transition is specified on the link/form
 			- if the click was on the close button, or the link has a data-rel="back" it'll go back in history naturally
 		*/
-		this.element		
-			.bind( "vclick submit", function(e){
-				var $targetel;
+		this.element
+			.bind( "vclick submit", function( e ) {
+				var $target;
 				if( e.type == "vclick" ){
-					$targetel = $(e.target).closest("a");
+					$target = $( e.target ).closest( "a" );
 				}
 				else{
-					$targetel = $(e.target).closest("form");
+					$target = $( e.target ).closest( "form" );
 				}
 				
-				if( $targetel.length && !$targetel.jqmData("transition") ){
-					$targetel
-						.attr("data-" + $.mobile.ns + "transition", $.mobile.urlHistory.getActive().transition )
-						.attr("data-" + $.mobile.ns + "direction", "reverse");
+				if( $target.length && !$target.jqmData( "transition" ) ){
+					$target
+						.attr( "data-" + $.mobile.ns + "transition", $.mobile.urlHistory.getActive().transition )
+						.attr( "data-" + $.mobile.ns + "direction", "reverse" );
 				}
 			});
-
 	},
 	
 	//close method goes back in history
-	close: function(){
+	close: function() {
 		window.history.back();
 	}
 });


### PR DESCRIPTION
jquery.mobile.dialog.js: Whitespace changes and string delimiters, bringing this up to jQuery coding standards.  Renamed one memory variable for legibility and clarity.

Signed-off-by: Steven Black steveb@stevenblack.com
