### PR TITLE
Fix for issue #2192 labels for form inputs have different vertical alignm

### DIFF
--- a/themes/default/jquery.mobile.forms.select.css
+++ b/themes/default/jquery.mobile.forms.select.css
@@ -31,7 +31,7 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 .ui-selectmenu .ui-header .ui-title { margin: 0.6em 46px 0.8em; }
 
 @media all and (min-width: 450px){
-	label.ui-select { display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
+	label.ui-select { vertical-align: top;  display: inline-block;  width: 20%;  margin: 0 2% 0 0; }
 	.ui-select { width: 60%; display: inline-block; }
 }	
 


### PR DESCRIPTION
label alignment for selectmenus misses vertical-align: top style if screen min-width: 480px
