### PR TITLE
Fix for custom select menu dynamic items not refreshed properly

### DIFF
--- a/js/jquery.mobile.forms.select.custom.js
+++ b/js/jquery.mobile.forms.select.custom.js
@@ -206,7 +206,7 @@
 				var self = this,
 				select = this.element,
 				isMultiple = this.isMultiple,
-				options = this.optionElems = select.find( "option" ),
+				options = this.optionElems = this.selectOptions = select.find( "option" ),
 				selected = this.selected(),
 				// return an array of all selected index's
 				indicies = this.selectedIndices();


### PR DESCRIPTION
Added selectOptions to the assignment of options in the custom select refresh method.

Custom menu items that are dynamically added with the $(elem).selectmenu('refresh') method were not getting equal treatment as the other elements.

I've made a jsfiddle with references to the latest scripts to show the problem.

http://jsfiddle.net/jacob4u2/XjEG5/
