### PR TITLE
Issue 2725: Click handler exits when ajaxEnabled, page is embedded but ha

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1282,7 +1282,7 @@
 				href = path.makeUrlAbsolute( $link.attr( "href" ) || "#", baseUrl );
 
 			//if ajax is disabled, exit early
-			if( !$.mobile.ajaxEnabled && !path.isEmbeddedPage( href ) ){
+			if( !$.mobile.ajaxEnabled && ( !path.isEmbeddedPage( href ) || !$.mobile.hashListeningEnabled ) ) {
 				httpCleanup();
 				//use default click handling
 				return;


### PR DESCRIPTION
Issue 2725: Click handler exits when ajaxEnabled, page is embedded but hashListening is false
- The click handler still responds if ajaxEnabled is false but the page is embedded
- The click handler will now exit if ajaxEnabled is false, the page is embedded, but hashListeningEnabled is false

Now if ajaxEnabled is false and hashListeningEnabled is false, backbone.js hash-listening will work.
