### PR TITLE
Fix for scrolling when the user has already scrolled.

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -111,7 +111,9 @@
 	//then check what the scroll top is. Android will report 0... others 1
 	//note that this initial scroll won't hide the address bar. It's just for the check.
 	$(function(){
-		window.scrollTo( 0, 1 );
+    //don't scroll if the user has already scrolled the device, particularly visible when jQM
+    //being used on a desktop browser
+		if (!window.pageYOffset) window.scrollTo( 0, 1 );
 	
 		//if defaultHomeScroll hasn't been set yet, see if scrollTop is 1
 		//it should be 1 in most browsers, but android treats 1 as 0 (for hiding addr bar)


### PR DESCRIPTION
fix for scrolling the window when the user has already started scrolling - apparent when slow download and user is ahead of content or when jQM is being used on desktop platform - ref http://remysharp.com/doing-it-right-skipping-the-iphone-url-bar/
