### PR TITLE
Fix for #2322:  Move .ui-br out of swatches section of default theme

### DIFF
--- a/css/themes/default/jquery.mobile.theme.css
+++ b/css/themes/default/jquery.mobile.theme.css
@@ -90,12 +90,6 @@
     color: #2489CE /*{a-body-link-visited}*/;
 }
 
-.ui-br {
-	border-bottom: rgb(130,130,130);
-	border-bottom: rgba(130,130,130,.3);
-	border-bottom-width: 1px;
-	border-bottom-style: solid;
-}
 .ui-btn-up-a {
 	border: 1px solid 		#222 /*{a-bup-border}*/;
 	background: 			#333333 /*{a-bup-background-color}*/;
@@ -819,6 +813,15 @@ a.ui-link-inherit {
 	-moz-border-radius: 				   0;
 	-webkit-border-radius: 				   0;
 	border-radius: 						   0;
+}
+
+/* Form field separator
+-----------------------------------------------------------------------------------------------------------*/
+.ui-br {
+	border-bottom: rgb(130,130,130);
+	border-bottom: rgba(130,130,130,.3);
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
 }
 
 /* Interaction cues

--- a/css/themes/valencia/jquery.mobile.theme.css
+++ b/css/themes/valencia/jquery.mobile.theme.css
@@ -876,6 +876,15 @@ a.ui-link-inherit {
   -webkit-background-clip: padding-box;
      -moz-background-clip: padding;
           background-clip: padding-box;
+
+}
+
+/* Form field separator */
+.ui-br {
+	border-bottom: rgb(130,130,130);
+	border-bottom: rgba(130,130,130,.3);
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
 }
 
 /* Overlays */


### PR DESCRIPTION
Moved .ui-br class from swatches section to structure section of default theme.

Also added .ui-br to Valencia theme.  After the structure/theme split of the css files, the form field separator was missing if the default theme wasn't loaded first.

Fixes #2322.
