### PR TITLE
Add a $.mobile.tapholdDuration parameter

### DIFF
--- a/docs/api/globalconfig.html
+++ b/docs/api/globalconfig.html
@@ -112,7 +112,10 @@ $(document).bind("mobileinit", function(){
 	<dd>Set the default transition for dialog changes that use Ajax. Set to 'none' for no transitions by default.</dd>
 
 	<dt><code>minScrollBack</code> <em>string</em>, default: 150</dt> 
-	<dd>Minimum scroll distance that will be remembered when returning to a page. </dd>
+    <dd>Minimum scroll distance that will be remembered when returning to a page. </dd>
+
+	<dt><code>tapholdDuration</code> <em>integer</em>, default: 750</dt> 
+	<dd>The time (in milliseconds) before the "taphold" event is triggered.</dd>
 	
 	<dt><code>loadingMessage</code> <em>string</em>, default: "loading"</dt> 
 	<dd>Set the text that appears when a page is loading. If set to false, the message will not appear at all.</dd>

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -38,6 +38,9 @@
 		// Minimum scroll distance that will be remembered when returning to a page
 		minScrollBack: 250,
 
+        // The timeout for taphold events, in milliseconds
+        tapholdDuration: 750,
+
 		// Set default dialog transition - 'none' for no transitions
 		defaultDialogTransition: "pop",
 

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -110,7 +110,7 @@ $.event.special.tap = {
 
 			timer = setTimeout(function() {
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold" ) );
-			}, 750 );
+			}, $.mobile.tapholdDuration);
 		});
 	}
 };

--- a/tests/unit/event/event_core.js
+++ b/tests/unit/event/event_core.js
@@ -151,7 +151,7 @@
 		setTimeout(function(){
 			ok(taphold);
 			start();
-		}, 751);
+		}, $.mobile.tapholdDuration + 1);
 	});
 
 	//NOTE used to simulate movement when checked


### PR DESCRIPTION
Hi,

This is just a small patch based on a pull request originally authored by @kpozin here:
https://github.com/jquery/jquery-mobile/pull/2172

This request has been inactive for well over a month.

I have also updated the tests and documentation to reflect the new parameter.
