### PR TITLE
Docs forms / selects: double title at dialog-page of non-native-select

### DIFF
--- a/docs/forms/selects/index.html
+++ b/docs/forms/selects/index.html
@@ -70,8 +70,8 @@
 <p>Here is an example of a select with a long list of options:</p>
 
 <div data-role="fieldcontain">
-	<label for="select-choice-3" class="select">Your state:</label>
-	<select name="select-choice-3" id="select-choice-3">
+	<label for="select-choice-2" class="select">Your state:</label>
+	<select name="select-choice-2" id="select-choice-2">
 		<option value="AL">Alabama</option>
 		<option value="AK">Alaska</option>
 		<option value="AZ">Arizona</option>


### PR DESCRIPTION
Title of dialog-page for non-native-selectmenu "your state", red from select-label, had duplicate title cause of non-unique ids for selects.
