### PR TITLE
Make taphold duration configurable

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -38,6 +38,9 @@
 		// Minimum scroll distance that will be remembered when returning to a page
 		minScrollBack: screen.height / 2,
 
+                // The timeout for taphold event, in milliseconds
+                tapholdDuration: 750,
+
 		// Set default dialog transition - 'none' for no transitions
 		defaultDialogTransition: "pop",
 

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -38,7 +38,7 @@
 		// Minimum scroll distance that will be remembered when returning to a page
 		minScrollBack: screen.height / 2,
 
-		// The timeout for taphold event, in milliseconds
+		// The timeout for taphold events, in milliseconds
 		tapholdDuration: 750,
 
 		// Set default dialog transition - 'none' for no transitions

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -38,8 +38,8 @@
 		// Minimum scroll distance that will be remembered when returning to a page
 		minScrollBack: screen.height / 2,
 
-                // The timeout for taphold event, in milliseconds
-                tapholdDuration: 750,
+		// The timeout for taphold event, in milliseconds
+		tapholdDuration: 750,
 
 		// Set default dialog transition - 'none' for no transitions
 		defaultDialogTransition: "pop",

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -108,7 +108,7 @@ $.event.special.tap = {
 				if ( touching ) {
 					triggerCustomEvent( thisObject, "taphold", event );
 				}
-			}, $.mobile.tapholdTimeout );
+			}, $.mobile.tapholdDuration );
 		});
 	}
 };

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -108,7 +108,7 @@ $.event.special.tap = {
 				if ( touching ) {
 					triggerCustomEvent( thisObject, "taphold", event );
 				}
-			}, 750 );
+			}, $.mobile.tapholdTimeout );
 		});
 	}
 };


### PR DESCRIPTION
I'd like to suggest making the taphold timeout duration customizable as a property on `$.mobile`, instead of the fixed 750 ms currently used. This will allow developers to adjust the timeout to work well on their target devices.
