### PR TITLE
Fix issue of the select menu not closing on Chrome

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -585,6 +585,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		else{
 			self.screen.addClass( "ui-screen-hidden" );
 			self.listbox.addClass( "ui-selectmenu-hidden" ).removeAttr( "style" ).removeClass( "in" );
+			self.list.appendTo( self.listbox );
 			self._focusButton();
 		}
 


### PR DESCRIPTION
On Chrome when we click out of the menu or on the already selected option, the select menu is not closed. The menu is closed when the mouse move over another option but if the menu have only one option, it can't be closed.

Adding self.list.appendTo( self.listbox ) before calling self._focusButton() as its done for the pagehide of the full page menu seem to fix the issue. But maybe a better solution would be to put self.list.appendTo( self.listbox ) in _focusButton() like it was before.
