### PR TITLE
Fixed header/footer positioning in IE 7/8

### DIFF
--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -75,7 +75,7 @@ $.fixedToolbars = (function(){
 
 		Works with $(document), not $(window) : Opera Mobile (WinMO phone; kinda broken anyway)
 		Works with $(window), not $(document) : IE 7/8
-		Works with either $(window) or $(document) : Chrome, FF 3.6/4, IE 7/8, Android 1.6/2.1, iOS
+		Works with either $(window) or $(document) : Chrome, FF 3.6/4, Android 1.6/2.1, iOS
 		Needs work either way : BB5, Opera Mobile (iOS)
 
 */

--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -67,7 +67,19 @@ $.fixedToolbars = (function(){
 						stateBefore = null;
 					}
 				}
-			})
+			});
+
+/*		
+		The below checks first for a $(document).scrollTop() value, and if zero, binds scroll events to $(window) instead. If the scrollTop value is actually zero, both will return zero anyway.
+
+		Works with $(document), not $(window) : Opera Mobile (WinMO phone; kinda broken anyway)
+		Works with $(window), not $(document) : IE 7/8
+		Works with either $(window) or $(document) : Chrome, FF 3.6/4, IE 7/8, Android 1.6/2.1, iOS
+		Needs work either way : BB5, Opera Mobile (iOS)
+
+*/
+
+		(( $(document).scrollTop() == 0 ) ? $(window) : $(document))
 			.bind('scrollstart',function(event){
 				scrollTriggered = true;
 				if(stateBefore == null){ stateBefore = currentstate; }

--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -67,7 +67,8 @@ $.fixedToolbars = (function(){
 						stateBefore = null;
 					}
 				}
-			});
+			})
+			.bind('silentscroll', showEventCallback);
 
 /*		
 		The below checks first for a $(document).scrollTop() value, and if zero, binds scroll events to $(window) instead. If the scrollTop value is actually zero, both will return zero anyway.
@@ -105,8 +106,7 @@ $.fixedToolbars = (function(){
 					$.fixedToolbars.startShowTimer();
 				}
 				stateBefore = null;
-			})
-			.bind('silentscroll', showEventCallback);
+			});
 
 			$(window).bind('resize', showEventCallback);
 	});


### PR DESCRIPTION
Desktop IE wasn't reporting a scrollTop value for fixed headers/footers—'window' is now provided as a fallback in the event that $(document).scrollTop() reports zero.
