### PR TITLE
Fixed issue #2817 - disabled page zoom in docs

### DIFF
--- a/docs/about/accessibility.html
+++ b/docs/about/accessibility.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Accessibility</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/about/features.html
+++ b/docs/about/features.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Features</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery UI Mobile Framework - About</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/about/intro.html
+++ b/docs/about/intro.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Intro</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/about/platforms.html
+++ b/docs/about/platforms.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Supported platforms</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/api/events.html
+++ b/docs/api/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Events</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/api/globalconfig.html
+++ b/docs/api/globalconfig.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Configuring default settings</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery UI Mobile Framework - API</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/api/mediahelpers.html
+++ b/docs/api/mediahelpers.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Responsive Layout Helpers</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/api/methods.html
+++ b/docs/api/methods.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Methods</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/api/themes.html
+++ b/docs/api/themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Static Containers, States</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/api-buttons.html
+++ b/docs/buttons/api-buttons.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Buttons</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/buttons-events.html
+++ b/docs/buttons/buttons-events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Button events</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/buttons-grouped.html
+++ b/docs/buttons/buttons-grouped.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Grouped Buttons</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/> 

--- a/docs/buttons/buttons-icons.html
+++ b/docs/buttons/buttons-icons.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Button icons</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/buttons-inline.html
+++ b/docs/buttons/buttons-inline.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Inline buttons</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/buttons-methods.html
+++ b/docs/buttons/buttons-methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Button methods</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/buttons-options.html
+++ b/docs/buttons/buttons-options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Button options</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/buttons-themes.html
+++ b/docs/buttons/buttons-themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Theming buttons</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/buttons-types.html
+++ b/docs/buttons/buttons-types.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Button types</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/buttons/index.html
+++ b/docs/buttons/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Buttons</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/dialogTransition.html
+++ b/docs/config/dialogTransition.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/iOSFullscreen.html
+++ b/docs/config/iOSFullscreen.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black">
 	<link rel="apple-touch-icon" href="../_assets/images/ios_icon.png"/>

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/jq17b1.html
+++ b/docs/config/jq17b1.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/loadingMessage.html
+++ b/docs/config/loadingMessage.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/minScrollBack.html
+++ b/docs/config/minScrollBack.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/pageLoadErrorMessage.html
+++ b/docs/config/pageLoadErrorMessage.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/pageTransition.html
+++ b/docs/config/pageTransition.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/pushState.html
+++ b/docs/config/pushState.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/config/touchOverflow.html
+++ b/docs/config/touchOverflow.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/content/api-content.html
+++ b/docs/content/api-content.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<script src="../../js/jquery.js"></script>

--- a/docs/content/content-collapsible-set.html
+++ b/docs/content/content-collapsible-set.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Collapsible Content</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/content/content-collapsible.html
+++ b/docs/content/content-collapsible.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Collapsible Content</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/content/content-grids.html
+++ b/docs/content/content-grids.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Content Grids</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/content/content-html.html
+++ b/docs/content/content-html.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - HTML formatting</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/content/content-themes.html
+++ b/docs/content/content-themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Content Themes</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Content formatting</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/api-forms.html
+++ b/docs/forms/api-forms.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Forms API</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/checkboxes/events.html
+++ b/docs/forms/checkboxes/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Checkboxes</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/checkboxes/index.html
+++ b/docs/forms/checkboxes/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Checkboxes</title> 
 	<link rel="stylesheet"  href="../../../css/themes/default/" />  
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/checkboxes/methods.html
+++ b/docs/forms/checkboxes/methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Checkboxes</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/checkboxes/options.html
+++ b/docs/forms/checkboxes/options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Checkboxes</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/docs-forms.html
+++ b/docs/forms/docs-forms.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Forms</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/forms-all-native.html
+++ b/docs/forms/forms-all-native.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Native Form Controls</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/forms-all.html
+++ b/docs/forms/forms-all.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Gallery of Form Controls</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/forms-sample-response.php
+++ b/docs/forms/forms-sample-response.php
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Sample form response</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/forms-sample-selfsubmit.php
+++ b/docs/forms/forms-sample-selfsubmit.php
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Sample Form Submit to Self</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/forms-sample.html
+++ b/docs/forms/forms-sample.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Sample Form Submit</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/forms-themes.html
+++ b/docs/forms/forms-themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Theming Forms</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/index.html
+++ b/docs/forms/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Forms</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/plugin-eventsmethods.html
+++ b/docs/forms/plugin-eventsmethods.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Form Plugin Methods</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/forms/radiobuttons/events.html
+++ b/docs/forms/radiobuttons/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Radio buttons</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/radiobuttons/index.html
+++ b/docs/forms/radiobuttons/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Radio Buttons</title> 
 	<link rel="stylesheet"  href="../../../css/themes/default/" /> 
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/> 

--- a/docs/forms/radiobuttons/methods.html
+++ b/docs/forms/radiobuttons/methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Radio buttons</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/radiobuttons/options.html
+++ b/docs/forms/radiobuttons/options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Radio buttons</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/search/events.html
+++ b/docs/forms/search/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Search Input events</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/search/index.html
+++ b/docs/forms/search/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Search input</title> 
 	<link rel="stylesheet"  href="../../../css/themes/default/" />  
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/search/methods.html
+++ b/docs/forms/search/methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Search Input methods</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/search/options.html
+++ b/docs/forms/search/options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Text Search options</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/selects/events.html
+++ b/docs/forms/selects/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Select events</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/selects/index.html
+++ b/docs/forms/selects/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Select</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/selects/methods.html
+++ b/docs/forms/selects/methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Select methods</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/selects/options.html
+++ b/docs/forms/selects/options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Select options</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/slider/events.html
+++ b/docs/forms/slider/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Slider events</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/slider/index.html
+++ b/docs/forms/slider/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Slider</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/slider/methods.html
+++ b/docs/forms/slider/methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Slider methods</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/slider/options.html
+++ b/docs/forms/slider/options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Slider options</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/switch/events.html
+++ b/docs/forms/switch/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Slider events</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/switch/index.html
+++ b/docs/forms/switch/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Sliders</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/switch/methods.html
+++ b/docs/forms/switch/methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Slider methods</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/switch/options.html
+++ b/docs/forms/switch/options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Slider options</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/textinputs/events.html
+++ b/docs/forms/textinputs/events.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Text Input events</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/textinputs/index.html
+++ b/docs/forms/textinputs/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Text inputs</title> 
 	<link rel="stylesheet"  href="../../../css/themes/default/" />  
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/textinputs/methods.html
+++ b/docs/forms/textinputs/methods.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Text Input methods</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/forms/textinputs/options.html
+++ b/docs/forms/textinputs/options.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Text Input options</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery UI Mobile Framework - Documentation</title>
 	<link rel="stylesheet"  href="../css/themes/default/" /> 
 	<link rel="stylesheet" href="_assets/css/jqm-docs.css"/>

--- a/docs/lists/api-lists.html
+++ b/docs/lists/api-lists.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Lists API</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/docs-lists.html
+++ b/docs/lists/docs-lists.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Lists Overview</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/index.html
+++ b/docs/lists/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-all-full.html
+++ b/docs/lists/lists-all-full.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-count.html
+++ b/docs/lists/lists-count.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Lists Count Bubbles</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-divider.html
+++ b/docs/lists/lists-divider.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - List Dividers</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-formatting.html
+++ b/docs/lists/lists-formatting.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - List Formatting</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-forms-inset.html
+++ b/docs/lists/lists-forms-inset.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Inset Lists with Forms</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-forms.html
+++ b/docs/lists/lists-forms.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Lists with Forms</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-icons.html
+++ b/docs/lists/lists-icons.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - List Icons</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-inset.html
+++ b/docs/lists/lists-inset.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Lists with Form Controls</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-nested.html
+++ b/docs/lists/lists-nested.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Nested Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-ol.html
+++ b/docs/lists/lists-ol.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Ordered Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-performance.html
+++ b/docs/lists/lists-performance.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - List Performance Test</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-readonly-inset.html
+++ b/docs/lists/lists-readonly-inset.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Readonly Inset Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-readonly.html
+++ b/docs/lists/lists-readonly.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Inset Readonly Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-search-inset.html
+++ b/docs/lists/lists-search-inset.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Filtered Inset Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-search.html
+++ b/docs/lists/lists-search.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Filtered Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-split-purchase.html
+++ b/docs/lists/lists-split-purchase.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Sample Dialog</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-split.html
+++ b/docs/lists/lists-split.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Split Button Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-themes.html
+++ b/docs/lists/lists-themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Theming Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-thumbnails.html
+++ b/docs/lists/lists-thumbnails.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Lists with Thumbnails</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/lists/lists-ul.html
+++ b/docs/lists/lists-ul.html
@@ -3,7 +3,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Basic Lists</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/api-pages.html
+++ b/docs/pages/api-pages.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Pages API</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/dialog-alt.html
+++ b/docs/pages/dialog-alt.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/dialog-buttons.html
+++ b/docs/pages/dialog-buttons.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/dialog-success.html
+++ b/docs/pages/dialog-success.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Framework - Dialog Example</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/dialog-with-select.html
+++ b/docs/pages/dialog-with-select.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Dialog Example with Select</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/dialog.html
+++ b/docs/pages/dialog.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/docs-links-urltest/index.html
+++ b/docs/pages/docs-links-urltest/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Test URL Example</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Pages</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/multipage-template.html
+++ b/docs/pages/multipage-template.html
@@ -3,7 +3,7 @@
 
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>Multi-page template</title> 
 	<link rel="stylesheet" href="http://code.jquery.com/mobile/1.0rc2/jquery.mobile-1.0rc2.min.css" />
 	<script src="http://code.jquery.com/jquery-1.6.4.min.js"></script>

--- a/docs/pages/page-anatomy.html
+++ b/docs/pages/page-anatomy.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Anatomy of a Page</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-cache.html
+++ b/docs/pages/page-cache.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Prefetching &amp; caching pages</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-dialogs.html
+++ b/docs/pages/page-dialogs.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Dialogs</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-dynamic.html
+++ b/docs/pages/page-dynamic.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Dynamically Injecting Pages</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-links.html
+++ b/docs/pages/page-links.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Linking Pages</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-navmodel.html
+++ b/docs/pages/page-navmodel.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile Docs - Ajax, hashes &amp; history</title>
 	<link rel="stylesheet"  href="../../css/themes/default/" />
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-scripting.html
+++ b/docs/pages/page-scripting.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Scripting pages</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-template.html
+++ b/docs/pages/page-template.html
@@ -3,7 +3,7 @@
 
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>Single page template</title> 
 	<link rel="stylesheet" href="http://code.jquery.com/mobile/1.0rc2/jquery.mobile-1.0rc2.min.css" />
 	<script src="http://code.jquery.com/jquery-1.6.4.min.js"></script>

--- a/docs/pages/page-titles.html
+++ b/docs/pages/page-titles.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Page titles</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/page-transitions.html
+++ b/docs/pages/page-transitions.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Transitions</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/pages-themes.html
+++ b/docs/pages/pages-themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Theming Pages</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/pages/transition-success.html
+++ b/docs/pages/transition-success.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Dialog Example</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/api-bars.html
+++ b/docs/toolbars/api-bars.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Toolbars API</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/bars-fixed.html
+++ b/docs/toolbars/bars-fixed.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Fixed Toolbars</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/bars-fullscreen.html
+++ b/docs/toolbars/bars-fullscreen.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Fullscreen Fixed toolbars</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/bars-themes.html
+++ b/docs/toolbars/bars-themes.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Theming Toolbars</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/docs-bars.html
+++ b/docs/toolbars/docs-bars.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Toolbar Basics</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/docs-footers.html
+++ b/docs/toolbars/docs-footers.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Footer Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/docs-headers.html
+++ b/docs/toolbars/docs-headers.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Header Bars</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/docs-navbar.html
+++ b/docs/toolbars/docs-navbar.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Navbar</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/footer-persist-a.html
+++ b/docs/toolbars/footer-persist-a.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Persistent footer A</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/footer-persist-b.html
+++ b/docs/toolbars/footer-persist-b.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Persistent footer B</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/footer-persist-c.html
+++ b/docs/toolbars/footer-persist-c.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Framework - Persistent footer C</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/docs/toolbars/index.html
+++ b/docs/toolbars/index.html
@@ -2,7 +2,7 @@
 <html> 
 	<head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1"> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"> 
 	<title>jQuery Mobile Docs - Toolbars</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>jQuery Mobile: Demos and Documentation</title>
 	<link rel="stylesheet"  href="css/themes/default/" />
 	<link rel="stylesheet" href="docs/_assets/css/jqm-docs.css" />


### PR DESCRIPTION
Now, when rotating to landscape, the page doesn't zoom in and is fully visible.

I tested it on iOS 5
