### PR TITLE
Fixes #2593 — Prevents rounded corners on icons in lists.

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -91,6 +91,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 					.addClass( "ui-corner-tr" )
 				.end()
 				.find( ".ui-li-thumb" )
+					.not(".ui-li-icon")
 					.addClass( "ui-corner-tl" );
 
 			// Select the last visible li element
@@ -102,6 +103,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 					.addClass( "ui-corner-br" )
 				.end()
 				.find( ".ui-li-thumb" )
+					.not(".ui-li-icon")
 					.addClass( "ui-corner-bl" );
 		}
 	},


### PR DESCRIPTION
Fixes #2593 — Prevents application of ‘ui-corner-bl’ and ‘ui-corner-tl’ classes to ‘ui-li-thumb’ elements that have a class of ‘ui-li-icon.’
