### PR TITLE
Fix for issue #2379 when clicking button, redundant codes are added

### DIFF
--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -41,21 +41,22 @@ $.widget( "mobile.button", $.mobile.widget, {
 		// Add hidden input during submit
 		type = $el.attr( "type" );
 
-		if ( type !== "button" && type !== "reset" ) {
-
+		// button.type = submit
+		// button's default type is submit when the button is child of form	
+		if ( type === "submit" || ( !type && $el.parents("form") ) ) {
 			$el.bind( "vclick", function() {
-
-				var $buttonPlaceholder = $( "<input>", {
-							type: "hidden",
-							name: $el.attr( "name" ),
-							value: $el.attr( "value" )
-						})
-						.insertBefore( $el );
-
-				// Bind to doc to remove after submit handling
-				$( document ).submit(function(){
-					 $buttonPlaceholder.remove();
-				});
+				if ( !$el.attr( "aria-disabled" ) ) {
+					var $buttonPlaceholder = $( "<input>", {
+								type: "hidden",
+								name: $el.attr( "name" ),
+								value: $el.attr( "value" )
+							})
+							.insertBefore( $el );
+					// Bind to doc to remove after submit handling
+					$( document ).submit(function(){
+						$buttonPlaceholder.remove();
+					});
+				}
 			});
 		}
 


### PR DESCRIPTION
Bug discription :
When button is clicked, input element is added for "submit".
This element is removed only when the button is submitted.
The extra input element is added even if the button is disabled or
it is not a "submit" button.

Fix :
Add input element when the button is enabled and
the button is "submit".
It checks if the parent is "form" or not because button in the form
is considered as "submit" by default when it is not declared.
