### PR TITLE
Change usage of "the JQuery Mobile" that was repeated several times in on

### DIFF
--- a/docs/pages/page-titles.html
+++ b/docs/pages/page-titles.html
@@ -25,7 +25,7 @@
 					
 		<h2>Titles in Ajax navigation</h2>
 		
-		<p>When you load the first page of a jQuery Mobile based site, then click a link or submit a form, the jQuery Mobile uses Ajax to pull in the content of the requested page. Having both pages in the DOM is essential to enable the animated page transitions, but one downside of this approach is that the page title is always that of the first page, not the subsequent page you’re viewing.</p>
+		<p>When you load the first page of a jQuery Mobile based site, then click a link or submit a form, Ajax is used to pull in the content of the requested page. Having both pages in the DOM is essential to enable the animated page transitions, but one downside of this approach is that the page title is always that of the first page, not the subsequent page you’re viewing.</p>
 		<p>To remedy this, jQuery Mobile automatically parses the <code>title</code> of the page pulled via Ajax and changes the <code>title</code> attribute of the parent document to match.</p>		
 		
 		<h2>Titles in multi-page templates</h2>


### PR DESCRIPTION
Change usage of "the JQuery Mobile" that was repeated several times in one sentence. Also, tried to fix other typos seen on the live site (docuemnt, for example), but they appear to already be correct in source.  
