### PR TITLE
Fixes #2729 — Sets a max-width of ~600px on dialogs.

### DIFF
--- a/css/structure/jquery.mobile.dialog.css
+++ b/css/structure/jquery.mobile.dialog.css
@@ -4,6 +4,7 @@
 * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
 */
 .ui-dialog { min-height: 480px; }
-.ui-dialog .ui-header, .ui-dialog .ui-content,  .ui-dialog .ui-footer { margin: 15px; position: relative; }
-.ui-dialog .ui-header, .ui-dialog .ui-footer { z-index: 10; width: auto; }
+.ui-dialog .ui-header, .ui-dialog .ui-content,  .ui-dialog .ui-footer { max-width: 500px; margin: 15px auto; padding: 15px; width: 85%; position: relative; }
+.ui-dialog .ui-header { padding: 0 15px; }
+.ui-dialog .ui-header, .ui-dialog .ui-footer { z-index: 10; }
 .ui-dialog .ui-content, .ui-dialog .ui-footer { margin-top: -15px;  }

--- a/docs/pages/page-dialogs.html
+++ b/docs/pages/page-dialogs.html
@@ -67,6 +67,16 @@
 			<p>And dialogs can be can used more like a control sheet to offer multiple buttons by removing the header:</p>
 						<a href="dialog-buttons.html" data-role="button" data-inline="true" data-rel="dialog" data-transition="slidedown">Share photos...</a>
 			
+			<p>For the sake of readability, dialogs have a default <code>max-width</code> of 500 pixels (plus 15px padding on each side). To override this, use the following CSS in your theme:</p>
+
+<code>
+.ui-dialog .ui-header,
+.ui-dialog .ui-content,
+.ui-dialog .ui-footer { <strong>max-width: 100%;</strong> }
+</code>
+
+
+
 			
 	</div><!--/content-primary -->		
 


### PR DESCRIPTION
Fixes #2729 — Sets a max-width of ~600px on dialogs (inc. full-screen selects), changes dialog width to percentage-based value.

Yes, I am sending myself this pull request. Last one, promise.
