### PR TITLE
Fix for #2721: changed select label don't reflect related dialog-page-title

### DIFF
--- a/js/jquery.mobile.forms.select.custom.js
+++ b/js/jquery.mobile.forms.select.custom.js
@@ -336,6 +336,7 @@
 					});
 
 					self.menuType = "page";
+					self.menuPage.find("div .ui-title").text(widget.label.getEncodedText());
 					self.menuPageContent.append( self.list );
 					$.mobile.changePage( self.menuPage, {
 						transition: $.mobile.defaultDialogTransition

--- a/js/jquery.mobile.forms.select.custom.js
+++ b/js/jquery.mobile.forms.select.custom.js
@@ -336,7 +336,7 @@
 					});
 
 					self.menuType = "page";
-					self.menuPage.find("div .ui-title").text(widget.label.getEncodedText());
+					self.menuPage.find("div .ui-title").text(self.label.text());
 					self.menuPageContent.append( self.list );
 					$.mobile.changePage( self.menuPage, {
 						transition: $.mobile.defaultDialogTransition


### PR DESCRIPTION
@johnbender
Could you please take look at this fix, if it is acceptable?
I set the custom selectmenu dialog-page-title when the dialog is opened
(without checking if the select-label has changed since the parent-page loaded)
