### PR TITLE
Add Step to Slider (including decimal), logic from jQueryUI

### DIFF
--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -225,7 +225,7 @@ $.widget( "mobile.slider", $.mobile.widget, {
 			cType = control[0].nodeName.toLowerCase(),
 			min = cType === "input" ? parseFloat( control.attr( "min" ) ) : 0,
 			max = cType === "input" ? parseFloat( control.attr( "max" ) ) : control.find( "option" ).length - 1,
-			step = (cType === "input" && parseFloat(control.attr("step"))>0) ? parseFloat(control.attr("step")) : 1; 
+			step = (cType === "input" && parseFloat( control.attr( "step" ) ) > 0) ? parseFloat(control.attr("step")) : 1; 
 			
 		if ( typeof val === "object" ) {
 			var data = val,
@@ -256,17 +256,17 @@ $.widget( "mobile.slider", $.mobile.widget, {
 			percent = 100;
 		}
 
-		var newval = Math.round( ( percent / 100 ) * ( max - min ) ) + min;
+		var newval = ( percent / 100 ) * ( max - min ) + min;
 
 		//from jQuery UI slider, the following source will round to the neraest step
-		var valModStep = (newval - min) % step;	
+		var valModStep = ( newval - min ) % step;	
 		var alignValue = newval - valModStep;	
 
-		if ( Math.abs(valModStep) * 2 >= step ) {
+		if ( Math.abs( valModStep ) * 2 >= step ) {
 			alignValue += ( valModStep > 0 ) ? step : ( -step );
 		}
 		// Since JavaScript has problems with large floats, round
-		// the final value to 5 digits after the decimal point (see jQuery UI: #4124)
+		// the final value to 5 digits after the decimal point (see jQueryUI: #4124)
 		newval = parseFloat( alignValue.toFixed(5) );
 
 		if ( newval < min ) {

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -257,6 +257,17 @@ $.widget( "mobile.slider", $.mobile.widget, {
 
 		var newval = Math.round( ( percent / 100 ) * ( max - min ) ) + min;
 
+		//from jQuery UI slider, the following source will round to the neraest step
+		var valModStep = (newval - min) % step;	
+		var alignValue = newval - valModStep;	
+
+		if ( Math.abs(valModStep) * 2 >= step ) {
+			alignValue += ( valModStep > 0 ) ? step : ( -step );
+		}
+		// Since JavaScript has problems with large floats, round
+		// the final value to 5 digits after the decimal point (see jQuery UI: #4124)
+		newval = parseFloat( alignValue.toFixed(5) );
+
 		if ( newval < min ) {
 			newval = min;
 		}

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -224,8 +224,9 @@ $.widget( "mobile.slider", $.mobile.widget, {
 		var control = this.element, percent,
 			cType = control[0].nodeName.toLowerCase(),
 			min = cType === "input" ? parseFloat( control.attr( "min" ) ) : 0,
-			max = cType === "input" ? parseFloat( control.attr( "max" ) ) : control.find( "option" ).length - 1;
-
+			max = cType === "input" ? parseFloat( control.attr( "max" ) ) : control.find( "option" ).length - 1,
+			step = (cType === "input" && parseFloat(control.attr("step"))>0) ? parseFloat(control.attr("step")) : 1; 
+			
 		if ( typeof val === "object" ) {
 			var data = val,
 				// a slight tolerance helped get to the ends of the slider


### PR DESCRIPTION
I borrowed the logic from the jQuery UI to bring the functionality of the "step" attribute on par with jQueryUI's. I know this issue request has been rejected twice before but I could never get those patches to work either.

I've tested this quite a bit (I've been using it since Alpha 4, now still working on Beta 2). And you could also consider it tested by the jQueryUI community as well.

To test, create a slider with step 0.5 like so:

``` html
<div data-role="fieldcontain">
  <label for="rWidth">Width:</label>
  <input type="range" name="rWidth" id="rWidth" value="8.5" min="4" max="20" step="0.5"   />
</div>
```

This is my first time sending a pull request, using github, etc., so forgive me if I did something wrong. 
