### PR TITLE
fixed #1811 - clear button on search input textbox isn't visible when multibyte string is inputed

### DIFF
--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -53,7 +53,15 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 			}
 			
 			toggleClear();
-			input.keyup(toggleClear);
+      var timer;
+      input.focus(function(){
+        timer = setInterval(toggleClear, 100)
+      });
+      input.blur(function(){
+        clearTimeout(timer);
+      });
+      
+      
 	                input.focus(toggleClear);   
 		}
 		else{


### PR DESCRIPTION
Keyup event isn't processed when I input (Japanese) multibyte string.
I use setTimeout to implement it.
