### PR TITLE
check the domCache option before rebinding the page remove on select menu

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -583,9 +583,11 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 			// rebind the page remove that was unbound in the open function
 			// to allow for the parent page removal from actions other than the use
 			// of a dialog sized custom select
-			self.thisPage.bind( "pagehide.remove", function(){
-				$(this).remove();
-			});
+			if( !self.thisPage.data("page").options.domCache ){
+				self.thisPage.bind( "pagehide.remove", function(){
+					$(this).remove();
+				});
+			}
 
 			// doesn't solve the possible issue with calling change page
 			// where the objects don't define data urls which prevents dialog key


### PR DESCRIPTION
When closing a fullpage select menu we need to check the domCache option before rebinding the page remove handler. If domCache is true the page remove wasn't bound in the first place, so binding it on menu close will cause the removing of a page that mustn't be removed.
