### PR TITLE
Fix for issue: vmouse doesn't have offset property

### DIFF
--- a/experiments/scrollview/scrollview.js
+++ b/experiments/scrollview/scrollview.js
@@ -53,6 +53,7 @@ $(":jqmData(role='page')").live("pageshow", function(event) {
 	// also handle the case where pages are loaded dynamically.
 
 	ResizePageContentHeight(event.target);
+	$.mobile.fixedToolbars.show( true, this );
 });
 
 $(window).bind("orientationchange", function(event) {

--- a/js/jquery.mobile.vmouse.js
+++ b/js/jquery.mobile.vmouse.js
@@ -53,6 +53,38 @@ function getNativeEvent( event ) {
 	return event;
 }
 
+function getElementPositionLeft( element ) {
+	var x = 0,
+		e;
+	for ( e = element; e; e = e.offsetParent ) {
+		x += e.offsetLeft;
+	}
+
+	for ( e = element.parentNode; e && e != document.body; e = e.parentNode ) {
+		if ( e.scrollLeft ) {
+			x -= e.scrollLeft;
+		}
+	}
+
+	return x;
+}
+
+function getElementPositionTop( element ) {
+	var y = 0,
+		e;
+	for ( e = element; e; e = e.offsetParent ) {
+		y += e.offsetTop;
+	}
+
+	for ( e = element.parentNode; e && e != document.body ; e = e.parentNode ) {
+		if ( e.scrollTop ) {
+			y -= e.scrollTop;
+		}
+	}
+
+	return y;
+}
+
 function createVirtualEvent( event, eventType ) {
 
 	var t = event.type,
@@ -85,6 +117,10 @@ function createVirtualEvent( event, eventType ) {
 				prop = touchEventProps[ j ];
 				event[ prop ] = touch[ prop ];
 			}
+			// TouchEvent doesn't have offsetX and offsetY.
+			// add offsetX, offsetY property to virtual event.
+			event[ "offsetX" ] = touch.pageX - getElementPositionLeft( event.target );
+			event[ "offsetY" ] = touch.pageY - getElementPositionTop( event.target );
 		}
 	}
 


### PR DESCRIPTION
Touch event doesn't have offsetX and offsetY properties.
Therefore it breaks functionality when developer uses offsetX and offsetY
to develop the application for the device supporting mouse and touch events.
I added the offsetX and offsetY properties on vmouse event to sync.

commit id :42a5168a 
