### PR TITLE
Made Collapsibles respect icon options (issues #2022 & #1797)

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -47,7 +47,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 					shadow: !collapsibleParent.length,
 					corners: false,
 					iconpos: $el.jqmData("iconpos") || "left",
-					icon: "plus",
+					icon: $el.jqmData("icon-collapsed") || "plus",
 					theme: o.theme
 				})
 				.find( ".ui-icon" )
@@ -56,7 +56,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 						shadow: true,
 						corners: true,
 						iconpos: "notext",
-						icon: "plus",
+						icon: $el.jqmData("icon-collapsed") || "plus",
 						theme: o.iconTheme
 					});
 
@@ -88,8 +88,8 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 							.text( o.expandCueText )
 						.end()
 						.find( ".ui-icon" )
-							.removeClass( "ui-icon-minus" )
-							.addClass( "ui-icon-plus" );
+							.removeClass( "ui-icon-" + ( collapsibleContain.jqmData("icon-expanded") || "minus" ) )
+							.addClass( "ui-icon-" + ( collapsibleContain.jqmData("icon-collapsed") || "plus" ) );
 
 					collapsibleContent.addClass( "ui-collapsible-content-collapsed" ).attr( "aria-hidden", true );
 
@@ -109,7 +109,9 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 						.removeClass( "ui-collapsible-heading-collapsed" )
 						.find( ".ui-collapsible-heading-status" ).text( o.collapseCueText );
 
-					collapsibleHeading.find( ".ui-icon" ).removeClass( "ui-icon-plus" ).addClass( "ui-icon-minus" );
+					collapsibleHeading.find( ".ui-icon" )
+						.removeClass( "ui-icon-" + ( collapsibleContain.jqmData("icon-collapsed") || "plus" ) )
+						.addClass( "ui-icon-" + ( collapsibleContain.jqmData("icon-expanded") || "minus" ) );
 
 					collapsibleContent.removeClass( "ui-collapsible-content-collapsed" ).attr( "aria-hidden", false );
 

--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -46,7 +46,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 				.buttonMarkup({
 					shadow: !collapsibleParent.length,
 					corners: false,
-					iconPos: "left",
+					iconpos: $el.jqmData("iconpos") || "left",
 					icon: "plus",
 					theme: o.theme
 				})
@@ -55,7 +55,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 					.buttonMarkup({
 						shadow: true,
 						corners: true,
-						iconPos: "notext",
+						iconpos: "notext",
 						icon: "plus",
 						theme: o.iconTheme
 					});


### PR DESCRIPTION
To make collapsibles a little more customisable, I've added support for the data-iconpos attribute and allowed the definition of data-icon-collapsed and data-icon-expanded attributes.
