### PR TITLE
Fix nested waiting-for-dom for initializePage

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -125,7 +125,7 @@
 	
 		//dom-ready inits
 		if( $.mobile.autoInitializePage ){
-			$( $.mobile.initializePage );
+			$.mobile.initializePage();
 		}
 		
 		//window load event


### PR DESCRIPTION
Using dom-ready within dom-ready meant that initializePage went to the end of
the queue. That brought problems when other dom-ready code expected jQM to be
set up, capable of changing pages and so on. But because $.mobile.pageContainer
is also set in initializePage, changePage and others didn't work.
