### PR TITLE
Style count only when list is enhanced

### DIFF
--- a/themes/default/jquery.mobile.listview.css
+++ b/themes/default/jquery.mobile.listview.css
@@ -34,7 +34,7 @@ ol.ui-listview .ui-li-jsnumbering:before { content: "" !important; } /* to avoid
 }	 
 .ui-li-divider { cursor: default; }
 .ui-li-has-alt .ui-btn-inner a.ui-link-inherit, .ui-li-static.ui-li-has-alt { padding-right: 95px; }
-.ui-li-count { position: absolute; font-size: 11px; font-weight: bold; padding: .2em .5em; top: 50%; margin-top: -.9em; right: 38px; }
+.ui-li-has-count .ui-li-count { position: absolute; font-size: 11px; font-weight: bold; padding: .2em .5em; top: 50%; margin-top: -.9em; right: 38px; }
 .ui-li-divider .ui-li-count, .ui-li-static .ui-li-count { right: 10px; }
 .ui-li-has-alt .ui-li-count { right: 55px; }
 .ui-li-link-alt { position: absolute; width: 40px; height: 100%; border-width: 0; border-left-width: 1px; top: 0; right: 0; margin: 0; padding: 0; }


### PR DESCRIPTION
List item counts should not be styled when the list is not enhanced. Doing so positions the count poorly when lists are not enhanced by jQuery Mobile (e.g., on C-grade devices or when JavaScript is disabled).

Changing the selector for styling the count to include .ui-li-has-count as an ancestor fixes that problem.
