### PR TITLE
Fix for issue #2390: fixed typo: 'throttledResize' => 'throttledresize'

### DIFF
--- a/js/jquery.mobile.media.classes.js
+++ b/js/jquery.mobile.media.classes.js
@@ -77,7 +77,7 @@ $( document ).bind( "mobileinit.htmlclass", function() {
 
 	var ev = $.support.orientation;
 
-	$window.bind( "orientationchange.htmlclass throttledResize.htmlclass", function( event ) {
+	$window.bind( "orientationchange.htmlclass throttledresize.htmlclass", function( event ) {
 
 		// add orientation class to HTML element on flip/resize.
 		if ( event.orientation ) {


### PR DESCRIPTION
`$window.bind` is called with the events 'orientationchange.htmlclass' and 'throttledResize.htmlclass'; but the second event is declared and used elsewhere in jQuery Mobile as 'throttledresize' (not a capital R). At least on some browsers, this typo causes the associated code _not_ to be fired whenever the 'throttledresize' event is triggered.
