### PR TITLE
Ticket #1549

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -245,7 +245,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 				}
 
 				// trigger change if value changed
-				if( oldIndex !== newIndex ){
+				if( isMultiple || oldIndex !== newIndex ){
 					select.trigger( "change" );
 				}
 


### PR DESCRIPTION
Fix for ticket #1549 - No _change_ event was triggered on multiple select when first option was deselected due to `oldIndex === newIndex` => fix: always trigger _change_ when an option was clicked in multiple select
