### PR TITLE
Scrollview: fixed binding of orientationchange event

### DIFF
--- a/experiments/scrollview/scrollview.js
+++ b/experiments/scrollview/scrollview.js
@@ -55,6 +55,6 @@ $(":jqmData(role='page')").live("pageshow", function(event) {
 	ResizePageContentHeight(event.target);
 });
 
-$(document).live("orientationchange", function(event) {
+$(window).bind("orientationchange", function(event) {
 	ResizePageContentHeight($(".ui-page"));
 });


### PR DESCRIPTION
fixed binding of orientationchange event (was on document, but only works on window). Moreover, it is now bound using 'bind' instead of 'live'
