### PR TITLE
Don't apply $.mobile.activeBtnClass when button of navbar is disabled

### DIFF
--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -35,9 +35,11 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 			iconpos:	iconpos
 		});
 
-		$navbar.delegate( "a", "vclick", function( event ) {
-			$navbtns.not( ".ui-state-persist" ).removeClass( $.mobile.activeBtnClass );
-			$( this ).addClass( $.mobile.activeBtnClass );
+		$navbar.delegate("a", "vclick",function(event){
+			if ( !$( this ).hasClass( "ui-disabled" ) ) {
+				$navbtns.not( ".ui-state-persist" ).removeClass( $.mobile.activeBtnClass );
+				$( this ).addClass( $.mobile.activeBtnClass );
+			}
 		});
 	}
 });


### PR DESCRIPTION
To test:
Just add a class="ui-disabled" in a anchor tag of navbar.

Could you add a sample in doc & demo page of jquery mobile?
