### PR TITLE
Fix for #2865: Page title overridden on (first load) reload 

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1112,7 +1112,7 @@
 		}
 
 		//if title element wasn't found, try the page div data attr too
-		var newPageTitle = toPage.jqmData( "title" ) || toPage.children(":jqmData(role='header')").find(".ui-title" ).getEncodedText();
+		var newPageTitle = toPage.jqmData( "title" ) || pageTitle || toPage.children(":jqmData(role='header')").find(".ui-title" ).getEncodedText();
 		if( !!newPageTitle && pageTitle == document.title ) {
 			pageTitle = newPageTitle;
 		}


### PR DESCRIPTION
Fix for #2865
On page-reload, i believe, `toPage.jqmData( "title" )` is null and the page-header-text is always used.
@gseguin and @toddparker: could you please review this?
