### PR TITLE
Store title of initial page

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1120,6 +1120,9 @@
 		if( !!newPageTitle && pageTitle == document.title ) {
 			pageTitle = newPageTitle;
 		}
+		if ( !toPage.jqmData( "title" ) ) {
+			toPage.jqmData( "title", pageTitle );
+		}
 
 		// Make sure we have a transition defined.
 		settings.transition = settings.transition


### PR DESCRIPTION
There's a funny edge case right now where if you go from the first page to a different page, then return to the initial page via a link instead of the back button, the title of the first page is overwritten by the title of the page where the link to the first page appears. Seems to be because the title of the first page is never stored, and this should fix that.
