### PR TITLE
fix height issue for transitioning page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ init:
 
 # Build the minified JS file
 min: init js
-	# Build the minified Javascript file
+	# Build the minified JavaScript file
 	@@head -8 js/jquery.mobile.core.js | ${SED_VER} > ${OUTPUT}/${MIN}
 	@@java -jar build/google-compiler-20110405.jar --js ${OUTPUT}/${JS} --warning_level QUIET --js_output_file ${MIN}.tmp
 	@@cat ${MIN}.tmp >> ${OUTPUT}/${MIN}

--- a/themes/default/jquery.mobile.core.css
+++ b/themes/default/jquery.mobile.core.css
@@ -14,14 +14,14 @@
 .ui-mobile-viewport {  margin: 0; overflow-x: hidden; -webkit-text-size-adjust: none; -ms-text-size-adjust:none; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
 
 /* "page" containers - full-screen views, one should always be in view post-pageload */
-.ui-mobile [data-role=page], .ui-mobile [data-role=dialog], .ui-page { top: 0; left: 0; width: 100%; min-height: 100%; position: absolute; display: none; border: 0; } 
+.ui-mobile [data-role=page], .ui-mobile [data-role=dialog], .ui-page { top: 0; left: 0; width: 100%; min-height: 100%; height: auto !important; height: 100%; position: absolute; display: none; border: 0; } 
 .ui-mobile .ui-page-active { display: block; overflow: visible; }
 
 /*orientations from js are available */
 .portrait,
-.portrait .ui-page { min-height: 100%; }
+.portrait .ui-page,
 .landscape,
-.landscape .ui-page  { min-height: 100%; }
+.landscape .ui-page  { min-height: 100%; height: auto !important; height: 100%; }
 
 /* loading screen */
 .ui-loading .ui-mobile-viewport { overflow: hidden !important; }


### PR DESCRIPTION
IE doesnt like min-height

.ui-page should also have min-height 100% defined all the time, not just on page transition, to get rid of weird effects on page transitions
