### PR TITLE
Updated nested list pages to show back button

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -222,12 +222,13 @@ $.widget( "mobile.listview", $.mobile.widget, {
 				title = nodeEls.first().text(),//url limits to first 30 chars of text
 				id = ( parentUrl || "" ) + "&" + $.mobile.subPageUrlKey + "=" + listId,
 				theme = list.jqmData( "theme" ) || o.theme,
+				addBackBtn = list.jqmData( "add-back-btn" ) === undefined ? true : list.jqmData( "add-back-btn" ),
 				countTheme = list.jqmData( "counttheme" ) || parentList.jqmData( "counttheme" ) || o.countTheme,
 				newPage, anchor;
 
 
 			newPage = list.detach()
-						.wrap( "<div " + dns + "role='page' " +	dns + "url='" + id + "' " + dns + "theme='" + theme + "' " + dns + "count-theme='" + countTheme + "'><div " + dns + "role='content'></div></div>" )
+						.wrap( "<div " + dns + "role='page' " + dns + "add-back-btn='" + addBackBtn + "'" + dns + "url='" + id + "' " + dns + "theme='" + theme + "' " + dns + "count-theme='" + countTheme + "'><div " + dns + "role='content'></div></div>" )
 						.parent()
 							.before( "<div " + dns + "role='header' " + dns + "theme='" + o.headerTheme + "'><div class='ui-title'>" + title + "</div></div>" )
 							.after( persistentFooterID ? $( "<div " + dns + "role='footer' " + dns + "id='"+ persistentFooterID +"'>") : "" )


### PR DESCRIPTION
I drastically simplified my previous code by just looking for the data-add-back-btn attribute on the list and adding the attribute to the header template for the created page before the page.page() call.  This way, the page() method can use it's existing logic to add the back button instead of repeating it here.

I'm still defaulting to showing the back button if not specified and I haven't included any ability to theme.
