### PR TITLE
Issue #1447 - unescape entities in page titles

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -848,6 +848,9 @@
 					}
 
 					if ( newPageTitle && !page.jqmData( "title" ) ) {
+						if ( newPageTitle.indexOf( "&" ) ) {
+							newPageTitle = $( "<div>" + newPageTitle + "</div>" ).text();
+						}
 						page.jqmData( "title", newPageTitle );
 					}
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -848,7 +848,7 @@
 					}
 
 					if ( newPageTitle && !page.jqmData( "title" ) ) {
-						if ( newPageTitle.indexOf( "&" ) ) {
+						if ( ~newPageTitle.indexOf( "&" ) ) {
 							newPageTitle = $( "<div>" + newPageTitle + "</div>" ).text();
 						}
 						page.jqmData( "title", newPageTitle );


### PR DESCRIPTION
Fix for #1447 - create element and read text from there to unescape entities in page title
