### PR TITLE
[experiments] Fix : show fixedfooter after calculating page content height for scrollview.

### DIFF
--- a/experiments/scrollview/scrollview.js
+++ b/experiments/scrollview/scrollview.js
@@ -53,6 +53,7 @@ $(":jqmData(role='page')").live("pageshow", function(event) {
 	// also handle the case where pages are loaded dynamically.
 
 	ResizePageContentHeight(event.target);
+	$.mobile.fixedToolbars.show( true, this );
 });
 
 $(window).bind("orientationchange", function(event) {


### PR DESCRIPTION
Currently Fixed header and footer is shown before calculating
page content height for scrollview.
"pageshow" event is propagated to fixed header & footer first.
Because it is experimental, I want to call show function explicitly.
