### PR TITLE
Issue 2226- persistent footer error caused by race condition during fast 

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -90,7 +90,7 @@ function closestEnabledButton( element ) {
     var cname;
     
     while ( element ) {
-        cname = element.className && element.className.split(' ');
+        cname = element.className && element.className.split && element.className.split(' ');
         if ( cname && cname.indexOf( "ui-btn" ) > -1 && cname.indexOf( "ui-disabled" ) < 0 ) {
             break;
         }

--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -41,7 +41,7 @@ $.mobile.fixedToolbars = (function() {
 		return;
 	}
 
-	var stickyFooter, delayTimer,
+	var stickyFooter, _stickyFooterTimer, delayTimer,
 		currentstate = "inline",
 		autoHideMode = false,
 		showDelay = 100,
@@ -173,8 +173,12 @@ $.mobile.fixedToolbars = (function() {
 			var $this = $( this );
 
 			if ( stickyFooter && stickyFooter.length ) {
+				if (_stickyFooterTimer) {
+					clearTimeout(_stickyFooterTimer);
+				}
 
-				setTimeout(function() {
+				_stickyFooterTimer = setTimeout(function() {
+					_stickyFooterTimer = null;
 					setTop( stickyFooter.appendTo( $this ).addClass( "fade" ) );
 					stickyFooter = null;
 				}, 500);


### PR DESCRIPTION
Issue 2226- persistent footer (stickyFooter) occasionally is null while browsing around.  I think this error is caused by a race condition during fast switching, so I threw in the ye olde 'set / clear the setTimeout timer handle' trick, which fixes the bug for me.  I ran the tests, seemed fine.  I might be wrong about the nature of the bug, but this seems to do the trick.    In any case, there maybe should also be a null guard inside the setTimeout callback?
