### PR TITLE
Popup widget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ JSFILES = 	  js/jquery.ui.widget.js \
 			  js/jquery.mobile.links.js \
 			  js/jquery.mobile.fixHeaderFooter.js \
 			  js/jquery.mobile.fixHeaderFooter.native.js \
+			  js/jquery.mobile.popup.js \
 			  js/jquery.mobile.init.js
 
 CSSTHEMEFILES = css/themes/${CSSTHEME}/jquery.mobile.theme.css
@@ -90,6 +91,7 @@ CSSSTRUCTUREFILES = css/structure/jquery.mobile.core.css \
 			  css/structure/jquery.mobile.forms.select.css \
 			  css/structure/jquery.mobile.forms.textinput.css \
 			  css/structure/jquery.mobile.listview.css \
+			  css/structure/jquery.mobile.popup.css \
 			  css/structure/jquery.mobile.forms.slider.css
 
 

--- a/css/structure/index.php
+++ b/css/structure/index.php
@@ -14,6 +14,7 @@ $files = array_merge($files, array(
 	'../../structure/jquery.mobile.forms.select.css',
 	'../../structure/jquery.mobile.forms.textinput.css',
 	'../../structure/jquery.mobile.listview.css',
+	'../../structure/jquery.mobile.popup.css',
 	'../../structure/jquery.mobile.forms.slider.css'
 ));
 

--- a/css/structure/jquery.mobile.popup.css
+++ b/css/structure/jquery.mobile.popup.css
@@ -1,0 +1,10 @@
+.ui-popup-container {
+  display: inline-block;
+  position: absolute;
+  z-index: 100 !important;
+  padding: 6px;
+}
+
+.ui-popup-screen {
+  opacity: 0;
+}

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -33,6 +33,7 @@
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-anatomy.html
+++ b/docs/pages/page-anatomy.html
@@ -198,6 +198,7 @@
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-cache.html
+++ b/docs/pages/page-cache.html
@@ -99,6 +99,7 @@ $.mobile.page.prototype.options.domCache = true;
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li data-theme="a"><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-dialogs.html
+++ b/docs/pages/page-dialogs.html
@@ -96,6 +96,7 @@
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li data-theme="a"><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-dynamic.html
+++ b/docs/pages/page-dynamic.html
@@ -275,6 +275,7 @@ function showCategory( urlObj, options )
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li data-theme="a"><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-links.html
+++ b/docs/pages/page-links.html
@@ -116,6 +116,7 @@
 								<li data-theme="a"><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-navmodel.html
+++ b/docs/pages/page-navmodel.html
@@ -156,6 +156,7 @@ $.ajaxPrefilter( function(options, originalOptions, jqXHR) {
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li data-theme="a"><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-scripting.html
+++ b/docs/pages/page-scripting.html
@@ -123,6 +123,7 @@ $.mobile.silentScroll(300);
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-titles.html
+++ b/docs/pages/page-titles.html
@@ -57,6 +57,7 @@
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/page-transitions.html
+++ b/docs/pages/page-transitions.html
@@ -67,6 +67,7 @@
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li data-theme="a"><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/pages-themes.html
+++ b/docs/pages/pages-themes.html
@@ -203,6 +203,7 @@
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically Injecting Pages</a></li>

--- a/docs/pages/popup/events.html
+++ b/docs/pages/popup/events.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+	<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Docs - Popup events</title>
+	<link rel="stylesheet"  href="../../../css/themes/default/" />
+	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
+	<script src="../../../js/jquery.js"></script>
+	<script src="../../../experiments/themeswitcher/jquery.mobile.themeswitcher.js"></script>
+	<script src="../../_assets/js/jqm-docs.js"></script>
+	<script src="../../../js/"></script>
+</head>
+<body>
+
+	<div data-role="page" class="type-interior">
+
+		<div data-role="header" data-theme="f">
+		<h1>Popup</h1>
+		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
+	</div><!-- /header -->
+
+	<div data-role="content">
+		<div class="content-primary">
+
+		<form action="#" method="get">
+
+			<h2>Popup</h2>
+			
+			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
+				<li><a href="index.html" data-role="button" data-transition="fade">Basics</a></li>
+				<li><a href="options.html" data-role="button" data-transition="fade">Options</a></li>
+				<li><a href="methods.html" data-role="button" data-transition="fade">Methods</a></li>
+				<li><a href="events.html" data-role="button" data-transition="fade" class="ui-btn-active">Events</a></li>
+			</ul>
+			
+			<p>The popup plugin has the following custom event:</p>
+
+	<dl>
+				
+		<dt><code>closed</code> triggered when a popup is closed (by clicking outside of it)</dt>
+		<dd>
+
+			<pre><code>
+$( ".selector" ).slider({
+   closed: function(event, ui) { ... }
+});		
+			</code></pre>
+		</dd>
+		
+
+	</dl>
+	    
+	</form>
+	</div><!--/content-primary -->		
+	
+				<div class="content-secondary">
+
+					<div data-role="collapsible" data-collapsed="true" data-theme="b" data-content-theme="d">
+
+							<h3>More in this section</h3>
+
+							<ul data-role="listview" data-theme="c" data-dividertheme="d">
+
+								<li data-role="list-divider">Pages &amp; Dialogs</li>
+								<li><a href="../page-anatomy.html">Anatomy of a page</a></li>
+								<li><a href="../page-template.html" data-ajax="false">Single page template</a></li>
+								<li><a href="../multipage-template.html" data-ajax="false">Multi-page template</a></li>
+								<li><a href="../page-titles.html">Page titles</a></li>
+								<li><a href="../page-links.html">Linking pages</a></li>
+								<li><a href="../page-transitions.html" data-ajax="false">Page transitions</a></li>
+								<li><a href="../page-dialogs.html">Dialogs</a></li>
+								<li data-theme="a"><a href="index.html">Popups</a></li>
+								<li><a href="../page-cache.html">Prefetching &amp; caching pages</a></li>
+								<li><a href="../page-navmodel.html">Ajax, hashes &amp; history</a></li>
+								<li><a href="../page-dynamic.html">Dynamically Injecting Pages</a></li>
+								<li><a href="../page-scripting.html">Scripting pages</a></li>
+								<li><a href="../pages-themes.html">Theming pages</a></li>
+
+							</ul>
+					</div>
+				</div>		
+
+</div><!-- /content -->
+
+<div data-role="footer" class="footer-docs" data-theme="c">
+		<p>&copy; 2011 The jQuery Project</p>
+</div>
+	
+</div><!-- /page -->
+
+</body>
+</html>
+

--- a/docs/pages/popup/events.html
+++ b/docs/pages/popup/events.html
@@ -42,7 +42,7 @@
 		<dd>
 
 			<pre><code>
-$( ".selector" ).slider({
+$( ".selector" ).popup({
    closed: function(event, ui) { ... }
 });		
 			</code></pre>

--- a/docs/pages/popup/index.html
+++ b/docs/pages/popup/index.html
@@ -80,10 +80,10 @@ $('#myPopupDiv').popup();
 		<a href="#popupTester" data-rel="popup" data-role="button" data-inline="true" data-theme="b">Pop</a>
 		<a href="#popupTester" data-rel="popup" data-role="button" data-inline="true" data-theme="e">Pop</a>
 </p>
-<p>However, you can override this by setting the theme yourself. You can apply a theme separately to the popup itself and to its contents. To apply a theme to the popup itself, set the <code>data-overlay-theme</code> attribute to one of the swatches. For example, <code>data-overlay-theme="a"</code>. To apply a theme to the contents of the popup, add one of the <code>ui-body-(a-z)</code> classes to the popup div. Here is an example of an explicitly themed popup:</p>
+<p>However, you can override this by setting the theme yourself. You can apply a theme separately to the popup itself and to its contents. To apply a theme to the popup itself, set the <code>data-overlay-theme</code> attribute to one of the swatches. For example, <code>data-overlay-theme="a"</code>. To apply a theme to the contents of the popup, add the swatch of your choice via the <code>data-theme</code> attribute to the popup div. For example, <code>data-theme="a"</code>. Here is an example of an explicitly themed popup:</p>
 
 <pre><code>
-&lt;div data-role=&quotpopup&quot; id=&quot;popupTesterThemed&quot; data-overlay-theme=&quot;e&quot; class=&quot;ui-body-a&quot;&gt;
+&lt;div data-role=&quotpopup&quot; id=&quot;popupTesterThemed&quot; data-overlay-theme=&quot;e&quot; data-theme=&quot;a&quot;&gt;
 	&lt;table&gt;
 		&lt;tr&gt;&lt;td&gt;Mary&lt;/td&gt;&lt;td&gt;had-a&lt;/td&gt;&lt;td&gt;little&lt;/td&gt;&lt;td&gt;lamb&lt;/td&gt;&lt;/tr&gt;
 		&lt;tr&gt;&lt;td&gt;And&lt;/td&gt;&lt;td&gt;it-was&lt;/td&gt;&lt;td&gt;white-as&lt;/td&gt;&lt;td&gt;snow&lt;/td&gt;&lt;/tr&gt;
@@ -96,7 +96,7 @@ $('#myPopupDiv').popup();
 		
 <p> This is the result:</p>
 
-		<div data-role="popup" id="popupTesterThemed" data-overlay-theme="e" class="ui-body-a">
+		<div data-role="popup" id="popupTesterThemed" data-overlay-theme="e" data-theme="a">
 			<table>
 				<tr><td>Mary</td><td>had-a</td><td>little</td><td>lamb</td></tr>
 				<tr><td>And</td><td>it-was</td><td>white-as</td><td>snow</td></tr>

--- a/docs/pages/popup/index.html
+++ b/docs/pages/popup/index.html
@@ -68,8 +68,33 @@ $('#myPopupDiv').popup();
     
 
 		<h2>Theming the popup</h2>
-<p>Normally, the popup's theme will be set to align with the theme of the link that launches it. However, you can override this by setting the theme yourself. You can apply a theme separately to the popup itself and to its contents. To apply a theme to the popup itself, set the <code>data-overlay-theme</code> attribute to one of the swatches. For example, <code>data-overlay-theme="a"</code>. To apply a theme to the contents of the popup, add one of the <code>ui-body-(a-z)</code> classes to the popup div.</p>
+<p>Normally, the popup's theme will be set to align with the theme of the link that launches it. However, you can override this by setting the theme yourself. You can apply a theme separately to the popup itself and to its contents. To apply a theme to the popup itself, set the <code>data-overlay-theme</code> attribute to one of the swatches. For example, <code>data-overlay-theme="a"</code>. To apply a theme to the contents of the popup, add one of the <code>ui-body-(a-z)</code> classes to the popup div. Here is an example of an explicitly themed popup:</p>
+
+<pre><code>
+&lt;div data-role=&quotpopup&quot; id=&quot;popupTesterThemed&quot; data-overlay-theme=&quot;e&quot; class=&quot;ui-body-a&quot;&gt;
+	&lt;table&gt;
+		&lt;tr&gt;&lt;td&gt;Eenie&lt;/td&gt;&lt;td&gt;meenie&lt;/td&gt;&lt;td&gt;miney&lt;/td&gt;&lt;td&gt;mo&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;Catch-a&lt;/td&gt;&lt;td&gt;tiger&lt;/td&gt;&lt;td&gt;by-the&lt;/td&gt;&lt;td&gt;toe&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;if-he&lt;/td&gt;&lt;td&gt;hollers&lt;/td&gt;&lt;td&gt;let-him&lt;/td&gt;&lt;td&gt;go&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;Eenie&lt;/td&gt;&lt;td&gt;meenie&lt;/td&gt;&lt;td&gt;miney&lt;/td&gt;&lt;td&gt;mo&lt;/td&gt;&lt;/tr&gt;
+	&lt;/table&gt;
+&lt;/div&gt;
+&lt;a href=&quot;#popupTesterThemed&quot; data-rel=&quot;popup&quot; data-role=&quot;button&quot; data-inline=&quot;true&quot;&gt;Pop&lt;/a&gt;
+</code></pre>
 		
+<p> This is the result:</p>
+
+		<div data-role="popup" id="popupTesterThemed" data-overlay-theme="e" class="ui-body-a">
+			<table>
+				<tr><td>Eenie</td><td>meenie</td><td>miney</td><td>mo</td></tr>
+				<tr><td>Catch-a</td><td>tiger</td><td>by-the</td><td>toe</td></tr>
+				<tr><td>if-he</td><td>hollers</td><td>let-him</td><td>go</td></tr>
+				<tr><td>Eenie</td><td>meenie</td><td>miney</td><td>mo</td></tr>
+			</table>
+		</div>
+		<a href="#popupTesterThemed" data-rel="popup" data-role="button" data-inline="true">Pop</a>
+
+
 	</div><!--/content-primary -->		
 	
 				<div class="content-secondary">

--- a/docs/pages/popup/index.html
+++ b/docs/pages/popup/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+	<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Docs - Popup</title>
+	<link rel="stylesheet"  href="../../../css/themes/default/" />
+	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
+	<script src="../../../js/jquery.js"></script>
+	<script src="../../../experiments/themeswitcher/jquery.mobile.themeswitcher.js"></script>
+	<script src="../../_assets/js/jqm-docs.js"></script>
+	<script src="../../../js/"></script>
+</head>
+<body>
+
+	<div data-role="page" class="type-interior">
+
+		<div data-role="header" data-theme="f">
+		<h1>Popup</h1>
+		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
+	</div><!-- /header -->
+
+	<div data-role="content">
+		<div class="content-primary">
+
+		<form action="#" method="get">
+			<h2>Popup</h2>
+			
+			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
+				<li><a href="index.html" data-role="button" data-transition="fade" class="ui-btn-active">Basics</a></li>
+				<li><a href="options.html" data-role="button" data-transition="fade">Options</a></li>
+				<li><a href="methods.html" data-role="button" data-transition="fade">Methods</a></li>
+				<li><a href="events.html" data-role="button" data-transition="fade">Events</a></li>
+			</ul>
+
+			<p>To turn any div into a popup, add the <code>data-role="popup"</code> attribute to the div. If you would like the popup to appear when the user clicks on a link, create a link such that its <code>href</code> attribute is set to the id of the popup, and the link has the attribute <code>data-rel="popup"</code>. </p>
+
+<pre><code>
+&lt;div data-role=&quot;popup&quot; id=&quot;popupTester&quot;&gt;
+	&lt;table&gt;
+		&lt;tr&gt;&lt;td&gt;Eenie&lt;/td&gt;&lt;td&gt;meenie&lt;/td&gt;&lt;td&gt;miney&lt;/td&gt;&lt;td&gt;mo&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;Catch-a&lt;/td&gt;&lt;td&gt;tiger&lt;/td&gt;&lt;td&gt;by-the&lt;/td&gt;&lt;td&gt;toe&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;if-he&lt;/td&gt;&lt;td&gt;hollers&lt;/td&gt;&lt;td&gt;let-him&lt;/td&gt;&lt;td&gt;go&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;Eenie&lt;/td&gt;&lt;td&gt;meenie&lt;/td&gt;&lt;td&gt;miney&lt;/td&gt;&lt;td&gt;mo&lt;/td&gt;&lt;/tr&gt;
+	&lt;/table&gt;
+&lt;/div&gt;
+&lt;a href=&quot;#popupTester&quot; data-rel=&quot;popup&quot; data-role=&quot;button&quot; data-inline=&quot;true&quot;&gt;Pop&lt;/a&gt;
+</code></pre>
+
+				<p>This will result in the following popup:</p>
+
+		<div data-role="popup" id="popupTester">
+			<table>
+				<tr><td>Eenie</td><td>meenie</td><td>miney</td><td>mo</td></tr>
+				<tr><td>Catch-a</td><td>tiger</td><td>by-the</td><td>toe</td></tr>
+				<tr><td>if-he</td><td>hollers</td><td>let-him</td><td>go</td></tr>
+				<tr><td>Eenie</td><td>meenie</td><td>miney</td><td>mo</td></tr>
+			</table>
+		</div>
+		<a href="#popupTester" data-rel="popup" data-role="button" data-inline="true">Pop</a>
+
+		<h2>Calling the popup plugin</h2>
+
+<p>This plugin will auto initialize on any page that contains a div with the attribute <code>data-role="popup"</code>. However, if needed you can directly call the <code>popup</code> plugin on any selector, just like any jQuery plugin:</p>
+<pre><code>
+$('#myPopupDiv').popup();			
+</code></pre>
+    
+
+		<h2>Theming the popup</h2>
+<p>Normally, the popup's theme will be set to align with the theme of the link that launches it. However, you can override this by setting the theme yourself. You can apply a theme separately to the popup itself and to its contents. To apply a theme to the popup itself, set the <code>data-overlay-theme</code> attribute to one of the swatches. For example, <code>data-overlay-theme="a"</code>. To apply a theme to the contents of the popup, add one of the <code>ui-body-(a-z)</code> classes to the popup div.</p>
+		
+	</div><!--/content-primary -->		
+	
+				<div class="content-secondary">
+
+					<div data-role="collapsible" data-collapsed="true" data-theme="b" data-content-theme="d">
+
+							<h3>More in this section</h3>
+
+							<ul data-role="listview" data-theme="c" data-dividertheme="d">
+
+								<li data-role="list-divider">Pages &amp; Dialogs</li>
+								<li><a href="../page-anatomy.html">Anatomy of a page</a></li>
+								<li><a href="../page-template.html" data-ajax="false">Single page template</a></li>
+								<li><a href="../multipage-template.html" data-ajax="false">Multi-page template</a></li>
+								<li><a href="../page-titles.html">Page titles</a></li>
+								<li><a href="../page-links.html">Linking pages</a></li>
+								<li><a href="../page-transitions.html" data-ajax="false">Page transitions</a></li>
+								<li><a href="../page-dialogs.html">Dialogs</a></li>
+								<li data-theme="a"><a href="index.html">Popups</a></li>
+								<li><a href="../page-cache.html">Prefetching &amp; caching pages</a></li>
+								<li><a href="../page-navmodel.html">Ajax, hashes &amp; history</a></li>
+								<li><a href="../page-dynamic.html">Dynamically Injecting Pages</a></li>
+								<li><a href="../page-scripting.html">Scripting pages</a></li>
+								<li><a href="../pages-themes.html">Theming pages</a></li>
+
+							</ul>
+					</div>
+				</div>		
+
+</div><!-- /content -->
+
+<div data-role="footer" class="footer-docs" data-theme="c">
+		<p>&copy; 2011 The jQuery Project</p>
+</div>
+	
+</div><!-- /page -->
+
+</body>
+</html>
+

--- a/docs/pages/popup/index.html
+++ b/docs/pages/popup/index.html
@@ -68,15 +68,27 @@ $('#myPopupDiv').popup();
     
 
 		<h2>Theming the popup</h2>
-<p>Normally, the popup's theme will be set to align with the theme of the link that launches it. However, you can override this by setting the theme yourself. You can apply a theme separately to the popup itself and to its contents. To apply a theme to the popup itself, set the <code>data-overlay-theme</code> attribute to one of the swatches. For example, <code>data-overlay-theme="a"</code>. To apply a theme to the contents of the popup, add one of the <code>ui-body-(a-z)</code> classes to the popup div. Here is an example of an explicitly themed popup:</p>
+<p>Normally, the popup's theme will be set to align with the theme of the link that launches it. The above popup can be shown in multiple places. Each time, upon appearing, the popup's theme is set to match that of the link that launches it:</p>
+<pre><code>
+&lt;a href=&quot;#popupTester&quot; data-rel=&quot;popup&quot; data-role=&quot;button&quot; data-inline=&quot;true&quot; data-theme=&quot;a&quot;&gt;Pop&lt;/a&gt;
+&lt;a href=&quot;#popupTester&quot; data-rel=&quot;popup&quot; data-role=&quot;button&quot; data-inline=&quot;true&quot; data-theme=&quot;b&quot;&gt;Pop&lt;/a&gt;
+&lt;a href=&quot;#popupTester&quot; data-rel=&quot;popup&quot; data-role=&quot;button&quot; data-inline=&quot;true&quot; data-theme=&quot;e&quot;&gt;Pop&lt;/a&gt;
+</code></pre>
+<p>
+	The result:
+		<a href="#popupTester" data-rel="popup" data-role="button" data-inline="true" data-theme="a">Pop</a>
+		<a href="#popupTester" data-rel="popup" data-role="button" data-inline="true" data-theme="b">Pop</a>
+		<a href="#popupTester" data-rel="popup" data-role="button" data-inline="true" data-theme="e">Pop</a>
+</p>
+<p>However, you can override this by setting the theme yourself. You can apply a theme separately to the popup itself and to its contents. To apply a theme to the popup itself, set the <code>data-overlay-theme</code> attribute to one of the swatches. For example, <code>data-overlay-theme="a"</code>. To apply a theme to the contents of the popup, add one of the <code>ui-body-(a-z)</code> classes to the popup div. Here is an example of an explicitly themed popup:</p>
 
 <pre><code>
 &lt;div data-role=&quotpopup&quot; id=&quot;popupTesterThemed&quot; data-overlay-theme=&quot;e&quot; class=&quot;ui-body-a&quot;&gt;
 	&lt;table&gt;
-		&lt;tr&gt;&lt;td&gt;Eenie&lt;/td&gt;&lt;td&gt;meenie&lt;/td&gt;&lt;td&gt;miney&lt;/td&gt;&lt;td&gt;mo&lt;/td&gt;&lt;/tr&gt;
-		&lt;tr&gt;&lt;td&gt;Catch-a&lt;/td&gt;&lt;td&gt;tiger&lt;/td&gt;&lt;td&gt;by-the&lt;/td&gt;&lt;td&gt;toe&lt;/td&gt;&lt;/tr&gt;
-		&lt;tr&gt;&lt;td&gt;if-he&lt;/td&gt;&lt;td&gt;hollers&lt;/td&gt;&lt;td&gt;let-him&lt;/td&gt;&lt;td&gt;go&lt;/td&gt;&lt;/tr&gt;
-		&lt;tr&gt;&lt;td&gt;Eenie&lt;/td&gt;&lt;td&gt;meenie&lt;/td&gt;&lt;td&gt;miney&lt;/td&gt;&lt;td&gt;mo&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;Mary&lt;/td&gt;&lt;td&gt;had-a&lt;/td&gt;&lt;td&gt;little&lt;/td&gt;&lt;td&gt;lamb&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;And&lt;/td&gt;&lt;td&gt;it-was&lt;/td&gt;&lt;td&gt;white-as&lt;/td&gt;&lt;td&gt;snow&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;Everywhere&lt;/td&gt;&lt;td&gt;that&lt;/td&gt;&lt;td&gt;Mary&lt;/td&gt;&lt;td&gt;went&lt;/td&gt;&lt;/tr&gt;
+		&lt;tr&gt;&lt;td&gt;It&lt;/td&gt;&lt;td&gt;was&lt;/td&gt;&lt;td&gt;sure&lt;/td&gt;&lt;td&gt;to-go&lt;/td&gt;&lt;/tr&gt;
 	&lt;/table&gt;
 &lt;/div&gt;
 &lt;a href=&quot;#popupTesterThemed&quot; data-rel=&quot;popup&quot; data-role=&quot;button&quot; data-inline=&quot;true&quot;&gt;Pop&lt;/a&gt;
@@ -86,10 +98,10 @@ $('#myPopupDiv').popup();
 
 		<div data-role="popup" id="popupTesterThemed" data-overlay-theme="e" class="ui-body-a">
 			<table>
-				<tr><td>Eenie</td><td>meenie</td><td>miney</td><td>mo</td></tr>
-				<tr><td>Catch-a</td><td>tiger</td><td>by-the</td><td>toe</td></tr>
-				<tr><td>if-he</td><td>hollers</td><td>let-him</td><td>go</td></tr>
-				<tr><td>Eenie</td><td>meenie</td><td>miney</td><td>mo</td></tr>
+				<tr><td>Mary</td><td>had-a</td><td>little</td><td>lamb</td></tr>
+				<tr><td>And</td><td>it-was</td><td>white-as</td><td>snow</td></tr>
+				<tr><td>Everywhere</td><td>that</td><td>Mary</td><td>went</td></tr>
+				<tr><td>It</td><td>was</td><td>sure</td><td>to-go</td></tr>
 			</table>
 		</div>
 		<a href="#popupTesterThemed" data-rel="popup" data-role="button" data-inline="true">Pop</a>

--- a/docs/pages/popup/methods.html
+++ b/docs/pages/popup/methods.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+	<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Docs - Popup methods</title>
+	<link rel="stylesheet"  href="../../../css/themes/default/" />
+	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
+	<script src="../../../js/jquery.js"></script>
+	<script src="../../../experiments/themeswitcher/jquery.mobile.themeswitcher.js"></script>
+	<script src="../../_assets/js/jqm-docs.js"></script>
+	<script src="../../../js/"></script>
+</head>
+<body>
+
+	<div data-role="page" class="type-interior">
+
+		<div data-role="header" data-theme="f">
+		<h1>Popup</h1>
+		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
+	</div><!-- /header -->
+
+	<div data-role="content">
+		<div class="content-primary">
+
+		<form action="#" method="get">
+
+			<h2>Popup</h2>
+			
+			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
+				<li><a href="index.html" data-role="button" data-transition="fade">Basics</a></li>
+				<li><a href="options.html" data-role="button" data-transition="fade">Options</a></li>
+				<li><a href="methods.html" data-role="button" data-transition="fade" class="ui-btn-active">Methods</a></li>
+				<li><a href="events.html" data-role="button" data-transition="fade">Events</a></li>
+			</ul>
+			
+			<p>The popup plugin has the following methods:</p>
+
+		<dl>									
+			<dt><code>open(x, y)</code> display the popup centered at coordinates (x, y)</dt>
+			<dd>
+				<pre><code>
+$('.selector').popup('open', x, y);			
+				</code></pre>
+			</dd>
+			
+			<dt><code>close</code> close an open popup</dt>
+			<dd>
+				<pre><code>
+$('.selector').popup('close');			
+				</code></pre>
+			</dd>
+		</dl>	
+    
+	</form>
+	</div><!--/content-primary -->		
+	
+				<div class="content-secondary">
+
+					<div data-role="collapsible" data-collapsed="true" data-theme="b" data-content-theme="d">
+
+							<h3>More in this section</h3>
+
+							<ul data-role="listview" data-theme="c" data-dividertheme="d">
+
+								<li data-role="list-divider">Pages &amp; Dialogs</li>
+								<li><a href="../page-anatomy.html">Anatomy of a page</a></li>
+								<li><a href="../page-template.html" data-ajax="false">Single page template</a></li>
+								<li><a href="../multipage-template.html" data-ajax="false">Multi-page template</a></li>
+								<li><a href="../page-titles.html">Page titles</a></li>
+								<li><a href="../page-links.html">Linking pages</a></li>
+								<li><a href="../page-transitions.html" data-ajax="false">Page transitions</a></li>
+								<li><a href="../page-dialogs.html">Dialogs</a></li>
+								<li data-theme="a"><a href="index.html">Popups</a></li>
+								<li><a href="../page-cache.html">Prefetching &amp; caching pages</a></li>
+								<li><a href="../page-navmodel.html">Ajax, hashes &amp; history</a></li>
+								<li><a href="../page-dynamic.html">Dynamically Injecting Pages</a></li>
+								<li><a href="../page-scripting.html">Scripting pages</a></li>
+								<li><a href="../pages-themes.html">Theming pages</a></li>
+
+							</ul>
+					</div>
+				</div>		
+
+</div><!-- /content -->
+
+<div data-role="footer" class="footer-docs" data-theme="c">
+		<p>&copy; 2011 The jQuery Project</p>
+</div>
+	
+</div><!-- /page -->
+
+</body>
+</html>
+

--- a/docs/pages/popup/options.html
+++ b/docs/pages/popup/options.html
@@ -39,12 +39,22 @@
 		<dl>
 			<dt><code>overlayTheme</code> <em>string</em></dt>
 			<dd>
-				<p class="default">default: ""</p>
+				<p class="default">default: null</p>
 				<p>Sets the color scheme (swatch) for the popup border and background. If initially unset, and the popup is used
 				in association with a link that has <code>data-rel="popup"</code> set, this attribute will be set when the popup
 				is invoked from the link.</p>
 				<pre><code>$('.selector').popup(<strong>{ overlayTheme: "a" }</strong>);</code></pre>
 				 <p>This option is also exposed as a data attribute: <code>data-overlay-theme=&quot;a&quot;</code></p>
+			</dd>
+
+			<dt><code>theme</code> <em>string</em></dt>
+			<dd>
+				<p class="default">default: null</p>
+				<p>Sets the color scheme (swatch) for the popup contents. If initially unset, and the popup is used
+				in association with a link that has <code>data-rel="popup"</code> set, this attribute will be set when the popup
+				is invoked from the link.</p>
+				<pre><code>$('.selector').popup(<strong>{ theme: "a" }</strong>);</code></pre>
+				 <p>This option is also exposed as a data attribute: <code>data-theme=&quot;a&quot;</code></p>
 			</dd>
 
 			<dt><code>initSelector</code> <em>CSS selector string</em></dt>

--- a/docs/pages/popup/options.html
+++ b/docs/pages/popup/options.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+	<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Docs - Popup options</title>
+	<link rel="stylesheet"  href="../../../css/themes/default/" />
+	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
+	<script src="../../../js/jquery.js"></script>
+	<script src="../../../experiments/themeswitcher/jquery.mobile.themeswitcher.js"></script>
+	<script src="../../_assets/js/jqm-docs.js"></script>
+	<script src="../../../js/"></script>
+</head>
+<body>
+
+	<div data-role="page" class="type-interior">
+
+		<div data-role="header" data-theme="f">
+		<h1>Popup</h1>
+		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
+	</div><!-- /header -->
+
+	<div data-role="content">
+		<div class="content-primary">
+
+		<form action="#" method="get">
+
+			<h2>Popup</h2>
+
+			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
+				<li><a href="index.html" data-role="button" data-transition="fade">Basics</a></li>
+				<li><a href="options.html" data-role="button" data-transition="fade" class="ui-btn-active">Options</a></li>
+				<li><a href="methods.html" data-role="button" data-transition="fade">Methods</a></li>
+				<li><a href="events.html" data-role="button" data-transition="fade">Events</a></li>
+			</ul>
+
+			<p>The popup plugin has the following options:</p>
+
+		<dl>
+			<dt><code>overlayTheme</code> <em>string</em></dt>
+			<dd>
+				<p class="default">default: ""</p>
+				<p>Sets the color scheme (swatch) for the popup border and background. If initially unset, and the popup is used
+				in association with a link that has <code>data-rel="popup"</code> set, this attribute will be set when the popup
+				is invoked from the link.</p>
+				<pre><code>$('.selector').popup(<strong>{ overlayTheme: "a" }</strong>);</code></pre>
+				 <p>This option is also exposed as a data attribute: <code>data-overlay-theme=&quot;a&quot;</code></p>
+			</dd>
+
+			<dt><code>initSelector</code> <em>CSS selector string</em></dt>
+			<dd>
+				<p class="default">default: ":jqmData(role='popup')"</p>
+				<p>This is used to define the selectors (element types, data roles, etc.) that will automatically be initialized as popups. To change which elements are initialized, bind this option to the <a href="../../api/globalconfig.html">mobileinit event</a>:</p>
+<pre><code>$( document ).bind( "mobileinit", function(){
+   <strong>$.mobile.popup.prototype.options.initSelector = ".mypopup";</strong>
+});
+</code></pre>
+			</dd>
+
+			<dt><code>shadow</code> <em>boolean</em></dt>
+			<dd>
+				<p class="default">default: true</p>
+				<p>Sets whether to draw a shadow around the popup. This option is also exposed as a data attribute: <code>data-shadow=&quot;true&quot;</code></p>
+				<pre><code>$('.selector').popup(<strong>{ shadow: true }</strong>);</code></pre>
+			</dd>
+
+			<dt><code>corners</code> <em>boolean</em></dt>
+			<dd>
+				<p class="default">default: true</p>
+				<p>Sets whether to draw the popup with rounded corners. This option is also exposed as a data attribute: <code>data-corners=&quot;true&quot;</code></p>
+				<pre><code>$('.selector').popup(<strong>{ corners: true }</strong>);</code></pre>
+			</dd>
+
+			<dt><code>fade</code> <em>boolean</em></dt>
+			<dd>
+				<p class="default">default: true</p>
+				<p>Sets whether the popup's background fades as the popup appears. This option is also exposed as a data attribute: <code>data-fade=&quot;true&quot;</code></p>
+				<pre><code>$('.selector').popup(<strong>{ fade: true }</strong>);</code></pre>
+			</dd>
+
+			<dt><code>transition</code> <em>string</em></dt>
+			<dd>
+				<p class="default">default: $.mobile.defaultDialogTransition</p>
+				<p>Sets the <a href="../page-transitions.html">transition</a> to use as the popup appears. This option is also exposed as a data attribute: <code>data-transition=&quot;pop&quot;</code></p>
+
+				<pre><code>$('.selector').popup(<strong>{ transition: "pop" }</strong>);</code></pre>
+			</dd>
+
+		</dl>	
+
+	</form>
+	</div><!--/content-primary -->		
+
+				<div class="content-secondary">
+
+					<div data-role="collapsible" data-collapsed="true" data-theme="b" data-content-theme="d">
+
+							<h3>More in this section</h3>
+
+							<ul data-role="listview" data-theme="c" data-dividertheme="d">
+
+								<li data-role="list-divider">Pages &amp; Dialogs</li>
+								<li><a href="../page-anatomy.html">Anatomy of a page</a></li>
+								<li><a href="../page-template.html" data-ajax="false">Single page template</a></li>
+								<li><a href="../multipage-template.html" data-ajax="false">Multi-page template</a></li>
+								<li><a href="../page-titles.html">Page titles</a></li>
+								<li><a href="../page-links.html">Linking pages</a></li>
+								<li><a href="../page-transitions.html" data-ajax="false">Page transitions</a></li>
+								<li><a href="../page-dialogs.html">Dialogs</a></li>
+								<li data-theme="a"><a href="index.html">Popups</a></li>
+								<li><a href="../page-cache.html">Prefetching &amp; caching pages</a></li>
+								<li><a href="../page-navmodel.html">Ajax, hashes &amp; history</a></li>
+								<li><a href="../page-dynamic.html">Dynamically Injecting Pages</a></li>
+								<li><a href="../page-scripting.html">Scripting pages</a></li>
+								<li><a href="../pages-themes.html">Theming pages</a></li>
+
+							</ul>
+					</div>
+				</div>		
+
+</div><!-- /content -->
+
+<div data-role="footer" class="footer-docs" data-theme="c">
+		<p>&copy; 2011 The jQuery Project</p>
+</div>
+	
+</div><!-- /page -->
+
+</body>
+</html>
+

--- a/js/index.php
+++ b/js/index.php
@@ -34,6 +34,7 @@ $files = array(
 	'jquery.mobile.links.js',
 	'jquery.mobile.fixHeaderFooter.js',
 	'jquery.mobile.fixHeaderFooter.native.js',
+	'jquery.mobile.popup.js',
 	'jquery.mobile.init.js'
 );
 

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -1,0 +1,272 @@
+/*
+=* jQuery Mobile Framework : "popup" plugin
+* Copyright (c) jQuery Project
+* Dual licensed under the MIT or GPL Version 2 licenses.
+* http://jquery.org/license
+*/
+
+(function($, undefined) {
+
+$.widget("mobile.popup", $.mobile.widget, {
+	options: {
+		overlayTheme: "",
+		shadow: true,
+		corners: true,
+		fade: true,
+		transition: $.mobile.defaultDialogTransition,
+		initSelector: ":jqmData(role='popup')"
+	},
+
+	_create: function() {
+		var widgetOptionNames = {
+		    	"overlayTheme" : "data-" + ($.mobile.ns || "") + "overlay-theme",
+					"shadow"       : "data-" + ($.mobile.ns || "") + "shadow",
+					"corners"      : "data-" + ($.mobile.ns || "") + "corners",
+					"fade"         : "data-" + ($.mobile.ns || "") + "fade",
+					"transition"   : "data-" + ($.mobile.ns || "") + "transition"
+		    },
+				ui = {
+					screen    : "#ui-popup-screen",
+					container : "#ui-popup-container"
+				},
+				proto = $(
+"<div>" +
+"    <div id='ui-popup-screen' class='ui-selectmenu-screen ui-screen-hidden ui-popup-screen'></div>" +
+"    <div id='ui-popup-container' class='ui-popup-container ui-selectmenu-hidden'></div>" +
+"</div>"
+),
+				thisPage = (this.element.closest(".ui-page") || $("body")),
+				self = this;
+
+		// Assign the relevant parts of the proto
+		for (var key in ui)
+			ui[key] = $(proto).find(ui[key]).removeAttr("id");
+
+		// Apply the proto
+		thisPage.append(ui.screen);
+		ui.container.insertAfter(ui.screen);
+		ui.container.append(this.element);
+
+		// Define instance variables
+		$.extend (this, {
+			_ui     : ui,
+			_isOpen : false
+		});
+
+		// Apply options - data-* options, if present, take precedence over this.options.*
+		for (var key in this.options)
+			this._setOption(key,
+				(widgetOptionNames[key] === undefined || this.element.attr(widgetOptionNames[key]) === undefined)
+					? this.options[key]
+					: this.element.attr(widgetOptionNames[key]), true);
+
+		ui.screen.bind("vclick", function(e) {
+			self.close();
+		});
+	},
+
+	_set_overlayTheme: function(value, unconditional) {
+
+		if (value.match(/^[a-z]$/) || value === "") {
+			function setTheme(dst, theme) {
+				var currentTheme = dst.attr("class")
+			    		.split(" ")
+			    		.filter(function(el, idx, ar) {
+			    			return el.match(/^ui-body-[a-z]$/);
+			    		});
+
+				currentTheme = ((currentTheme.length > 0) ? currentTheme[0].match(/^ui-body-([a-z])/)[1] : "");
+
+				if (value != currentTheme || unconditional) {
+					dst.removeClass("ui-body-" + currentTheme);
+					if (value !== "")
+						dst.addClass("ui-body-" + theme);
+				}
+			}
+	
+			setTheme(this._ui.container, value);
+			this._ui.screen.removeAttr("style");
+			// The screen must always have some kind of background for fade to work, so, if the theme is being unset, set the background to black.
+			if ("" === value)
+				this._ui.screen.css("background", "#000000");
+			else
+				setTheme(this._ui.screen, value);
+		}
+		else
+			console.log("Warning: " + value + " is not a valid overlay theme! Please specify a single letter a-z or an empty string!");
+	},
+
+	_set_shadow: function(value, unconditional) {
+		value = this._parseBoolean(value);
+		if (this._ui.container.hasClass("ui-overlay-shadow") != value || unconditional)
+			this._ui.container[value ? "addClass" : "removeClass"]("ui-overlay-shadow");
+	},
+
+	_set_corners: function(value, unconditional) {
+		value = this._parseBoolean(value);
+		if (this._ui.container.hasClass("ui-corner-all") != value || unconditional)
+			this._ui.container[value ? "addClass" : "removeClass"]("ui-corner-all");
+	},
+
+	_parseBoolean: function(value) {
+		if (typeof value === "boolean")
+			return value;
+		else {
+			value = value.toLowerCase();
+			return (value === "true" || value === "yes" || value === "1");
+		}
+	},
+
+	_set_fade: function(value, unconditional) {
+		this.options.fade = this._parseBoolean(value);
+	},
+
+	_set_transition: function(value, unconditional) {
+		if (this.options.transition != value || unconditional) {
+			this._ui.container
+				.removeClass(this.options.transition)
+				.addClass(value);
+			this.options.transition = value;
+		}
+	},
+
+	_setOption: function(key, value, unconditional) {
+		if (unconditional === undefined)
+			unconditional = false;
+		if (this["_set_" + key] !== undefined)
+			this["_set_" + key](value, unconditional);
+	},
+
+	_placementCoords: function(x, y) {
+		// Try and center the overlay over the given coordinates
+		var ret,
+		    menuHeight = this._ui.container.outerHeight(true),
+		    menuWidth = this._ui.container.outerWidth(true),
+		    scrollTop = $( window ).scrollTop(),
+		    screenHeight = window.innerHeight,
+		    screenWidth = window.innerWidth,
+		    halfheight = menuHeight / 2,
+		    maxwidth = parseFloat( this._ui.container.css( "max-width" ) ),
+		    roomtop = y - scrollTop,
+		    roombot = scrollTop + screenHeight - y,
+		    newtop, newleft;
+
+		if ( roomtop > menuHeight / 2 && roombot > menuHeight / 2 ) {
+		  newtop = y - halfheight;
+		}
+		else {
+		  // 30px tolerance off the edges
+		  newtop = roomtop > roombot ? scrollTop + screenHeight - menuHeight - 30 : scrollTop + 30;
+		}
+
+		// If the menuwidth is smaller than the screen center is
+		if ( menuWidth < maxwidth ) {
+		  newleft = ( screenWidth - menuWidth ) / 2;
+		}
+		else {
+		  //otherwise insure a >= 30px offset from the left
+		  newleft = x - menuWidth / 2;
+
+		  // 30px tolerance off the edges
+		  if ( newleft < 30 ) {
+		    newleft = 30;
+		  }
+		  else
+			if ( ( newleft + menuWidth ) > screenWidth ) {
+		    newleft = screenWidth - menuWidth - 30;
+		  }
+		}
+
+		return { x : newleft, y : newtop };
+	},
+
+	open: function(x, y) {
+		if (!this._isOpen) {
+			var self = this,
+			    coords = this._placementCoords(
+			    	(undefined === x ? window.innerWidth / 2 : x),
+			    	(undefined === y ? window.innerWidth / 2 : y));
+
+			this._ui.screen
+				.height($(document).height())
+				.removeClass("ui-screen-hidden");
+
+			if (this.options.fade)
+				this._ui.screen.animate({opacity: 0.5}, "fast");
+
+			this._ui.container
+				.removeClass("ui-selectmenu-hidden")
+				.css({
+					left: coords.x,
+					 top: coords.y
+				})
+				.addClass("in")
+				.animationComplete(function() {
+					self._ui.screen.height($(document).height());
+				});
+
+			this._isOpen = true;
+		}
+	},
+
+	close: function() {
+		if (this._isOpen) {
+			var self = this,
+		    	hideScreen = function() {
+		    		self._ui.screen.addClass("ui-screen-hidden");
+		    		self._isOpen = false;
+		    		self.element.trigger("closed");
+		    	};
+
+			this._ui.container
+				.removeClass("in")
+				.addClass("reverse out")
+				.animationComplete(function() {
+					self._ui.container
+						.removeClass("reverse out")
+						.addClass("ui-selectmenu-hidden")
+						.removeAttr("style");
+				});
+
+				if (this.options.fade)
+					this._ui.screen.animate({opacity: 0.0}, "fast", hideScreen);
+				else
+					hideScreen();
+		}
+	}
+});
+
+$(document).bind("pagecreate create", function(e) {
+	$($.mobile.popup.prototype.options.initSelector, e.target)
+		.not(":jqmData(role='none'), :jqmData(role='nojs')")
+		.popup();
+
+	$("a[href^='#']:jqmData(rel='popup')").each(function() {
+		var btn = $(this),
+				popup = $(btn.attr("href"));
+
+		if (popup[0]) {
+			// If the popup has a theme set, prevent it from being clobbered by the associated button
+			if (popup.popup("option", "overlayTheme").match(/[a-z]/))
+				popup.jqmData("overlay-theme-set", true);
+			btn
+				.attr({
+					"aria-haspopup": true,
+					"aria-owns": btn.attr("href")
+				})
+				.removeAttr("href")
+				.bind("vclick", function() {
+					// When /this/ button causes a popup, align the popup's theme with that of the button, unless the popup has a theme pre-set
+					if (!popup.jqmData("overlay-theme-set"))
+						popup.popup("option", "overlayTheme", btn.jqmData("theme"))
+					popup.popup("open",
+						btn.offset().left + btn.outerWidth()  / 2,
+						btn.offset().top  + btn.outerHeight() / 2);
+				});
+		}
+		else
+			console.log("popup menu " + btn.attr("href") + " not found.");
+	});
+});
+
+})(jQuery);

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -40,7 +40,7 @@ $.widget("mobile.popup", $.mobile.widget, {
 
 		// Assign the relevant parts of the proto
 		for (var key in ui)
-			ui[key] = $(proto).find(ui[key]).removeAttr("id");
+			ui[key] = proto.find(ui[key]).removeAttr("id");
 
 		// Apply the proto
 		thisPage.append(ui.screen);

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -9,7 +9,8 @@
 
 $.widget("mobile.popup", $.mobile.widget, {
 	options: {
-		overlayTheme: "",
+		theme: null,
+		overlayTheme: null,
 		shadow: true,
 		corners: true,
 		fade: true,
@@ -23,7 +24,8 @@ $.widget("mobile.popup", $.mobile.widget, {
 					"shadow"       : "data-" + ($.mobile.ns || "") + "shadow",
 					"corners"      : "data-" + ($.mobile.ns || "") + "corners",
 					"fade"         : "data-" + ($.mobile.ns || "") + "fade",
-					"transition"   : "data-" + ($.mobile.ns || "") + "transition"
+					"transition"   : "data-" + ($.mobile.ns || "") + "transition",
+					"theme"        : "data-" + ($.mobile.ns || "") + "theme"
 		    },
 				ui = {
 					screen    : "#ui-popup-screen",
@@ -65,32 +67,39 @@ $.widget("mobile.popup", $.mobile.widget, {
 		});
 	},
 
-	_set_overlayTheme: function(value, unconditional) {
+	_setTheme: function(dst, theme, unconditional) {
+		var currentTheme = (dst.attr("class") || "")
+	    		.split(" ")
+	    		.filter(function(el, idx, ar) {
+	    			return el.match(/^ui-body-[a-z]$/);
+	    		});
+
+		currentTheme = ((currentTheme.length > 0) ? currentTheme[0].match(/^ui-body-([a-z])/)[1] : null);
+
+		if (theme !== currentTheme || unconditional) {
+			dst.removeClass("ui-body-" + currentTheme);
+			if (theme !== null)
+				dst.addClass("ui-body-" + theme);
+		}
+	},
+
+	_set_theme: function(value, unconditional) {
+		if (value === null)
+			value = "";
 
 		if (value.match(/^[a-z]$/) || value === "") {
-			function setTheme(dst, theme) {
-				var currentTheme = dst.attr("class")
-			    		.split(" ")
-			    		.filter(function(el, idx, ar) {
-			    			return el.match(/^ui-body-[a-z]$/);
-			    		});
+			this._setTheme(this.element, value, unconditional);
+		}
+	},
 
-				currentTheme = ((currentTheme.length > 0) ? currentTheme[0].match(/^ui-body-([a-z])/)[1] : "");
-
-				if (value != currentTheme || unconditional) {
-					dst.removeClass("ui-body-" + currentTheme);
-					if (value !== "")
-						dst.addClass("ui-body-" + theme);
-				}
-			}
-	
-			setTheme(this._ui.container, value);
-			this._ui.screen.removeAttr("style");
-			// The screen must always have some kind of background for fade to work, so, if the theme is being unset, set the background to black.
-			if ("" === value)
-				this._ui.screen.css("background", "#000000");
-			else
-				setTheme(this._ui.screen, value);
+	_set_overlayTheme: function(value, unconditional) {
+		if (value === null)
+			value = "";
+		if (value.match(/^[a-z]$/) || value === "") {
+			this._setTheme(this._ui.container, value, unconditional);
+			// The screen must always have some kind of background for fade to work, so, if the theme is being unset,
+			// set the background to "a".
+			this._setTheme(this._ui.screen, (value === "" ? "a" : value), unconditional);
 		}
 		else
 			console.log("Warning: " + value + " is not a valid overlay theme! Please specify a single letter a-z or an empty string!");
@@ -247,7 +256,7 @@ $(document).bind("pagecreate create", function(e) {
 
 		if (popup[0]) {
 			// If the popup has a theme set, prevent it from being clobbered by the associated button
-			if (popup.popup("option", "overlayTheme").match(/[a-z]/))
+			if ((popup.popup("option", "overlayTheme") || "").match(/[a-z]/))
 				popup.jqmData("overlay-theme-set", true);
 			btn
 				.attr({


### PR DESCRIPTION
Allows one to turn any div into a popup (overlay). Additionally, a link whose data-rel attribute is set to "popup" will display a previously created popup centered above the link. The popup is identified by the link's href attribute.

This plugin could be used to simplify the portion of the select plugin which creates non-native menus, because it is based on that code.
