### PR TITLE
Add button styling to f swatch for docs

### DIFF
--- a/docs/_assets/css/jqm-docs.css
+++ b/docs/_assets/css/jqm-docs.css
@@ -140,6 +140,60 @@ dd h4 { margin:15px 0 0 0; }
 	color: 					#fff;
 	font-weight: bold;
 }
+.ui-btn-up-f {
+	border: 1px solid 		#3B6F07;
+	background: 			#56A00E;
+	font-weight: bold;
+	color: 					#fff;
+	text-shadow: 0 -1px 1px #234403;
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#74b042), to(#56A00E)); /* Saf4+, Chrome */
+	background-image: -webkit-linear-gradient(top, #74b042, #56A00E); /* Chrome 10+, Saf5.1+ */
+	background-image:    -moz-linear-gradient(top, #74b042, #56A00E); /* FF3.6 */
+	background-image:     -ms-linear-gradient(top, #74b042, #56A00E); /* IE10 */
+	background-image:      -o-linear-gradient(top, #74b042, #56A00E); /* Opera 11.10+ */
+	background-image:         linear-gradient(top, #74b042, #56A00E);
+}
+.ui-btn-up-f a.ui-link-inherit {
+	color: 					#fff;
+}
+.ui-btn-hover-f {
+	border: 1px solid 		#3B6F07;
+	background: 			#6EBC1F;
+	font-weight: bold;
+	color: 					#fff;
+	text-shadow: 0 -1px 1px #234403;
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#8FC963), to(#6EBC1F)); /* Saf4+, Chrome */
+	background-image: -webkit-linear-gradient(top, #8FC963, #6EBC1F); /* Chrome 10+, Saf5.1+ */
+	background-image:    -moz-linear-gradient(top, #8FC963, #6EBC1F); /* FF3.6 */
+	background-image:     -ms-linear-gradient(top, #8FC963, #6EBC1F); /* IE10 */
+	background-image:      -o-linear-gradient(top, #8FC963, #6EBC1F); /* Opera 11.10+ */
+	background-image:         linear-gradient(top, #8FC963, #6EBC1F);
+}
+.ui-btn-hover-f a.ui-link-inherit {
+	color: 					#fff;
+}
+.ui-btn-down-f {
+	border: 1px solid 		#3B6F07;
+	background: 			#3d3d3d;
+	font-weight: bold;
+	color: 					#fff;
+	text-shadow: 0 -1px 1px #234403;
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#56A00E), to(#64A234)); /* Saf4+, Chrome */
+	background-image: -webkit-linear-gradient(top, #56A00E, #64A234); /* Chrome 10+, Saf5.1+ */
+	background-image:    -moz-linear-gradient(top, #56A00E, #64A234); /* FF3.6 */
+	background-image:     -ms-linear-gradient(top, #56A00E, #64A234); /* IE10 */
+	background-image:      -o-linear-gradient(top, #56A00E, #64A234); /* Opera 11.10+ */
+	background-image:         linear-gradient(top, #56A00E, #64A234);
+}
+.ui-btn-down-f a.ui-link-inherit {
+	color: 					#fff;
+}
+.ui-btn-up-f,
+.ui-btn-hover-f,
+.ui-btn-down-f {
+	font-family: Helvetica, Arial, sans-serif;
+	text-decoration: none;
+}
 
 
 


### PR DESCRIPTION
Fixes back button link color issue raised in #2692 discussion.

Otherwise this does not significantly modify the look of the docs.  Really only relevant in the case of viewing the docs in iOS fullscreen web app mode.
