### PR TITLE
Fix for Bug #1931 - Collapsible Set - Visual Bug

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -132,7 +132,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 
 				});
 
-			var set = collapsibleParent.find( ":jqmData(role='collapsible'):first" );
+			var set = collapsibleParent.children( ":jqmData(role='collapsible')" );
 
 			set.first()
 				.find( "a:eq(0)" )


### PR DESCRIPTION
collapsable selector was using :first so set was only ever one element.

see https://github.com/jquery/jquery-mobile/issues/1931
