### PR TITLE
Fix for #2947: ui-btn-hover is not removed when mouse down

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -135,7 +135,7 @@ var attachEvents = function() {
 			if ( btn ) {
 				$btn = $( btn );
 				theme = $btn.attr( "data-" + $.mobile.ns + "theme" );
-				$btn.removeClass( "ui-btn-up-" + theme ).addClass( "ui-btn-down-" + theme );
+				$btn.removeClass( "ui-btn-up-" + theme + " ui-btn-hover-" + theme ).addClass( "ui-btn-down-" + theme );
 			}
 		},
 		"vmousecancel vmouseup": function( event ) {


### PR DESCRIPTION
#2947 remove the ui-btn-hover-class when mouse button is pressed
