### PR TITLE
Fix for issue #1900 Split list icon CSS bug

### DIFF
--- a/themes/valencia/jquery.mobile.theme.css
+++ b/themes/valencia/jquery.mobile.theme.css
@@ -585,6 +585,10 @@ a.ui-link-inherit {
   border-color:           rgba(255,255,255,.25);
 }
 
+.ui-listview * .ui-btn-inner > .ui-btn > .ui-btn-inner {
+  border-top: 0px;
+}
+
 /* Container Corner radius */
 .ui-corner-tl { 
   -moz-border-radius-topleft:         .6em;


### PR DESCRIPTION
removes the white top border above split list icons (finally)
