### PR TITLE
Fix for #2893: Buttons keep ui-btn-down-x class if leaved with mouse button pressed

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -165,7 +165,7 @@ var attachEvents = function() {
 			if ( btn ) {
 				$btn = $( btn );
 				theme = $btn.attr( "data-" + $.mobile.ns + "theme" );
-				$btn.removeClass( "ui-btn-hover-" + theme ).addClass( "ui-btn-up-" + theme );
+				$btn.removeClass( "ui-btn-hover-" + theme  + " ui-btn-down-" + theme ).addClass( "ui-btn-up-" + theme );
 			}
 		}
 	});


### PR DESCRIPTION
Consistent clean up assigned ui-btn-down-pseudo-class.
