### PR TITLE
Fix for issue 1836 - List view filter placeholder data attribute is not used.

### DIFF
--- a/js/jquery.mobile.listview.filter.js
+++ b/js/jquery.mobile.listview.filter.js
@@ -17,10 +17,12 @@ $( ":jqmData(role='listview')" ).live( "listviewcreate", function() {
 		return;
 	}
 
+	var placeholder = list.data("filter-placeholder") ? list.data("filter-placeholder") : listview.options.filterPlaceholder;
+
 	var wrapper = $( "<form>", { "class": "ui-listview-filter ui-bar-c", "role": "search" } ),
 
 		search = $( "<input>", {
-				placeholder: listview.options.filterPlaceholder
+				placeholder: placeholder
 			})
 			.attr( "data-" + $.mobile.ns + "type", "search" )
 			.jqmData( 'lastval', "" )


### PR DESCRIPTION
The documentation mentions the use of a data-attribute on list views to set the placeholder text for the filter search box. However, the attribute was not being used.
