### PR TITLE
Fix for Issue 2677

### DIFF
--- a/themes/valencia/jquery.mobile.theme.css
+++ b/themes/valencia/jquery.mobile.theme.css
@@ -874,7 +874,7 @@ a.ui-link-inherit {
 .ui-btn-corner-br, .ui-btn-corner-top, .ui-btn-corner-bottom, 
 .ui-btn-corner-right, .ui-btn-corner-left, .ui-btn-corner-all {
   -webkit-background-clip: padding-box;
-     -moz-background-clip: padding-box;
+     -moz-background-clip: padding;
           background-clip: padding-box;
 }
 


### PR DESCRIPTION
Recap of https://github.com/jquery/jquery-mobile/pull/2678. 
I grepped -moz-background-clip throughout the entire theme css files and found only this valencia file has the wrong value. So the default theme doesn't need an update regarding this issue.
