### PR TITLE
Possible fix for #779

### DIFF
--- a/docs/content/content-themes.html
+++ b/docs/content/content-themes.html
@@ -41,7 +41,7 @@
 			<h1>H1 Heading</h1>
 			<p>This is a paragraph that contains <strong>strong</strong>, <em>emphasized</em> and <a href="index.html">linked</a> text. Here is more text so you can see how HTML markup works in content. Here is more text so you can see how HTML markup works in content.</p>
 			<div data-role="collapsible" data-collapsed="true" data-theme="a">
-				<h3>I'm an themed collapsible</h3>
+				<h3>I'm a themed collapsible</h3>
 				<p>I have <code> data-theme</code> attribute set manually on my container to set the color to match the content block I'm in. </p>
 			</div><!-- /collapsible -->
 		</div><!-- /themed container -->
@@ -51,7 +51,7 @@
 			<h1>H1 Heading</h1>
 			<p>This is a paragraph that contains <strong>strong</strong>, <em>emphasized</em> and <a href="index.html">linked</a> text. Here is more text so you can see how HTML markup works in content. Here is more text so you can see how HTML markup works in content.</p>
 			<div data-role="collapsible" data-collapsed="true" data-theme="b">
-				<h3>I'm an themed collapsible</h3>
+				<h3>I'm a themed collapsible</h3>
 				<p>I have <code> data-theme</code> attribute set manually on my container to set the color to match the content block I'm in. </p>
 			</div><!-- /collapsible -->
 		</div><!-- /themed container -->
@@ -61,7 +61,7 @@
 			<h1>H1 Heading</h1>
 			<p>This is a paragraph that contains <strong>strong</strong>, <em>emphasized</em> and <a href="index.html">linked</a> text. Here is more text so you can see how HTML markup works in content. Here is more text so you can see how HTML markup works in content.</p>
 			<div data-role="collapsible" data-collapsed="true" data-theme="c">
-				<h3>I'm an themed collapsible</h3>
+				<h3>I'm a themed collapsible</h3>
 				<p>I have <code> data-theme</code> attribute set manually on my container to set the color to match the content block I'm in. </p>
 			</div><!-- /collapsible -->
 		</div><!-- /themed container -->
@@ -71,7 +71,7 @@
 			<h1>H1 Heading</h1>
 			<p>This is a paragraph that contains <strong>strong</strong>, <em>emphasized</em> and <a href="index.html">linked</a> text. Here is more text so you can see how HTML markup works in content. Here is more text so you can see how HTML markup works in content.</p>
 			<div data-role="collapsible" data-collapsed="true" data-theme="d">
-				<h3>I'm an themed collapsible</h3>
+				<h3>I'm a themed collapsible</h3>
 				<p>I have <code> data-theme</code> attribute set manually on my container to set the color to match the content block I'm in. </p>
 			</div><!-- /collapsible -->
 		</div><!-- /themed container -->
@@ -81,7 +81,7 @@
 			<h1>H1 Heading</h1>
 			<p>This is a paragraph that contains <strong>strong</strong>, <em>emphasized</em> and <a href="index.html">linked</a> text. Here is more text so you can see how HTML markup works in content. Here is more text so you can see how HTML markup works in content.</p>
 			<div data-role="collapsible" data-collapsed="true" data-theme="e">
-				<h3>I'm an themed collapsible</h3>
+				<h3>I'm a themed collapsible</h3>
 				<p>I have <code> data-theme</code> attribute set manually on my container to set the color to match the content block I'm in. </p>
 			</div><!-- /collapsible -->
 		</div><!-- /themed container -->

--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -45,7 +45,17 @@ $.widget( "mobile.listview", $.mobile.widget, {
 		.find( ".ui-li-aside" ).each(function() {
 			var $this = $(this);
 			$this.prependTo( $this.parent() ); //shift aside to front for css float
+		}).end()
+		.find( ".ui-link-inherit" ).each(function (i, el) {
+			var $el = $(el);
+			if ( !( $el.find( ".ui-li-count" ).length ) ) {
+				$el.addClass( "ui-li-has-count-or-linkicon" );
+			}
 		});
+
+		if ( !item.find( ".ui-li-count" ).length ) {
+			item.addClass( "ui-li-no-count-no-linkicon" );
+		}
 	},
 
 	_removeCorners: function( li, which ) {

--- a/themes/default/jquery.mobile.listview.css
+++ b/themes/default/jquery.mobile.listview.css
@@ -17,6 +17,9 @@ ol.ui-listview .ui-li-jsnumbering:before { content: "" !important; } /* to avoid
 .ui-li:last-child, .ui-li.ui-field-contain:last-child { border-bottom-width: 1px; }
 .ui-li>.ui-btn-inner { display: block; position: relative; padding: 0; }
 .ui-li .ui-btn-inner a.ui-link-inherit, .ui-li-static.ui-li { padding: .7em 75px .7em 15px; display: block; }
+.ui-li-static.ui-li:not(.ui-btn-inner) { padding-right: 40px; }
+.ui-li .ui-li-has-count-or-linkicon { padding-right: 40px !important; }
+.ui-li-static.ui-li.ui-li-no-count-no-linkicon { padding-right: 15px; }
 .ui-li-has-thumb .ui-btn-inner a.ui-link-inherit, .ui-li-static.ui-li-has-thumb  { min-height: 60px; padding-left: 100px; }
 .ui-li-has-icon .ui-btn-inner a.ui-link-inherit, .ui-li-static.ui-li-has-icon {  min-height: 20px; padding-left: 40px; }
 .ui-li-heading { font-size: 16px; font-weight: bold; display: block; margin: .6em 0; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;  }


### PR DESCRIPTION
I'm a jQuery beginner so this may not be the right approach, but for me this resolves the overly aggressive right-padding of listview items.

If there is no counter on a link list item, or just a counter on a static list item, right padding is 40px to make room for the ">" icon or the counter.  Static list items without a counter have 15px right padding to match the left side.
