### PR TITLE
Allow full width search inputs

### DIFF
--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -49,7 +49,7 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 		//"search" input widget
 		if ( input.is( "[type='search'],:jqmData(type='search')" ) ) {
 
-			focusedEl = input.wrap( "<div class='ui-input-search ui-shadow-inset ui-btn-corner-all ui-btn-shadow ui-icon-searchfield" + themeclass + "'></div>" ).parent();
+			focusedEl = input.wrap( "<div class='ui-input-search'><div class='ui-input-search-inner ui-shadow-inset ui-btn-corner-all ui-btn-shadow ui-icon-searchfield" + themeclass + "'></div></div>" ).parent();
 			clearbtn = $( "<a href='#' class='ui-input-clear' title='clear text'>clear text</a>" )
 				.tap(function( event ) {
 					input.val( "" ).focus();

--- a/themes/default/jquery.mobile.forms.textinput.css
+++ b/themes/default/jquery.mobile.forms.textinput.css
@@ -7,7 +7,8 @@ label.ui-input-text { font-size: 16px; line-height: 1.4; display: block; font-we
 input.ui-input-text, textarea.ui-input-text { background-image: none; padding: .4em; line-height: 1.4; font-size: 16px; display: block; width: 95%; }
 input.ui-input-text { -webkit-appearance: none; }
 textarea.ui-input-text { height: 50px; -webkit-transition: height 200ms linear; -moz-transition: height 200ms linear; -o-transition: height 200ms linear; transition: height 200ms linear; }
-.ui-input-search { padding: 0 30px; width: 77%; background-position: 8px 50%; background-repeat: no-repeat; position: relative; }
+.ui-input-search { width: 77%; }
+.ui-input-search-inner { padding: 0 30px; width: auto; background-position: 8px 50%; background-repeat: no-repeat; position: relative; }
 .ui-input-search input.ui-input-text { border: none; width: 98%; padding: .4em 0; margin: 0; display: block; background: transparent none; outline: 0 !important; }
 .ui-input-search .ui-input-clear { position: absolute; right: 0; top: 50%; margin-top: -14px; }
 .ui-input-search .ui-input-clear-hidden { display: none; }


### PR DESCRIPTION
Currently the structure of search inputs makes it hard to set full width search inputs. After several hours of debugging I found a workaround: 
- set the width of 'ui-input-search' to 'auto !important' 
- add a wrapping div with the desired width.

Please consider this patch that implements this so users just need to set the width for ui-input-search (and be consistent with other controls). Others have had this problem: [1].

Tested on iPad, Firefox, Playbook.

[1] https://forum.jquery.com/topic/input-type-search-with-100-width
