### PR TITLE
Two typos in docs.  Missing closing brackets for radio and checkbox in options

### DIFF
--- a/docs/forms/checkboxes/options.html
+++ b/docs/forms/checkboxes/options.html
@@ -42,7 +42,7 @@
 			<dd>
 				<p class="default">default: null, inherited from parent</p>
 				<p>Sets the theme swatch color scheme for the checkbox. This is a single letter from a-z that maps to the swatches included in your theme. By default, a checkbox will inherit the same swatch color as it's parent container if not explicitly set. This option is also exposed as a data attribute: <code>data-theme=&quot;a&quot;</code></p>		
-				<pre><code>$("input[type='checkbox'").checkboxradio(<strong>{ theme: "a" }</strong>);</code></pre>
+				<pre><code>$("input[type='checkbox']").checkboxradio(<strong>{ theme: "a" }</strong>);</code></pre>
 			</dd>
 			
 		</dl>	

--- a/docs/forms/radiobuttons/options.html
+++ b/docs/forms/radiobuttons/options.html
@@ -42,7 +42,7 @@
 			<dd>
 				<p class="default">default: null, inherited from parent</p>
 				<p>Sets the theme swatch color scheme for the  radio button. This is a single letter from a-z that maps to the swatches included in your theme. By default, a radio button will inherit the same swatch color as it's parent container if not explicitly set. This option is also exposed as a data attribute: <code>data-theme=&quot;a&quot;</code></p>		
-				<pre><code>$("input[type='radio'").checkboxradio(<strong>{ theme: "a" }</strong>);</code></pre>
+				<pre><code>$("input[type='radio']").checkboxradio(<strong>{ theme: "a" }</strong>);</code></pre>
 			</dd>
 			
 		</dl>	


### PR DESCRIPTION
Selectors for radio buttons and checkboxes were missing a closing brackets in the options section of the docs for their respective pages.  Added them in.  Minor correction but very helpful for all those copy-pasters out there.
