### PR TITLE
Propose for issue #2905: vertical controlgroup inside collapsible set display issue

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -93,7 +93,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 
 			colllapsiblesInSet.last()
 				.jqmData( "collapsible-last", true )
-				.find( "a:eq(0)" )
+				.find( "a:eq(0) .ui-collapsible-heading-toggle" )
 					.addClass( "ui-corner-bottom" )
 						.find( ".ui-btn-inner" )
 							.addClass( "ui-corner-bottom" );


### PR DESCRIPTION
Propose for issue #2905: In a collapsible-set the last collapsible-header gets the ui-corner-bottom class.
If the collapsible content contains an anchor, it got the class also. 
