### PR TITLE
Fixed a bug that can result in totally blank pages.

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -495,7 +495,8 @@
 				if( !$.support.dynamicBaseTag ) {
 					var newPath = path.get( fileUrl );
 					page.find( "[src], link[href], a[rel='external'], :jqmData(ajax='false'), a[target]" ).each(function() {
-						var thisAttr = $( this ).is( '[href]' ) ? 'href' : 'src',
+						var thisAttr = $( this ).is( '[href]' ) ? 'href' :
+								$(this).is('[src]') ? 'src' : 'action',
 							thisUrl = $( this ).attr( thisAttr );
 
 						// XXX_jblas: We need to fix this so that it removes the document


### PR DESCRIPTION
Bugfix: ":jqmData(ajax='false')" might also match forms, which have neither of "src" or "href". In that case, thisUrl is undefined, and the following replace results in an error.
