### PR TITLE
Doc Fix for Fixed Toolbar

### DIFF
--- a/docs/toolbars/bars-fixed.html
+++ b/docs/toolbars/bars-fixed.html
@@ -35,7 +35,7 @@
 		
 		<h2>Tap to toggle visibility</h2>
 		<p>To toggle the visibility of fixed toolbars, tap the screen. For example, if the fixed toolbars are visible, tap the screen to hide the toolbars and take full advantage of the screen real estate for content. Tapping again will bring the toolbars back into view. </p>
-		<p>It's possible to turn off the the tap to toggle visibility behavior like this: <code>$.fixedToolbars.setTouchToggleEnabled(false)</code>.</a>
+		<p>It's possible to turn off the the tap to toggle visibility behavior like this: <code>$.mobile.fixedToolbars.setTouchToggleEnabled(false)</code>.</a>
 	
 		<h2>Updating toolbar positioning</h2>
 		<p>If the height of the page changes, either through dynamic injection of markup, or by widgets that hide or collapse content, it can throw off the dynamic positioning of the toolbars. To manually tell the toolbars to re-position themselves then fade in, use <code>$.mobile.fixedToolbars.show();</code>. To have them appear immediately without the fade, use <code>$.mobile.fixedToolbars.show(true);</code>.</p>


### PR DESCRIPTION
jQuery Mobile Docs use old $.fixedToolbars code, should be $.mobile.fixedToolbars
