### PR TITLE
Fix for #2653 - Firefox 7.0.1 - Collapsible heading gets truncated beginn

### DIFF
--- a/themes/default/jquery.mobile.collapsible.css
+++ b/themes/default/jquery.mobile.collapsible.css
@@ -10,7 +10,7 @@
 .ui-collapsible-heading a span.ui-btn { position: absolute; left: 6px; top: 50%; margin: -12px 0 0 0; width: 20px; height: 20px; padding: 1px 0px 1px 2px; text-indent: -9999px; }
 .ui-collapsible-heading a span.ui-btn .ui-btn-inner { padding: 10px 0; }
 .ui-collapsible-heading a span.ui-btn .ui-icon { left: 0; margin-top: -10px; }
-.ui-collapsible-heading-status { position:absolute; left:-9999px; }
+.ui-collapsible-heading-status { position:fixed; left:-9999px; }
 .ui-collapsible-content {
 	display: block;
 	margin:  0 -8px;


### PR DESCRIPTION
the positioning of absolute -9999 for hiding collapsible header status lets firefox truncate the heading from the beginning. changed to positioning fixed.  
