### PR TITLE
Expose public enhance method on mobile.page (solves issue 1561)

### DIFF
--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -30,18 +30,18 @@ $.widget( "mobile.page", $.mobile.widget, {
 	},
 
 	_create: function() {
-    this.enhance();
+		if ( this._trigger( "beforeCreate" ) === false ) {
+			return;
+		}
+
+		this.enhance();
 	},
-	
+
 	enhance: function() {
 	  var $elem = this.element,
 			o = this.options;
 
 		this.keepNative = ":jqmData(role='none'), :jqmData(role='nojs')" + (o.keepNative ? ", " + o.keepNative : "");
-
-		if ( this._trigger( "beforeCreate" ) === false ) {
-			return;
-		}
 
 		//some of the form elements currently rely on the presence of ui-page and ui-content
 		// classes so we'll handle page and content roles outside of the main role processing

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -30,6 +30,10 @@ $.widget( "mobile.page", $.mobile.widget, {
 	},
 
 	_create: function() {
+		if ( this._trigger( "beforeCreate" ) === false ) {
+			return;
+		}
+
     this.enhance();
 	},
 	
@@ -38,10 +42,6 @@ $.widget( "mobile.page", $.mobile.widget, {
 			o = this.options;
 
 		this.keepNative = ":jqmData(role='none'), :jqmData(role='nojs')" + (o.keepNative ? ", " + o.keepNative : "");
-
-		if ( this._trigger( "beforeCreate" ) === false ) {
-			return;
-		}
 
 		//some of the form elements currently rely on the presence of ui-page and ui-content
 		// classes so we'll handle page and content roles outside of the main role processing

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -30,10 +30,6 @@ $.widget( "mobile.page", $.mobile.widget, {
 	},
 
 	_create: function() {
-		if ( this._trigger( "beforeCreate" ) === false ) {
-			return;
-		}
-
     this.enhance();
 	},
 	
@@ -42,6 +38,10 @@ $.widget( "mobile.page", $.mobile.widget, {
 			o = this.options;
 
 		this.keepNative = ":jqmData(role='none'), :jqmData(role='nojs')" + (o.keepNative ? ", " + o.keepNative : "");
+
+		if ( this._trigger( "beforeCreate" ) === false ) {
+			return;
+		}
 
 		//some of the form elements currently rely on the presence of ui-page and ui-content
 		// classes so we'll handle page and content roles outside of the main role processing

--- a/js/jquery.mobile.page.js
+++ b/js/jquery.mobile.page.js
@@ -30,7 +30,11 @@ $.widget( "mobile.page", $.mobile.widget, {
 	},
 
 	_create: function() {
-		var $elem = this.element,
+    this.enhance();
+	},
+	
+	enhance: function() {
+	  var $elem = this.element,
 			o = this.options;
 
 		this.keepNative = ":jqmData(role='none'), :jqmData(role='nojs')" + (o.keepNative ? ", " + o.keepNative : "");


### PR DESCRIPTION
Hi,

I've been running into issues with dynamically-generated content, since elements added after page load (for instance, Javascript templating + Ajax results = new list) don't get enhanced.

Exposing the enhancement code in mobile.page meets this need -- you can call pageObject.page("enhance") and any new content gets enhanced.  In my (limited) experience this seems to work without downsides.  (I looked at the unit tests with an eye toward updating them, but the jquery.mobile.page.js isn't immediately clear to me.)

One potential issue is that using page("enhance") requires knowing the relevant page object, which is pretty easy to get -- $("#newContent").closest(":jqmData(role='page')") -- but is not super friendly to the casual developer.  Creating a second method like $.mobile.enhance(selector), which finds the nearest page to the selector and enhances it, might be a better method; I'm happy to do that if this change is accepted.

Hope this is useful!

Alex
