### PR TITLE
Avoid js injection when Select control using data-native-menu property

### DIFF
--- a/js/jquery.mobile.forms.select.custom.js
+++ b/js/jquery.mobile.forms.select.custom.js
@@ -396,7 +396,7 @@
 					var $this = $( this ),
 						$parent = $this.parent(),
 						text = $this.text(),
- 				//previous: anchor = "<a href='#'>"+ text +"</a>", which allows js injection
+  	 				//avoid js injection
 						anchor = "<a href='#'>"+ $this.text(text).html() +"</a>",
 						classes = [],
 						extraAttrs = [];


### PR DESCRIPTION
I found that when Select control uses data-native-menu property, js injection is allowed, so I made a minor change to js/jquery.mobile.forms.select.custom.js to prevent js injection:
anchor = "&#60;a href='#'&#62;" +$this.text(text).html()+"&#60;/a&#62;", 

which is previously: 
anchor = "&#60;a href='#'&#62;"+ text +"&#60;/a&#62;",
