### PR TITLE
Fix wrong height of exprimental scrollview

### DIFF
--- a/experiments/scrollview/scrollview.js
+++ b/experiments/scrollview/scrollview.js
@@ -2,8 +2,20 @@ function ResizePageContentHeight(page)
 {
 	var $page = $(page);
 	var $content = $page.children(".ui-content");
+  var header = $page.children(".ui-header");
+  if (!header.get(0))
+  {
+    header = $(".ui-mobile-viewport").children(".ui-header");
+  }
 	var hh = $page.children(".ui-header").outerHeight(); hh = hh ? hh : 0;
-	var fh = $page.children(".ui-footer").outerHeight(); fh = fh ? fh : 0;
+
+  var footer = $page.children(".ui-footer");
+  if (!footer.get(0))
+  {
+    footer = $(".ui-mobile-viewport").children(".ui-footer");
+  }
+  var fh = footer.outerHeight(); fh = fh ? fh : 0;
+
 	var pt = parseFloat($content.css("padding-top"));
 	var pb = parseFloat($content.css("padding-bottom"));
 	var wh = window.innerHeight;


### PR DESCRIPTION
If header or footer has same data-id, then the height culculation is wrong.
