### PR TITLE
Added a jQuery mobile configuration setting to allow you

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -49,6 +49,9 @@
 		//error response message - appears when an Ajax page request fails
 		pageLoadErrorMessage: "Error Loading Page",
 
+		//configure if you want the toolbar to always be presented as an overlay
+		toolbarAlwaysOverlay: false,
+
 		//support conditions that must be met in order to proceed
 		//default enhanced qualifications are media query support OR IE 7+
 		gradeA: function(){

--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -62,7 +62,7 @@ $.fixedToolbars = (function(){
 			.bind( "vclick",function(event){
 				if( touchToggleEnabled ) {
 					if( $(event.target).closest(ignoreTargets).length ){ return; }
-					if( !scrollTriggered ){
+					if( !scrollTriggered && !$.mobile.toolbarAlwaysOverlay){
 						$.fixedToolbars.toggle(stateBefore);
 						stateBefore = null;
 					}


### PR DESCRIPTION
to specify that you always want the header and footer
to be available.  (Cannot toggle on/off state)
