### PR TITLE
Support for CSS transitions/animations under Firefox 5

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -485,7 +485,7 @@
 	//animation complete callback
 	$.fn.animationComplete = function( callback ) {
 		if( $.support.cssTransitions ) {
-			return $( this ).one( 'webkitAnimationEnd', callback );
+		    return $( this ).one( ($.browser.webkit ? 'webkitAnimationEnd' : 'animationend'), callback );
 		}
 		else{
 			// defer execution for consistency between webkit/non webkit

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -60,7 +60,7 @@ $.mobile.browser.ie = ( function() {
 $.extend( $.support, {
 	orientation: "orientation" in window,
 	touch: "ontouchend" in document,
-	cssTransitions: "WebKitTransitionEvent" in window,
+	cssTransitions: "WebKitTransitionEvent" in window || "TransitionEvent" in window,
 	pushState: !!history.pushState,
 	mediaquery: $.mobile.media( "only all" ),
 	cssPseudoElement: !!propExists( "content" ),

--- a/themes/default/jquery.mobile.transitions.css
+++ b/themes/default/jquery.mobile.transitions.css
@@ -263,3 +263,180 @@ Built by David Kaneda and maintained by Jonathan Stark.
         opacity: 0;
     }
 }
+
+/* Gecko equivalents */
+
+.spin  {
+	-moz-transform: rotate(360deg);
+	-moz-animation-name: spin;
+	-moz-animation-duration: 1s;
+	-moz-animation-iteration-count:  infinite;
+}
+@-moz-keyframes spin {
+	from {-moz-transform: rotate(0deg);}
+  	to {-moz-transform: rotate(360deg);}
+}
+
+.in, .out {
+	-moz-animation-timing-function: ease-in-out;
+	-moz-animation-duration: 350ms;
+}
+
+.slide.in {
+	-moz-transform: translateX(0);
+	-moz-animation-name: slideinfromright;
+}
+
+.slide.out {
+	-moz-transform: translateX(-100%);
+	-moz-animation-name: slideouttoleft;
+}
+
+.slide.in.reverse {
+	-moz-transform: translateX(0);
+	-moz-animation-name: slideinfromleft;
+}
+
+.slide.out.reverse {
+	-moz-transform: translateX(100%);
+	-moz-animation-name: slideouttoright;
+}
+
+.slideup.in {
+	-moz-transform: translateY(0);
+	-moz-animation-name: slideinfrombottom;
+}
+
+.slideup.out {
+	-moz-animation-name: dontmove;
+}
+
+.slideup.out.reverse {
+	-moz-transform: translateY(100%);
+	-moz-animation-name: slideouttobottom;
+}
+
+.slideup.in.reverse {
+	-moz-animation-name: dontmove;
+}
+.slidedown.in {
+	-moz-transform: translateY(0);
+	-moz-animation-name: slideinfromtop;
+}
+
+.slidedown.out {
+	-moz-animation-name: dontmove;
+}
+
+.slidedown.out.reverse {
+	-moz-transform: translateY(-100%);
+	-moz-animation-name: slideouttotop;
+}
+
+.slidedown.in.reverse {
+	-moz-animation-name: dontmove;
+}
+
+@-moz-keyframes slideinfromright {
+    from { -moz-transform: translateX(100%); }
+    to { -moz-transform: translateX(0); }
+}
+
+@-moz-keyframes slideinfromleft {
+    from { -moz-transform: translateX(-100%); }
+    to { -moz-transform: translateX(0); }
+}
+
+@-moz-keyframes slideouttoleft {
+    from { -moz-transform: translateX(0); }
+    to { -moz-transform: translateX(-100%); }
+}
+
+@-moz-keyframes slideouttoright {
+    from { -moz-transform: translateX(0); }
+    to { -moz-transform: translateX(100%); }
+}
+
+
+@-moz-keyframes slideinfromtop {
+    from { -moz-transform: translateY(-100%); }
+    to { -moz-transform: translateY(0); }
+}
+
+@-moz-keyframes slideinfrombottom {
+    from { -moz-transform: translateY(100%); }
+    to { -moz-transform: translateY(0); }
+}
+
+@-moz-keyframes slideouttobottom {
+    from { -moz-transform: translateY(0); }
+    to { -moz-transform: translateY(100%); }
+}
+
+@-moz-keyframes slideouttotop {
+    from { -moz-transform: translateY(0); }
+    to { -moz-transform: translateY(-100%); }
+}
+@-moz-keyframes fadein {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@-moz-keyframes fadeout {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
+.fade.in {
+	-moz-animation-name: fadein;
+}
+.fade.out {
+	-moz-animation-name: fadeout;
+}
+
+/* Hackish, but reliable. */
+
+@-moz-keyframes dontmove {
+    from { opacity: 1; }
+    to { opacity: 1; }
+}
+
+.pop {
+	-moz-transform-origin: 50% 50%;
+}
+
+.pop.in {
+	-moz-transform: scale(1);
+	-moz-animation-name: popin;
+}
+
+.pop.out.reverse {
+	-moz-transform: scale(.2);
+	-moz-animation-name: popout;
+}
+
+.pop.in.reverse {
+	-moz-animation-name: dontmove;
+}
+
+@-moz-keyframes popin {
+    from {
+        -moz-transform: scale(.2);
+        opacity: 0;
+    }
+    to {
+        -moz-transform: scale(1);
+        opacity: 1;
+    }
+}
+
+@-moz-keyframes popout {
+    from {
+        -moz-transform: scale(1);
+        opacity: 1;
+    }
+    to {
+        -moz-transform: scale(.2);
+        opacity: 0;
+    }
+}


### PR DESCRIPTION
Hey, this isn't really a pull request so much as a request for feedback... stechz and I hacked up these fixes to allow some of the sexy CSS transitions and animations to work under Firefox 5 desktop and mobile, which were released earlier this week. The flip transition doesn't work yet, but the others do, as does the loading animation.

There's some things that need to be fixed before really being pulled-in:
- Right now the `-moz` namespaced transitions are appended to the end of the CSS as separate rules from the `-webkit` namespaced ones. We should probably either combine them or use some fancy jQuery plugin to automatically duplicate the rules at runtime.
- Using the flip transition currently breaks the page change, because no CSS transition/animation events get fired. Need to fix that, but not sure how... We could just namespace the normal flip CSS to `-moz` like we did with the others, but that doesn't seem to actually do any kind of animation. Not even sure if it triggers the transition/animation event, actually.
- Since a lot of the code we're changing here was originally part of jQTouch, I'm not sure if it's better to first commit this patch upstream or not. jQTouch seems to support a lot of other funky things that Firefox doesn't support yet, though, so I'm not sure if that would be fruitful.

Anyhow, just wanted to see if you had any feedback about the above points, or if you had any issues about this approach in general.
