### PR TITLE
Fix for issue 509 textarea autogrow

### DIFF
--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -109,6 +109,13 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 				clearTimeout( keyupTimeout );
 				keyupTimeout = setTimeout( keyup, keyupTimeoutBuffer );
 			});
+			// Issue 509: the browser is not giving scrollHeight properly until after this function has run, adding in a setTimeout
+			// so we can properly access the scrollHeight
+			if ($.trim(input.text())) {
+				setTimeout( function() {
+					keyup();
+				}, 0 );
+			}
 		}
 	},
 


### PR DESCRIPTION
This is a fix for https://github.com/jquery/jquery-mobile/issues/#issue/509

The fix is based on the solution proposed here:
https://github.com/jquery/jquery-mobile/pull/872
with all unnecessary changes removed and based against more recent version of jquery-mobile code. 

Proposed fix was test to work on iOS4, iOS5beta6 and Android 2.2
