### PR TITLE
fix: swipe event fired during vertically scrolling

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -124,7 +124,7 @@ $.event.special.swipe = {
 								event.originalEvent.touches[ 0 ] : event,
 				start = {
 					time: ( new Date() ).getTime(),
-					coords: [ data.pageX, data.pageY ],
+					coords: [ data.pageX, data.pageY + document.body.scrollTop ],
 					origin: $( event.target )
 				},
 				stop;
@@ -140,7 +140,7 @@ $.event.special.swipe = {
 
 				stop = {
 					time: ( new Date() ).getTime(),
-					coords: [ data.pageX, data.pageY ]
+					coords: [ data.pageX, data.pageY + document.body.scrollTop]
 				};
 
 				// prevent scrolling


### PR DESCRIPTION
I think swipe event shouldn't be fired during vertically scrolling.
However,  if I move my finger diagonally, both screen scrolling and swipe event are occurred.

This behavior would get operability worse.
(On iPhone native UI, Swipe event isn't fired in this situation)
- jQuery Mobile beta1
  - iPhone3GS
  - iPhone4
  - iPad

movie:
http://www.youtube.com/watch?v=GsMsFIwsBYc

reproduce code:

```
    <!DOCTYPE html>
    <html>
    <head runat="server">
        <meta charset="utf-8">
        <title>swipe event test</title>
        <meta name="viewport" content="width=device-width, initial-scale=1,minimum-scale=1, maximum-scale=1"> 

        <link rel="stylesheet" href="css/jquery.mobile-1.0b1.css" />
        <link rel="stylesheet" href="css/catrea.mobile.common.css"/>

        <script type="text/javascript" src="js/jquery-1.6.1.js"></script>
        <script type="text/javascript" src="js/jquery.mobile-1.0b1.js"></script>

        <script type="text/javascript">
          $(function(){
            $("li").swipe(function(){
              $(this).append(' <font color="red">swiped!</red>');
            });
          });
        </script>
    </head>
    <body>
      <div data-role="page">
        <h1>test</h1>

        <ul data-role="listview">
          <li>0</li>
          <li>1</li>
          <li>2</li>
          <li>3</li>
          <li>4</li>
          <li>5</li>
          <li>6</li>
          <li>7</li>
          <li>8</li>
          <li>9</li>
          <li>10</li>
          <li>11</li>
          <li>12</li>
          <li>13</li>
          <li>14</li>
          <li>15</li>
          <li>16</li>
          <li>17</li>
          <li>18</li>
          <li>19</li>
          <li>20</li>
          <li>21</li>
          <li>22</li>
          <li>23</li>
          <li>24</li>
          <li>25</li>
          <li>26</li>
          <li>27</li>
          <li>28</li>
          <li>29</li>
        </ul>
      </div>
    </body>
    </html>
```
