### PR TITLE
Fix for #1935: non-native selectmenu don't lose ui-btn-hover-x

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -39,7 +39,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 		var self = this;
 
 		setTimeout( function() {
-			self.button.focus();
+			self.button.focus().trigger( 'vmouseout' );
 		}, 40);
 	},
 


### PR DESCRIPTION
Fix for #1935: removing the hover-class from the select-item by firing the vmouseout-event when coming back from the menu
