### PR TITLE
Fix for #2104, IE style in docs for ui-bar-f roundyness

### DIFF
--- a/docs/_assets/css/jqm-docs.css
+++ b/docs/_assets/css/jqm-docs.css
@@ -88,8 +88,7 @@ p.intro strong {
 							#56A00E);
 	background-image: -webkit-gradient(linear,left top,left bottom,
 		color-stop(0, 		#74b042),
-		color-stop(1, 		#56A00E));
-	-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr='#74b042', EndColorStr='#56A00E')";
+		color-stop(1, 		#56A00E));	
 }
 .ui-bar-f,
 .ui-bar-f .ui-link-inherit {

--- a/docs/_assets/css/jqm-docs.css
+++ b/docs/_assets/css/jqm-docs.css
@@ -82,13 +82,13 @@ p.intro strong {
 	background: 			#74b042;
 	color: 					#fff;
 	font-weight: bold;
-	text-shadow: 0 -1px 1px #234403;
-	background-image: -moz-linear-gradient(top, 
-							#74b042, 
-							#56A00E);
-	background-image: -webkit-gradient(linear,left top,left bottom,
-		color-stop(0, 		#74b042),
-		color-stop(1, 		#56A00E));	
+	text-shadow: 0 -1px 1px #234403;	
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#74b042), to(#56A00E)); /* Saf4+, Chrome */
+	background-image: -webkit-linear-gradient(top, #74b042, #56A00E); /* Chrome 10+, Saf5.1+ */
+	background-image:    -moz-linear-gradient(top, #74b042, #56A00E); /* FF3.6 */
+	background-image:     -ms-linear-gradient(top, #74b042, #56A00E); /* IE10 */
+	background-image:      -o-linear-gradient(top, #74b042, #56A00E); /* Opera 11.10+ */
+	background-image:         linear-gradient(top, #74b042, #56A00E);		
 }
 .ui-bar-f,
 .ui-bar-f .ui-link-inherit {


### PR DESCRIPTION
Updated jqm-docs.css to fix .ui-bar-f style for rounded corner smoothyness.

To verify, view the docs home page in IE9.
