### PR TITLE
Allow overriding `$.mobile.pageContainer`

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -93,7 +93,7 @@
 			$.mobile.firstPage = $pages.first();
 
 			//define page container
-			$.mobile.pageContainer = $pages.first().parent().addClass( "ui-mobile-viewport" );
+			$.mobile.pageContainer = ($.mobile.pageContainer || $pages.first().parent()).addClass( "ui-mobile-viewport" );
 
 			//cue page loading message
 			$.mobile.showPageLoadingMsg();


### PR DESCRIPTION
I have no `data-role="page"` element in my page when it initially loads, I manually add them later on (after rendering them using a template engine, in my case). Because of this, jQuery mobile can't automatically identify the page container, so I set it manually.

The problem is that `$.mobile.initializePage` ignores it and still attempts to set it itself. My change uses the existing `$.mobile.pageContainer` if it exists or identifies it as its usually does by default.
