### PR TITLE
Feature Request: Allow radios in horizontal controlgroup to have icons.

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -21,7 +21,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			inputtype = input.attr( "type" ),
 			checkedState = inputtype + "-on",
 			uncheckedState = inputtype + "-off",
-			icon = input.parents( ":jqmData(type='horizontal')" ).length ? undefined : uncheckedState,
+			icon = input.parents( ":jqmData(type='horizontal')" ).length ? (input.parents( ":jqmData(iconpos)" ).length ? uncheckedState : undefined) : uncheckedState,
 			activeBtn = icon ? "" : " " + $.mobile.activeBtnClass,
 			checkedClass = "ui-" + checkedState + activeBtn,
 			uncheckedClass = "ui-" + uncheckedState,


### PR DESCRIPTION
I found that most of the icon positioning settings display just fine in a horizontal controlgroup of radio buttons. The 'notext' positioning is fairly useless but I couldn't find an elegant way to ignore just that one iconpos value while still enabling the other positioning options.

If the data-iconpos is not set, which would be most cases, then the options display as they currently do, without any icon.

Commit messages: 
If the data-iconpos attribute is manually set on the radios in a horizontal controlgroup, allow the icons to be placed. Known problem that if you set iconpos='notext' that the buttons aren't useful and appear broken.
