### PR TITLE
Bugfix for named submit buttons

### DIFF
--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -56,7 +56,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 								.insertBefore( $el );
 
 						// Bind to doc to remove after submit handling
-						$( document ).submit(function(){
+						$( document ).one("submit", function(){
 							$buttonPlaceholder.remove();
 							$buttonPlaceholder = undefined;
 						});

--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -57,7 +57,8 @@ $.widget( "mobile.button", $.mobile.widget, {
 
 						// Bind to doc to remove after submit handling
 						$( document ).submit(function(){
-							 $buttonPlaceholder.remove();
+							$buttonPlaceholder.remove();
+							$buttonPlaceholder = undefined;
 						});
 					}
 				});


### PR DESCRIPTION
Bugfix: If a named submit button was clicked multiple times, the name wasn't sent in 2nd ... nth time, because the dummy hidden element was removed after the first time but never recreated.
