### PR TITLE
$.mobile.removePage(), with tests.

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -766,6 +766,30 @@
 		duplicateCachedPage: undefined,
 		pageContainer: undefined
 	};
+	
+	
+	//remove page(s) from the DOM
+	//removes all pages passed by selector or reference EXCEPT the active page and the root/origin page.
+	$.mobile.removePage = function( selector ) {
+		var toRemove;
+		if ( typeof selector !== "string" ) {
+			toRemove= jQuery( selector );
+		} else {
+			//by data-url...
+			try {
+				//there are failure cases to trap, for example when selector= ":jqmData(url='anything')", a plausible passed-in parameter.
+				toRemove= $( ":jqmData(url='" + selector + "')");
+			} catch( e ) {
+				toRemove= $();
+			}
+			//... and/or id, class, or other user-supplied selector
+			toRemove.add( selector );
+		}
+		if ( toRemove.length ) {
+			// remove only pages that aren't currently active, nor origin.
+			toRemove.filter( ":jqmData(role=page)" ).not( ".ui-page-active, :jqmData(url='" + $.mobile.urlHistory.stack[0].url + "')" ).remove();
+		}
+	};
 
 /* Event Bindings - hashchange, submit, and click */
 

--- a/tests/unit/navigation/index.html
+++ b/tests/unit/navigation/index.html
@@ -223,6 +223,28 @@
 
 </div>
 
+<!-- removePage() tests -->
+<div id="removePageTest-first" data-nstest-role="page">
+  <a href="#removePageTest-second" data-nstest-transition="slideup" data-nstest-role="button" >
+		Page 2
+	</a>
+</div>
+
+<div id="removePageTest-second" data-nstest-role="page">
+	<a href="#removePageTest-third" data-nstest-transition="slideup" data-nstest-role="button" >
+		Page 3
+	</a>
+</div>
+
+<div id="removePageTest-third" data-nstest-role="page">
+  <a href="#removePageTest-first" data-nstest-transition="slideup" data-nstest-role="button">
+		Page 1
+	</a>
+  <a href="#removePageTest-second" data-nstest-transition="slideup" data-nstest-role="button">
+		Page 2
+	</a>
+</div>
+
 <div data-nstest-role="page" id="pathing-tests-reset">
 	<div class="reset-value">page didn't change!</div>
 </div>

--- a/tests/unit/navigation/navigation_core.js
+++ b/tests/unit/navigation/navigation_core.js
@@ -422,4 +422,47 @@
 			}
 		], 1000);
 	});
-})(jQuery);
+	
+	//$.mobile.removePage() tests.   This test REMOVES PAGES so best keep this last.
+	asyncTest( "$.mobile.removePage() tests", function() {
+
+		$.testHelper.openPage( "#removePageTest-first" );
+
+		$.testHelper.sequence( [
+			function() { $( "#removePageTest-first a:first" ).click(); },
+			function() { $( "#removePageTest-second a:first" ).click(); },
+			function() {
+
+				// how many pages are we starting with
+				var numPages= $( ":jqmData(role='page')" ).length,
+					numElements= $( "*" ).length;
+
+				//passing nothing to $.mobile.removePage()
+				$.mobile.removePage();
+				same( numElements, numElements= $( "*" ).length, "Passing nothing to $.mobile.removePage() does nothing" );
+
+				//passing nonsense to $.mobile.removePage()
+				$.mobile.removePage( "qwuyetshets" );
+				same( numElements, numElements= $( "*" ).length, "Passing nonsense to $.mobile.removePage() does nothing" );
+
+				//passing unrelated selectors to $.mobile.removePage()
+				$.mobile.removePage( "a" );
+				same( numElements, numElements= $( "*" ).length, "Passing unrelated but valid string selectors to $.mobile.removePage() does nothing" );
+
+				//passing unrelated jQuery collections to $.mobile.removePage()
+				$.mobile.removePage( $( "a" ) );
+				same( numPages, numPages= $( ":jqmData(role='page')" ).length, "Passing unrelated jQuery collections to $.mobile.removePage() does nothing" );
+
+				//try deleting the active page
+				$.mobile.removePage( ".ui-page-active" );
+				same( numPages, numPages= $( ":jqmData(role='page')" ).length, "$.mobile.removePage() doesn\'t remove the active page" );
+
+				//try deleting the home page
+				$.mobile.removePage( $.mobile.urlHistory.stack[0].url );
+				same( numPages, numPages= $( ":jqmData(role='page')" ).length, "$.mobile.removePage() doesn\'t remove the home page" );
+
+				start();
+			}], 1000 );
+	} );
+	
+})( jQuery );


### PR DESCRIPTION
Pass it a data-url, id, class, or other selector and it will remove matching data-role="page" containers that are NOT .ui-page-active, or NOT first on the stack.

This commit is predicate to forthcoming development of data-cache="false" and DOM page purging features.

Signed-off-by: Steven Black steveb@stevenblack.com
