### PR TITLE
Fix issue 1913 - unnecessary ajax call and duplicate DOM nodes when refreshing a page with a dialog visible.

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -156,7 +156,9 @@
 			convertUrlToDataUrl: function( absUrl ) {
 				var u = path.parseUrl( absUrl );
 				if ( path.isEmbeddedPage( u ) ) {
-					return u.hash.replace( /^#/, "" );
+				    // For embedded pages, remove the dialog hash key as in getFilePath(),
+				    // otherwise the Data Url won't match the id of the embedded Page.
+					return u.hash.split( dialogHashKey )[0].replace( /^#/, "" );
 				} else if ( path.isSameDomain( u, documentBase ) ) {
 					return u.hrefNoHash.replace( documentBase.domain, "" );
 				}


### PR DESCRIPTION
This commit fixes the issue described in the bug report for issue 1913. I have manually tested this using the test page I made for the bug report itself, but I haven't created an automated test, because I'm not familiar enough with qunit yet. The $.mobile.path.convertUrlToDataUrl() function makes use of isEmbeddedPage(), which relies on documentUrl and documentBaseDiffers private variables, and I don't know how I would construct a test case to exercise the code path.
