### PR TITLE
Allow for customization of the loading message div and provide a general purpose $.mobile.showMessage() function

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -52,7 +52,11 @@
 
 		//show loading message during Ajax requests
 		//if false, message will not appear, but loading classes will still be toggled on html el
+		//if true, spinner will appear without message
 		loadingMessage: "loading",
+
+		//class used for loading message
+		loadingMessageClass: "ui-body-a",
 
 		//error response message - appears when an Ajax page request fails
 		pageLoadErrorMessage: "Error Loading Page",

--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -33,7 +33,12 @@
 
 	//loading div which appears during Ajax requests
 	//will not appear if $.mobile.loadingMessage is false
-	var $loader = $.mobile.loadingMessage ?		$( "<div class='ui-loader ui-body-a ui-corner-all'>" + "<span class='ui-icon ui-icon-loading spin'></span>" + "<h1>" + $.mobile.loadingMessage + "</h1>" + "</div>" )	: undefined;
+	//NOTE: interior h1 will not be added if $.mobile.loadingMessage == true instead of a string such as 'loading'
+	var $loader;
+	if ( $.mobile.loadingMessage )
+		$loader = $( "<div class='ui-loader ui-corner-all "+ $.mobile.loadingMessageClass +"'>" + "<span class='ui-icon ui-icon-loading spin'></span>" + ($.mobile.loadingMessage == true ? '' : "<h1>" + $.mobile.loadingMessage + "</h1>") + "</div>" );
+	else
+		$loader = undefined;
 
 	$.extend($.mobile, {
 		// turn on/off page loading message.

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -700,16 +700,8 @@
 
 				// Remove loading message.
 				if ( settings.showLoadMsg ) {
-					$.mobile.hidePageLoadingMsg();
-
 					//show error message
-					$( "<div class='ui-loader ui-overlay-shadow ui-body-e ui-corner-all'><h1>"+ $.mobile.pageLoadErrorMessage +"</h1></div>" )
-						.css({ "display": "block", "opacity": 0.96, "top": $window.scrollTop() + 100 })
-						.appendTo( settings.pageContainer )
-						.delay( 800 )
-						.fadeOut( 400, function() {
-							$( this ).remove();
-						});
+					$.mobile.showMessage( $.mobile.pageLoadErrorMessage, { pageContainer: settings.pageContainer, delayTime: 800 } );
 				}
 
 				deferred.reject( absUrl, options );
@@ -725,6 +717,28 @@
 		reloadPage: false,
 		role: undefined, // By default we rely on the role defined by the @data-role attribute.
 		showLoadMsg: true,
+		pageContainer: undefined
+	};
+
+	// Show a custom message to the user (will be shown in the active page unless specified otherwise in options)
+	$.mobile.showMessage = function( message, options ) {
+		$.mobile.hidePageLoadingMsg();
+
+		var showMessageOptions = $.extend( {}, $.mobile.showMessage.defaults, options );
+		$( "<div class='ui-loader ui-overlay-shadow ui-corner-all "+ showMessageOptions.wrapperClass +"'><h1>"+ message +"</h1></div>" )
+			.css({ "display": "block", "opacity": 0.96, "top": $window.scrollTop() + 100 })
+			.appendTo( showMessageOptions.pageContainer == undefined ? $.mobile.activePage : showMessageOptions.pageContainer )
+			.delay( showMessageOptions.delayTime )
+			.fadeOut( showMessageOptions.fadeTime, function() {
+			$( this ).remove();
+		});
+	};
+
+	// Default options for showMessage()
+	$.mobile.showMessage.defaults = {
+		delayTime: 2500,
+		fadeTime: 400,
+		wrapperClass: 'ui-body-e',
 		pageContainer: undefined
 	};
 


### PR DESCRIPTION
In the first commit, I allow for a customizable class (or classes) to be defined for the loading message div instead of, or in addition to, the default of "ui-body-a". Also, $.mobile.loadingMessage can now be set to true, instead of a string, so that a spinner may appear with no associated loading message.

In the second commit, I've extracted the error message logic into a new, reusable $.mobile.showMessage() function which can be used to display any message to the user. In addition to a custom message, options such as delayTime, fadeTime, and wrapperClass can be specified.

For a demo of these customizations in action, please see http://ioumate.com
