### PR TITLE
Fix for Docs Split Button List dialog has weird line artifact from .type-interior class

### DIFF
--- a/docs/lists/lists-split-purchase.html
+++ b/docs/lists/lists-split-purchase.html
@@ -14,7 +14,7 @@
 <body> 
 
 
-	<div data-role="page" class="type-interior">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="a">
 			<h1>Purchase?</h1>


### PR DESCRIPTION
Fix for Split Button List dialog having no background and weird line from background image.

You can confirm this bug by going to http://jquerymobile.com/test/docs/pages/page-dialogs.html#/test/docs/lists/lists-split.html and clicking one of the split buttons on the right of the list items.

The resulting dialog shouldn't have a line through it.  I made a guess that removing that class was the fix, the only other alternative I can see is to update the style to set the background if the page is a dialog.
