### PR TITLE
Propose to fix issue #2905: vertical controlgroup inside collapsible set display issue

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -94,6 +94,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 			colllapsiblesInSet.last()
 				.jqmData( "collapsible-last", true )
 				.find( "a:eq(0)" )
+					.not( "a" ).parent( "ui-controlgroup" )
 					.addClass( "ui-corner-bottom" )
 						.find( ".ui-btn-inner" )
 							.addClass( "ui-corner-bottom" );


### PR DESCRIPTION
Propose to fix issue #2905: The last anchor in a collapsible-set  usually gets the ui-cornor-bottom class.
In case the anchor is a child of a controlgroup this is inappropriate.
