### PR TITLE
Fix #1999, mismatched gradient stops for .ui-btn-up-c style

### DIFF
--- a/themes/default/jquery.mobile.theme.css
+++ b/themes/default/jquery.mobile.theme.css
@@ -308,7 +308,7 @@
 	color: 					#444;
 	text-shadow: 0 1px 1px #f6f6f6;
 	background-image: -moz-linear-gradient(top, 
-							#fefefe, 
+							#fdfdfd, 
 							#eeeeee);
 	background-image: -webkit-gradient(linear,left top,left bottom,
 		color-stop(0, 		#fdfdfd),


### PR DESCRIPTION
Fixed the mismatched gradient stops for the .ui-btn-up-c style.  The -ms-filter had already been updated to use the 6 character code.
