### PR TITLE
Don't apply $.mobile.activeBtnClass on a "disabled" button of navbar

### DIFF
--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -36,7 +36,7 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 			iconpos:	iconpos
 		});
 
-		$navbar.delegate( "a", "vclick", function( event ) {
+		$navbar.delegate( "a:not(.ui-disabled)", "vclick", function( event ) {
 			$navbtns.not( ".ui-state-persist" ).removeClass( $.mobile.activeBtnClass );
 			$( this ).addClass( $.mobile.activeBtnClass );
 		});


### PR DESCRIPTION
Related to https://github.com/jquery/jquery-mobile/pull/2083

For now if the user click on a disabled button (button with class "ui-disabled") in a navigation bar, a $.mobile.activeBtnClass: "ui-btn-active" class apply on it and the button appears as clicked.

In this pull request, I just added a condition to not bind vclick event on a "disabled" button.
