### PR TITLE
Fixes #2541 — Properly applies “disabled” styling and logic to custom form inputs.

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -122,7 +122,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		}
 
 		// Disable if specified
-		if ( options.disabled ) {
+		if ( options.disabled || this.element.attr('disabled')) {
 			this.disable();
 		}
 

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -215,7 +215,11 @@ $.widget( "mobile.slider", $.mobile.widget, {
 	},
 
 	refresh: function( val, isfromControl, preventInputUpdate ) {
-		if ( this.options.disabled ) { return; }
+
+		if ( this.options.disabled || this.element.attr('disabled')) { 
+			this.slider.addClass('ui-disabled');
+			return;
+		}
 
 		var control = this.element, percent,
 			cType = control[0].nodeName.toLowerCase(),


### PR DESCRIPTION
Fixes #2541 — Properly applies “disabled” styling and logic to flip switches, sliders, and custom selects based on attribute in underlying inputs’ markup.
