### PR TITLE
Support transparent dialog backgrounds

### DIFF
--- a/js/jquery.mobile.transition.js
+++ b/js/jquery.mobile.transition.js
@@ -19,7 +19,13 @@ function css3TransitionHandler( name, reverse, $to, $from ) {
 			$to.add( $from ).removeClass( "out in reverse " + name );
 
 			if ( $from ) {
-				$from.removeClass( $.mobile.activePageClass );
+			    $from.removeClass($.mobile.activePageClass);
+			    if ($to.attr("data-role") == "dialog") {
+			        $from.addClass("ui-dialog-background");
+			    }
+			    if ($from.attr("data-role") == "dialog") {
+			        $to.removeClass("ui-dialog-background");
+			    }
 			}
 
 			$to.parent().removeClass( viewportClass );

--- a/themes/default/jquery.mobile.dialog.css
+++ b/themes/default/jquery.mobile.dialog.css
@@ -7,3 +7,4 @@
 .ui-dialog .ui-header, .ui-dialog .ui-content,  .ui-dialog .ui-footer { margin: 15px; position: relative; }
 .ui-dialog .ui-header, .ui-dialog .ui-footer { z-index: 10; width: auto; }
 .ui-dialog .ui-content, .ui-dialog .ui-footer { margin-top: -15px;  }
+.ui-mobile .ui-dialog-background { display: block; }


### PR DESCRIPTION
This change allows the dialog to work more like a standard dialog when the device screen is significantly larger than the dialog content.

When transitioning to a dialog, the class ui-dialog-background is added to the previous page so that it will remain visible if the background of ui-dialog is set to transparent rather than black.

The background page may also need data-dom-cache set to prevent it from being removed - there doesn't seem to be an easy way around that without significantly complicating the timer call that removes hidden pages. 
