### PR TITLE
Fix for #2881 - Inconsistent background on themeless dialogs

### DIFF
--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -33,8 +33,9 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 				.prepend( headerCloseButton )
 			.end()
 			.find( ":jqmData(role='content'),:jqmData(role='footer')" )
+				.addClass( "ui-overlay-shadow" )
 				.last()
-				.addClass( "ui-corner-bottom ui-overlay-shadow" );
+				.addClass( "ui-corner-bottom" );
 
 		// this must be an anonymous function so that select menu dialogs can replace
 		// the close method. This is a change from previously just defining data-rel=back


### PR DESCRIPTION
@wilto Could you please review this:
Add the ui-overlay-shadow class to both, content and, if there, to the footer.
Then add the ui-corner-bottom-class to the last one.
