### PR TITLE
Issue #1259 - When we're setting a header or footer to a width of 100%, a

### DIFF
--- a/themes/default/jquery.mobile.headerfooter.css
+++ b/themes/default/jquery.mobile.headerfooter.css
@@ -4,7 +4,7 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
 */
 /* fixed page header & footer configuration */
-.ui-header, .ui-footer, .ui-page-fullscreen .ui-header, .ui-page-fullscreen .ui-footer  { position: absolute;  overflow: hidden; width: 100%; border-left-width: 0; border-right-width: 0; }
+.ui-header, .ui-footer, .ui-page-fullscreen .ui-header, .ui-page-fullscreen .ui-footer  { position: absolute;  overflow: hidden; width: 100%; border-left-width: 0; border-right-width: 0; box-sizing: border-box; -webkit-box-sizing: border-box; }
 .ui-header-fixed, .ui-footer-fixed {
 	z-index: 1000;
 	-webkit-transform: translateZ(0); /* Force header/footer rendering to go through the same rendering pipeline as native page scrolling. */

--- a/themes/default/jquery.mobile.headerfooter.css
+++ b/themes/default/jquery.mobile.headerfooter.css
@@ -4,7 +4,7 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
 */
 /* fixed page header & footer configuration */
-.ui-header, .ui-footer, .ui-page-fullscreen .ui-header, .ui-page-fullscreen .ui-footer  { position: absolute;  overflow: hidden; width: 100%; border-left-width: 0; border-right-width: 0; box-sizing: border-box; -webkit-box-sizing: border-box; }
+.ui-header, .ui-footer, .ui-page-fullscreen .ui-header, .ui-page-fullscreen .ui-footer  { position: absolute;  overflow: hidden; width: 100%; border-left-width: 0; border-right-width: 0; box-sizing: border-box; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; }
 .ui-header-fixed, .ui-footer-fixed {
 	z-index: 1000;
 	-webkit-transform: translateZ(0); /* Force header/footer rendering to go through the same rendering pipeline as native page scrolling. */


### PR DESCRIPTION
Issue #1259 - When we're setting a header or footer to a width of 100%, and then adding 15px of margin (for a ui-bar), we're actually getting 100%+30px, due to the content-box box model. This makes the viewport wider than 100%, so we get sideways scrolling.

Using -webkit-box-sizing and box-sizing set to border-box gives us something a little closer to what we're looking for, which is the bar to be full width including any padding.

I'm basing this off of (http://www.quirksmode.org/css/box.html)

I've tested this fix in iOS4 - I'd love some help testing to make sure there's no regressions. :)
