### PR TITLE
Fix for potential issues with getInheritedTheme

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -159,12 +159,12 @@
 	};
 	
 	$.fn.inheritedTheme = function( defaultTheme ) {
-		// Find the closest parent with a theme class on it.
-		var p = this.parent(),
-			cl = p.attr( "class" ),
-			ltr = (cl && ( ltr = /ui-(bar|body)-([a-z])\b/.exec( cl ) ) && ltr[ 2 ]) || "";
-
-		return ltr || ( p.parent() && p.inheritedTheme( defaultTheme ) ) || defaultTheme || "a";
+		var ltr;
+		this.parents("[class*='ui-bar-'],[class*='ui-body-']").each(function() {
+			ltr = ( ( ltr = /ui-(bar|body)-([a-z])\b/.exec( $(this).attr("class") ) ) && ltr[ 2 ]) || "";
+			if (ltr) return false;
+		});
+		return ltr || "a";
 	};
 
 	$.fn.removeWithDependents = function() {

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -128,17 +128,7 @@
 		},
 
 		getInheritedTheme: function( el, defaultTheme ) {
-			// Find the closest parent with a theme class on it.
-			var themedParent = el.closest( "[class*='ui-bar-'],[class*='ui-body-']" ),
-	
-				// If there's a themed parent, extract the theme letter
-				// from the theme class	.
-				ltr = ( themedParent.length && (ltr = /ui-(bar|body)-([a-z])\b/.exec( themedParent.attr( "class" ) )) && ltr[ 2 ] || "" ) || "";
-
-			// Return the theme letter we found, if none, return the
-			// specified default.
-
-			return ltr || defaultTheme || "a";
+			return $( el ).inheritedTheme( defaultTheme );
 		}
 	});
 
@@ -166,6 +156,15 @@
 
 	$.jqmRemoveData = function( elem, prop ) {
 		return $.removeData( elem, $.mobile.nsNormalize( prop ) );
+	};
+	
+	$.fn.inheritedTheme = function( defaultTheme ) {
+		// Find the closest parent with a theme class on it.
+		var p = this.parent(),
+			cl = p.attr( "class" ),
+			ltr = (cl && ( ltr = /ui-(bar|body)-([a-z])\b/.exec( cl ) ) && ltr[ 2 ]) || "";
+
+		return ltr || ( p.parent() && p.inheritedTheme( defaultTheme ) ) || defaultTheme || "a";
 	};
 
 	$.fn.removeWithDependents = function() {

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -164,7 +164,7 @@
 			ltr = ( ( ltr = /ui-(bar|body)-([a-z])\b/.exec( $(this).attr("class") ) ) && ltr[ 2 ]) || "";
 			if (ltr) return false;
 		});
-		return ltr || "a";
+		return ltr || defaultTheme || "a";
 	};
 
 	$.fn.removeWithDependents = function() {

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -133,7 +133,7 @@
 	
 				// If there's a themed parent, extract the theme letter
 				// from the theme class	.
-				ltr = ( themedParent.length && /ui-(bar|body)-([a-z])\b/.exec( themedParent.attr( "class" ) )[ 2 ] || "" ) || "";
+				ltr = ( themedParent.length && (ltr = /ui-(bar|body)-([a-z])\b/.exec( themedParent.attr( "class" ) )) && ltr[ 2 ] || "" ) || "";
 
 			// Return the theme letter we found, if none, return the
 			// specified default.


### PR DESCRIPTION
per: https://github.com/jquery/jquery-mobile/issues/2770

I think the safest approach is to turn this into a recursive function. Normally I'd reuse closest(), but unless we put in a jQuery expr to support our regex (which seems a bit much for this) this seems the best approach.

It also allows you to get an inherited theme right from a jQuery object, i.e. $("#field-one").inheritedTheme()
