### PR TITLE
Fix for small typo in collapsible-set docs page

### DIFF
--- a/docs/content/content-collapsible-set.html
+++ b/docs/content/content-collapsible-set.html
@@ -25,7 +25,7 @@
 		
 		<h2>Collapsible set markup</h2>
 		<p>Collapsible sets start with the exact same markup as <a href="content-collapsible.html">individual collapsibles</a>. By adding a parent wrapper with a <code> data-role="collapsible-set"</code> attribute around a number of collapsibles, the framework will style these to looks like a visually grouped widget and make it behave like an accordion so only one section can be open at a time.</p>
-		<p>By default, all the sections will be collapsed. To set a section to be open when the page loads, add the <code> data-role="data-collapsed="false"</code> attribute to the heading of the section you want expanded.</p>
+		<p>By default, all the sections will be collapsed. To set a section to be open when the page loads, add the <code> data-collapsed="false"</code> attribute to the heading of the section you want expanded.</p>
 
 	<pre><code>		
 &lt;div data-role="collapsible-set"&gt;


### PR DESCRIPTION
There was an extra data-role in the data-collapsed attribute code block.
