### PR TITLE
Support for data-containers from ajax received pages

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -66,9 +66,9 @@ $.fn.buttonMarkup = function( options ) {
 			.attr( "data-" + $.mobile.ns + "theme", o.theme )
 			.addClass( buttonClass );
 
-		var wrap = ( "<D class='" + innerClass + "'><D class='ui-btn-text'></D>" +
+		var wrap = "<"+o.wrapperEls+" class='" + innerClass + "'><"+o.wrapperEls+" class='ui-btn-text'></"+o.wrapperEls+">" +
 			( o.icon ? "<span class='" + iconClass + "'></span>" : "" ) +
-			"</D>" ).replace( /D/g, o.wrapperEls );
+			"</"+o.wrapperEls+">";
 
 		el.wrapInner( wrap );
 	});

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -669,6 +669,9 @@
 					});
 				}
 
+				//append data-containers to page
+				all.find( ":jqmData(role='data')" ).appendTo($.mobile.pageContainer);
+
 				//append to page and enhance
 				page
 					.attr( "data-" + $.mobile.ns + "url", path.convertUrlToDataUrl( fileUrl ) )

--- a/themes/default/jquery.mobile.core.css
+++ b/themes/default/jquery.mobile.core.css
@@ -14,7 +14,7 @@
 .ui-mobile-viewport {  margin: 0; overflow-x: hidden; -webkit-text-size-adjust: none; -ms-text-size-adjust:none; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
 
 /* "page" containers - full-screen views, one should always be in view post-pageload */
-.ui-mobile [data-role=page], .ui-mobile [data-role=dialog], .ui-page { top: 0; left: 0; width: 100%; min-height: 100%; position: absolute; display: none; border: 0; } 
+.ui-mobile [data-role=page], .ui-mobile [data-role=dialog], .ui-mobile [data-role=data], .ui-page { top: 0; left: 0; width: 100%; min-height: 100%; position: absolute; display: none; border: 0; } 
 .ui-mobile .ui-page-active { display: block; overflow: visible; }
 
 /*orientations from js are available */


### PR DESCRIPTION
Hi,

These commits add an extremely simple mechanism to add 'untouched' data fragments (e.g. divs) into the DOM from documents that are loaded by the Navigation widget. The data fragments are marked by an attribute 'date-role=data'.

The reason to have this mechanism is for collecting DOM fragments that need to be changed (through Javascript) before they are enhanced by Jquery Mobile. I currently have an use-case where I use template HTML, which is multiplied and changed through <a href="http://beebole.com/pure/">Pure.js</a>, before doing e.g. a listview() enhancement.

Hopefully you find this an useful addition. If needed I can also modify the documentation, let me know.

Greetings,
Ludo Stellingwerff.
