### PR TITLE
check the domCache option before rebinding the page remove on select menu

### DIFF
--- a/js/jquery.mobile.forms.select.custom.js
+++ b/js/jquery.mobile.forms.select.custom.js
@@ -248,9 +248,11 @@
 					// rebind the page remove that was unbound in the open function
 					// to allow for the parent page removal from actions other than the use
 					// of a dialog sized custom select
-					self.thisPage.bind( "pagehide.remove", function() {
-						$(this).remove();
-					});
+					if( !self.thisPage.data("page").options.domCache ){
+						self.thisPage.bind( "pagehide.remove", function() {
+							$(this).remove();
+						});
+					}
 
 					// doesn't solve the possible issue with calling change page
 					// where the objects don't define data urls which prevents dialog key

--- a/tests/unit/select/cached-dom-cache-true.html
+++ b/tests/unit/select/cached-dom-cache-true.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <div id="dialog-select-parent-domcache-test" data-nstest-role="page" data-nstest-dom-cache="true">
+	    <div data-nstest-role="fieldcontain" id="domcache-page-select-container">
+		    <label for="domcache-page-select" class="select">Your state:</label>
+		    <select name="domcache-page-select" id="domcache-page-select" data-nstest-native-menu="false">
+			    <option value="AL">Alabama</option>
+			    <option value="AK">Alaska</option>
+			    <option value="AZ">Arizona</option>
+			    <option value="AR">Arkansas</option>
+			    <option value="CA">California</option>
+			    <option value="CO">Colorado</option>
+			    <option value="CT">Connecticut</option>
+			    <option value="DE">Delaware</option>
+			    <option value="FL">Florida</option>
+			    <option value="GA">Georgia</option>
+			    <option value="HI">Hawaii</option>
+			    <option value="ID">Idaho</option>
+			    <option value="IL">Illinois</option>
+			    <option value="IN">Indiana</option>
+			    <option value="IA">Iowa</option>
+			    <option value="KS">Kansas</option>
+			    <option value="KY">Kentucky</option>
+			    <option value="LA">Louisiana</option>
+			    <option value="ME">Maine</option>
+			    <option value="MD">Maryland</option>
+			    <option value="MA">Massachusetts</option>
+			    <option value="MI">Michigan</option>
+			    <option value="MN">Minnesota</option>
+			    <option value="MS">Mississippi</option>
+			    <option value="MO">Missouri</option>
+			    <option value="MT">Montana</option>
+			    <option value="NE">Nebraska</option>
+			    <option value="NV">Nevada</option>
+			    <option value="NH">New Hampshire</option>
+			    <option value="NJ">New Jersey</option>
+			    <option value="NM">New Mexico</option>
+			    <option value="NY">New York</option>
+			    <option value="NC">North Carolina</option>
+			    <option value="ND">North Dakota</option>
+			    <option value="OH">Ohio</option>
+			    <option value="OK">Oklahoma</option>
+			    <option value="OR">Oregon</option>
+			    <option value="PA">Pennsylvania</option>
+			    <option value="RI">Rhode Island</option>
+			    <option value="SC">South Carolina</option>
+			    <option value="SD">South Dakota</option>
+			    <option value="TN">Tennessee</option>
+			    <option value="TX">Texas</option>
+			    <option value="UT">Utah</option>
+			    <option value="VT">Vermont</option>
+			    <option value="VA">Virginia</option>
+			    <option value="WA">Washington</option>
+			    <option value="WV">West Virginia</option>
+			    <option value="WI">Wisconsin</option>
+			    <option value="WY">Wyoming</option>
+		    </select>
+	    </div>
+    </div>
+  </body>
+</html>

--- a/tests/unit/select/select_cached.js
+++ b/tests/unit/select/select_cached.js
@@ -67,4 +67,35 @@
 			start
 		]);
 	});
+	
+	asyncTest( "dialog sized select shouldn't rebind its parent page remove handler when closing, if the parent page domCache option is true", function(){
+		expect( 3 );
+
+		$.testHelper.pageSequence([
+			resetHash,
+
+			function(){
+				$.mobile.changePage( "cached-dom-cache-true.html" );
+			},
+
+			function(){
+				$.mobile.activePage.find( "#domcache-page-select" ).siblings( 'a' ).click();
+			},
+
+			function(){
+				ok( $.mobile.activePage.hasClass('ui-dialog'), "the dialog came up" );
+				$.mobile.activePage.find( "li a" ).last().click();
+			},
+
+			function(){
+				ok( $.mobile.activePage.is( "#dialog-select-parent-domcache-test" ), "the dialog closed" );
+				$.mobile.changePage( $( "#default" ) );
+			},
+
+			function(){
+				same( $("#dialog-select-parent-domcache-test").length, 1, "make sure the select parent page is still cached in the dom after changing page" );
+				start();
+			}
+		]);
+	});
 })(jQuery);


### PR DESCRIPTION
Migration of https://github.com/jquery/jquery-mobile/pull/2222 in the new jquery.mobile.forms.select.custom.js

When closing a fullpage select menu we need to check the domCache option before rebinding the page remove handler. If domCache is true the page remove wasn't bound in the first place, so binding it on menu close will cause the removing of a page that mustn't be removed.

Also added a test case in select_cached.js (I'm not familiar with qunit so it might need a review).
