### PR TITLE
Fix for #1223: Adding back button functionality to nested lists

### DIFF
--- a/docs/_assets/css/jqm-docs.css
+++ b/docs/_assets/css/jqm-docs.css
@@ -89,7 +89,7 @@ p.intro strong {
 	background-image: -webkit-gradient(linear,left top,left bottom,
 		color-stop(0, 		#74b042),
 		color-stop(1, 		#56A00E));
-	-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr='#81a8ce', EndColorStr='#5e87b0')";
+	-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr='#74b042', EndColorStr='#56A00E')";
 }
 .ui-bar-f,
 .ui-bar-f .ui-link-inherit {

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -233,7 +233,21 @@ $.widget( "mobile.listview", $.mobile.widget, {
 							.after( persistentFooterID ? $( "<div " + dns + "role='footer' " + dns + "id='"+ persistentFooterID +"'>") : "" )
 							.parent()
 								.appendTo( $.mobile.pageContainer );
+								
+			if ( list.jqmData("backbtn") !== false ) {
+                // Add back btn on sub-list pages
+                // Mostly taken from the jquery.mobile.page.js file; _create function.
+                o.backBtnText = list.jqmData("backbtn-text") || "Back";
+                o.backBtnTheme = list.jqmData("backbtn-theme") || o.headerTheme;    
+                var $header = $(newPage).find(":jqmData(role='header')"),
+				    backBtn = $( "<a href='#' class='ui-btn-left' data-"+ $.mobile.ns +"rel='back' data-"+ $.mobile.ns +"icon='arrow-l'>"+ o.backBtnText +"</a>" ).prependTo( $header );
 
+				//if theme is provided, override default inheritance
+				if( o.backBtnTheme ){
+					backBtn.attr( "data-"+ $.mobile.ns +"theme", o.backBtnTheme );
+				}
+			}
+			
 			newPage.page();
 
 			anchor = parent.find('a:first');

--- a/tests/unit/listview/index.html
+++ b/tests/unit/listview/index.html
@@ -56,17 +56,52 @@
 					<li>quiver of cobras</li>
 					<li>troop of baboons</li>
 				</ul>
-			</li>
+			</li>			
 			<li class="linebreaknode">
 
 			More animals
-
 
 				<ul>
 					<li>Shoal of Bass</li>
 					<li>Rhumba of rattlesnakes</li>
 				</ul>
+			</li>			
+		</ul>
+	</div>
+</div>
+
+<!-- Nested List, with backbtn attributes -->
+<div  data-nstest-role="page" id='nested-list-backbtn-test'>
+	<div  data-nstest-role="header" data-nstest-position="inline">
+		<h1>Basic List View</h1>
+	</div>
+	<div  data-nstest-role="content">
+		<ul  data-nstest-role="listview">
+			<li class="first">Groups of animals
+				<ul>
+					<li>pod of whales</li>
+					<li>quiver of cobras</li>
+					<li>troop of baboons</li>
+				</ul>
+			</li>			
+			<li class="linebreaknode second">
+
+			More animals
+
+				<ul data-nstest-backbtn="true" data-nstest-backbtn-text="Previous" data-nstest-backbtn-theme="a">
+					<li>Shoal of Bass</li>
+					<li>Rhumba of rattlesnakes</li>
+				</ul>
 			</li>
+			<li class="linebreaknode third">
+
+			Even More animals
+
+				<ul data-nstest-backbtn="false">
+					<li>Flock of Seagulls</li>
+					<li>Murder of Counting Crows</li>
+				</ul>
+			</li>				
 		</ul>
 	</div>
 </div>

--- a/tests/unit/listview/listview_core.js
+++ b/tests/unit/listview/listview_core.js
@@ -91,8 +91,8 @@
 			}
 		]);
 	});
-
-	asyncTest( "should go back to top level when the back button is clicked", function() {
+	
+	asyncTest( "should go back to top level when the (browser) back button is clicked", function() {
 		$.testHelper.pageSequence([
 			function(){
 				$.testHelper.openPage("#nested-list-test&ui-page=0-0");
@@ -104,6 +104,92 @@
 
 			function(){
 				ok($('#nested-list-test').hasClass('ui-page-active'), 'Transitions back to the parent nested page');
+				start();
+			}
+		]);
+	});
+	
+	asyncTest( "nested page should have back button by default", function() {
+		$.testHelper.pageSequence([
+			function(){
+				$.testHelper.openPage("#nested-list-backbtn-test");
+			},
+
+			function(){
+				$('.ui-page-active ul:first li.first a:first').click();
+			},
+
+			function(){
+				var $new_page = $('.ui-page-active'),
+					$header = $new_page.find(":jqmData(role='header')");
+					
+				ok($header.has("a:jqmData(rel='back')").length > 0, 'The nested page has a back button in the header.');
+				
+				start();
+			}
+		]);
+	});
+	
+	asyncTest( "nested page should not have back button when data-backbtn='false'", function() {
+		$.testHelper.pageSequence([
+			function(){
+				$.testHelper.openPage("#nested-list-backbtn-test");
+			},
+
+			function(){
+				$('.ui-page-active ul:first li.third a:first').click();
+			},
+
+			function(){
+				var $new_page = $('.ui-page-active'),
+					$header = $new_page.find(":jqmData(role='header')");
+					
+				ok($header.has("a:jqmData(rel='back')").length === 0, 'The nested page does not have a back button in the header.');
+				
+				start();
+			}
+		]);
+	});
+	
+	asyncTest( "nested page should have back button text default to 'Back'", function() {
+		$.testHelper.pageSequence([
+			function(){
+				$.testHelper.openPage("#nested-list-backbtn-test");
+			},
+
+			function(){
+				$('.ui-page-active ul:first li.first a:first').click();
+			},
+
+			function(){
+				var $new_page = $('.ui-page-active'),
+					$header = $new_page.find(":jqmData(role='header')"),
+					$backBtn = $header.find("a:jqmData(rel='back')");
+					
+				ok($backBtn.text() === 'Back', 'back button text was "Back"; ' + $backBtn.text());
+				
+				start();
+			}
+		]);
+	});
+	
+	asyncTest( "nested page should have back button text set to backbtn-text data attribute", function() {
+		$.testHelper.pageSequence([
+			function(){
+				$.testHelper.openPage("#nested-list-backbtn-test");
+			},
+
+			function(){
+				$('.ui-page-active ul:first li.second a:first').click();
+			},
+
+			function(){
+				var $new_page = $('.ui-page-active'),
+					$header = $new_page.find(":jqmData(role='header')"),
+					$backBtn = $header.find("a:jqmData(rel='back')");
+					
+				ok($backBtn.text() === 'Previous', 'back button text was "Previous"; ' + $backBtn.text());
+				
 				start();
 			}
 		]);


### PR DESCRIPTION
I made an attempt at a solution for back buttons in nested lists.

I took some code from the _create function in jquery.mobile.page.js file and trimmed it down to add the back link to the header in the new page that is created from nested lists.

It defaults to adding back buttons with an option to be overridden by adding the data-backbtn="false" attribute, the theme of the button defaults to the header theme from the listview options but can be overridden with data-backbtn-theme, and the text defaults to "Back" but can be overridden with the data-backbtn-text attribute.  (attributes are added on the nested ul or ol element).

I've also added some basic unit tests to test the functionality.

I have not really taken into account deep links to nested lists, but I'm open to suggestion.

-Jacob
