### PR TITLE
Top corner in inset list with two items fails

### DIFF
--- a/tests/unit/listview/index.html
+++ b/tests/unit/listview/index.html
@@ -261,5 +261,17 @@
 	</div>
 </div>
 
+<!-- Rounded corners inset list with variable items -->
+<div  data-nstest-role="page" id='corner-rounded-test'>
+	<div  data-nstest-role="header" data-nstest-position="inline">
+		<h1>Basic List View</h1>
+	</div>
+	<div  data-nstest-role="content">
+		<ul  data-nstest-role="listview" data-nstest-inset="true">
+		</ul>
+	</div>
+</div>
+
+
 </body>
 </html>

--- a/tests/unit/listview/listview_core.js
+++ b/tests/unit/listview/listview_core.js
@@ -453,12 +453,37 @@
 
 				ul.find("li").last().remove();
 				equal(ul.find("li").length, 2, "There should be only 2 list items left");
-
+				
 				ul.listview('refresh');
 				ok(ul.find("li").last().hasClass("ui-corner-bottom"), "Last list item should have class ui-corner-bottom");
 				start();
 			}
 		]);
 	});
+
+	module("Rounded corners");
+
+	asyncTest("Top and bottom corners rounded in inset list", 10, function() {
+		$.testHelper.pageSequence([
+			function() {
+				$.testHelper.openPage("#corner-rounded-test");
+			},
+
+			function() {
+				var ul = $('#corner-rounded-test ul');
+				
+				for( var t = 0; t<5; t++){
+					ul.append("<li>Item " + t + "</li>");
+					ul.listview('refresh');					
+					ok(ul.find("li").first().hasClass("ui-corner-top"), "First list item should have class ui-corner-top in list with " + ul.find("li").length + " item(s)");
+					ok(ul.find("li").last().hasClass("ui-corner-bottom"), "Last list item should have class ui-corner-bottom in list with " + ul.find("li").length + " item(s)");
+				}
+				
+				start();
+			}
+		]);
+	});
+
+
 
 })(jQuery);


### PR DESCRIPTION
Hi there, 

The top corner style doesn't get applied in an inset list with two items (other number of items work fine). I added a red test for your convenience. 

Regards, 
Wietse
