### PR TITLE
Hue/Saturation/Value picker widget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ CSSTHEME = default
 # The files to include when compiling the JS files
 JSFILES = 	  js/jquery.ui.widget.js \
 			  js/jquery.mobile.widget.js \
+			  js/jquery.mobile.forms.hsvpicker.js \
 			  js/jquery.mobile.media.js \
 			  js/jquery.mobile.support.js \
 			  js/jquery.mobile.vmouse.js \
@@ -90,6 +91,7 @@ CSSSTRUCTUREFILES = css/structure/jquery.mobile.core.css \
 			  css/structure/jquery.mobile.forms.select.css \
 			  css/structure/jquery.mobile.forms.textinput.css \
 			  css/structure/jquery.mobile.listview.css \
+			  css/structure/jquery.mobile.forms.hsvpicker.css \
 			  css/structure/jquery.mobile.forms.slider.css
 
 

--- a/css/structure/index.php
+++ b/css/structure/index.php
@@ -14,6 +14,7 @@ $files = array_merge($files, array(
 	'../../structure/jquery.mobile.forms.select.css',
 	'../../structure/jquery.mobile.forms.textinput.css',
 	'../../structure/jquery.mobile.listview.css',
+	'../../structure/jquery.mobile.forms.hsvpicker.css',
 	'../../structure/jquery.mobile.forms.slider.css'
 ));
 

--- a/css/structure/jquery.mobile.forms.hsvpicker.css
+++ b/css/structure/jquery.mobile.forms.hsvpicker.css
@@ -1,0 +1,124 @@
+.ui-hsvpicker .hsvpicker-clrchannel-container {
+  display: table;
+  padding-left: 27px;
+  padding-right: 27px;
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-arrow-btn-container {
+  display: table-cell;
+  vertical-align: middle;
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-arrow-btn {
+  float: left;
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container {
+  float: left;
+  position: relative;
+  width: 300px;
+  height: 38px;
+  margin-left: 2px;
+  margin-right: 2px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container .hsvpicker-clrchannel-mask {
+  position: absolute;
+  width: 300px;
+  height: 38px;
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container .hsvpicker-clrchannel-mask-white {
+	background: #ffffff;
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container .hsvpicker-clrchannel-mask-black {
+	background: #000000;
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container .hsvpicker-clrchannel-selector {
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  width: 10px;
+  height: 40px;
+  border: 5px solid black;
+}
+
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container .hue-gradient {
+    background: rgb(255,0,0); /* Old browsers */
+    background: -webkit-gradient(linear, left top, right top,
+        color-stop(  0%          ,rgba(255,  0,  0,1)),
+        color-stop( 16.666666667%,rgba(255,255,  0,1)),
+        color-stop( 33.333333333%,rgba(0  ,255,  0,1)),
+        color-stop( 50%          ,rgba(0  ,255,255,1)),
+        color-stop( 66.666666667%,rgba(0  ,  0,255,1)),
+        color-stop( 83.333333333%,rgba(255,  0,255,1)),
+        color-stop(100%          ,rgba(255,  0,  0,1))); /* Chrome,Safari4+ */
+    background: -moz-linear-gradient(left, 
+        rgba(255,  0,  0,1)   0%, 
+        rgba(255,255,  0,1)  16.666666667%,
+        rgba(  0,255,  0,1)  33.333333333%,
+        rgba(  0,255,255,1)  50%,
+        rgba(  0,  0,255,1)  66.666666667%,
+        rgba(255,  0,255,1)  83.333333333%,
+        rgba(255,  0,  0,1) 100%);
+    background: -webkit-linear-gradient(left,
+        rgba(255,  0,  0,1)   0%, 
+        rgba(255,255,  0,1)  16.666666667%,
+        rgba(  0,255,  0,1)  33.333333333%,
+        rgba(  0,255,255,1)  50%,
+        rgba(  0,  0,255,1)  66.666666667%,
+        rgba(255,  0,255,1)  83.333333333%,
+        rgba(255,  0,  0,1) 100%);
+    background: -o-linear-gradient(left,
+        rgba(255,  0,  0,1)   0%, 
+        rgba(255,255,  0,1)  16.666666667%,
+        rgba(  0,255,  0,1)  33.333333333%,
+        rgba(  0,255,255,1)  50%,
+        rgba(  0,  0,255,1)  66.666666667%,
+        rgba(255,  0,255,1)  83.333333333%,
+        rgba(255,  0,  0,1) 100%);
+    background: -ms-linear-gradient(left,
+        rgba(255,  0,  0,1)   0%, 
+        rgba(255,255,  0,1)  16.666666667%,
+        rgba(  0,255,  0,1)  33.333333333%,
+        rgba(  0,255,255,1)  50%,
+        rgba(  0,  0,255,1)  66.666666667%,
+        rgba(255,  0,255,1)  83.333333333%,
+        rgba(255,  0,  0,1) 100%);
+    background: linear-gradient(left,
+        rgba(255,  0,  0,1)   0%, 
+        rgba(255,255,  0,1)  16.666666667%,
+        rgba(  0,255,  0,1)  33.333333333%,
+        rgba(  0,255,255,1)  50%,
+        rgba(  0,  0,255,1)  66.666666667%,
+        rgba(255,  0,255,1)  83.333333333%,
+        rgba(255,  0,  0,1) 100%);
+}
+
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container .sat-gradient {
+  background: #ff0000;
+  /* Old browsers */
+
+  background: -webkit-gradient(linear, left top, right top, color-stop(0%, #ffffff), color-stop(100%, rgba(255, 255, 255, 0)));
+  /* Chrome,Safari4+ */
+
+  background: -moz-linear-gradient(left, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
+  background: -webkit-linear-gradient(left, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
+  background: -o-linear-gradient(left, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
+  background: -ms-linear-gradient(left, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
+  background: linear-gradient(left, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
+}
+.ui-hsvpicker .hsvpicker-clrchannel-container .hsvpicker-clrchannel-masks-container .val-gradient {
+  background: #ff0000;
+  /* Old browsers */
+
+  background: -webkit-gradient(linear, left top, right top, color-stop(0%, #000000), color-stop(100%, rgba(0, 0, 0, 0)));
+  /* Chrome,Safari4+ */
+
+  background: -moz-linear-gradient(left, #000000 0%, rgba(0, 0, 0, 0) 100%);
+  background: -webkit-linear-gradient(left, #000000 0%, rgba(0, 0, 0, 0) 100%);
+  background: -o-linear-gradient(left, #000000 0%, rgba(0, 0, 0, 0) 100%);
+  background: -ms-linear-gradient(left, #000000 0%, rgba(0, 0, 0, 0) 100%);
+  background: linear-gradient(left, #000000 0%, rgba(0, 0, 0, 0) 100%);
+}

--- a/docs/forms/checkboxes/index.html
+++ b/docs/forms/checkboxes/index.html
@@ -145,6 +145,7 @@
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li data-theme="a"><a href="index.html">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/checkboxes/methods.html
+++ b/docs/forms/checkboxes/methods.html
@@ -83,6 +83,7 @@ $("input[type='checkbox']:first").attr("checked",true).checkboxradio("refresh");
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li data-theme="a"><a href="index.html">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/checkboxes/options.html
+++ b/docs/forms/checkboxes/options.html
@@ -68,6 +68,7 @@
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li data-theme="a"><a href="index.html">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/docs-forms.html
+++ b/docs/forms/docs-forms.html
@@ -217,6 +217,7 @@ $(document).bind('mobileinit',function(){
 					<li><a href="radiobuttons/">Radio buttons</a></li>
 					<li><a href="checkboxes/">Checkboxes</a></li>
 					<li><a href="selects/">Select menus</a></li>
+					<li><a href="hsvpicker/">Color picker</a></li>
 					<li><a href="forms-themes.html">Theming forms</a></li>
 					<li><a href="forms-all-native.html">Native form elements</a></li>
 					<li><a href="forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/forms-all-native.html
+++ b/docs/forms/forms-all-native.html
@@ -225,6 +225,7 @@
 					<li><a href="radiobuttons/">Radio buttons</a></li>
 					<li><a href="checkboxes/">Checkboxes</a></li>
 					<li><a href="selects/">Select menus</a></li>
+					<li><a href="hsvpicker/">Color picker</a></li>
 					<li><a href="forms-themes.html">Theming forms</a></li>
 					<li data-theme="a"><a href="forms-all-native.html">Native form elements</a></li>
 					<li><a href="forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/forms-all.html
+++ b/docs/forms/forms-all.html
@@ -223,6 +223,7 @@
 					<li><a href="radiobuttons/">Radio buttons</a></li>
 					<li><a href="checkboxes/">Checkboxes</a></li>
 					<li><a href="selects/">Select menus</a></li>
+					<li><a href="hsvpicker/">Color picker</a></li>
 					<li><a href="forms-themes.html">Theming forms</a></li>
 					<li><a href="forms-all-native.html">Native form elements</a></li>
 					<li><a href="forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/forms-sample.html
+++ b/docs/forms/forms-sample.html
@@ -90,6 +90,7 @@
 							<li><a href="radiobuttons/">Radio buttons</a></li>
 							<li><a href="checkboxes/">Checkboxes</a></li>
 							<li><a href="selects/">Select menus</a></li>
+							<li><a href="hsvpicker/">Color picker</a></li>
 							<li><a href="forms-themes.html">Theming forms</a></li>
 							<li><a href="forms-all-native.html">Native form elements</a></li>
 							<li data-theme="a"><a href="forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/forms-themes.html
+++ b/docs/forms/forms-themes.html
@@ -384,6 +384,7 @@
 						<li><a href="radiobuttons/">Radio buttons</a></li>
 						<li><a href="checkboxes/">Checkboxes</a></li>
 						<li><a href="selects/">Select menus</a></li>
+						<li><a href="hsvpicker/">Color picker</a></li>
 						<li data-theme="a"><a href="forms-themes.html">Theming forms</a></li>
 						<li><a href="forms-all-native.html">Native form elements</a></li>
 						<li><a href="forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/hsvpicker/events.html
+++ b/docs/forms/hsvpicker/events.html
@@ -3,7 +3,7 @@
 	<head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>jQuery Mobile Docs - Radio buttons</title>
+	<title>jQuery Mobile Docs - Hue/Saturation/Value Color picker events</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
 	<script src="../../../js/jquery.js"></script>
@@ -16,7 +16,7 @@
 	<div data-role="page" class="type-interior">
 
 		<div data-role="header" data-theme="f">
-		<h1>Radio buttons</h1>
+		<h1>Color picker</h1>
 		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
 	</div><!-- /header -->
 
@@ -25,28 +25,39 @@
 
 		<form action="#" method="get">
 
-		<h2>Radio buttons</h2>
+			<h2>Color picker</h2>
 			
 			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
 				<li><a href="index.html" data-role="button" data-transition="fade">Basics</a></li>
-				<li><a href="options.html" data-role="button" data-transition="fade" class="ui-btn-active">Options</a></li>
+				<li><a href="options.html" data-role="button" data-transition="fade">Options</a></li>
 				<li><a href="methods.html" data-role="button" data-transition="fade">Methods</a></li>
-				<li><a href="events.html" data-role="button" data-transition="fade">Events</a></li>
+				<li><a href="events.html" data-role="button" data-transition="fade" class="ui-btn-active">Events</a></li>
 			</ul>
 			
-			<p>The radio button has the following options:</p>
+			<p>Bind events directly to the element used to create the color picker. When enhancing an <code>input</code> element, use jQuery Mobile's <a href="../../api/events.html">virtual events</a>, or bind standard JavaScript events, like change, focus, blur, etc.:</p>
+			<pre><code> 
+$( ".selector" ).bind( "change", function(event, ui) {
+  ...
+});
+</code></pre> 
 
-		<dl>
-			
-			<dt><code>theme</code> <em>string</em></dt>
-			<dd>
-				<p class="default">default: null, inherited from parent</p>
-				<p>Sets the color scheme (swatch) for all instances of this widget. It accepts a single letter from a-z that maps to the swatches included in your theme. By default, it will inherit the same swatch color as it's parent container if not explicitly set. This option is also exposed as a data attribute: <code>data-theme=&quot;a&quot;</code></p>			
-				<pre><code>$("input[type='radio']").checkboxradio(<strong>{ theme: "a" }</strong>);</code></pre>
-			</dd>
-			
-		</dl>	
-    
+			<p>The hsvpicker plugin also provides the following custom event:</p>
+
+	<dl>
+				
+		<dt><code>colorchanged</code> triggered when a new color is chosen</dt>
+		<dd>
+
+			<pre><code>
+$( ".selector" ).slider({
+   colorchanged: function(event, clr) { ... }
+});		
+			</code></pre>
+		</dd>
+		
+
+	</dl>
+	    
 	</form>
 	</div><!--/content-primary -->		
 	
@@ -65,10 +76,10 @@
 					<li><a href="../search/">Search input</a></li>
 					<li><a href="../slider/">Slider</a></li>
 					<li><a href="../switch/">Flip toggle switch</a></li>
-					<li data-theme="a"><a href="index.html">Radio buttons</a></li>
+					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
-					<li><a href="../hsvpicker/">Color picker</a></li>
+					<li data-theme="a"><a href="index.html">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/hsvpicker/index.html
+++ b/docs/forms/hsvpicker/index.html
@@ -3,7 +3,7 @@
 	<head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>jQuery Mobile Docs - Checkboxes</title>
+	<title>jQuery Mobile Docs - Hue/Saturation/Value Color picker</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
 	<script src="../../../js/jquery.js"></script>
@@ -16,49 +16,71 @@
 	<div data-role="page" class="type-interior">
 
 		<div data-role="header" data-theme="f">
-		<h1>Checkboxes</h1>
+		<h1>Color picker</h1>
 		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
 	</div><!-- /header -->
 
 	<div data-role="content">
 		<div class="content-primary">
 
-		<form action="#" method="get">
-
-		<h2>Checkboxes</h2>
+			<h2>Color picker</h2>
 			
 			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
-				<li><a href="index.html" data-role="button" data-transition="fade">Basics</a></li>
+				<li><a href="index.html" data-role="button" data-transition="fade" class="ui-btn-active">Basics</a></li>
 				<li><a href="options.html" data-role="button" data-transition="fade">Options</a></li>
 				<li><a href="methods.html" data-role="button" data-transition="fade">Methods</a></li>
-				<li><a href="events.html" data-role="button" data-transition="fade" class="ui-btn-active">Events</a></li>
+				<li><a href="events.html" data-role="button" data-transition="fade">Events</a></li>
 			</ul>
-			
-			<p>Bind events directly to the <code>input</code> element.  Use jQuery Mobile's <a href="../../api/events.html">virtual events</a>, or bind standard JavaScript events, like change, focus, blur, etc.:</p>
-			<pre><code> 
-$("input[type='checkbox']").bind( "change", function(event, ui) {
-  ...
+    
+			<p>To add a color picker widget to your page, add a div with the attribute <code>data-role="hsvpicker"</code> set:</p>
+
+<pre><code>
+&lt;div data-role=&quot;hsvpicker&quot;&gt;&lt;/div&gt;
+</code></pre>
+
+<p>This gives you an HSV color picker:</p>
+
+<div data-role="hsvpicker"></div>
+
+<p>You can also enhance your color inputs with this widget. To do this, modify the <code>initSelector</code> option during  the <a href="../../api/globalconfig.html">mobileinit event</a>:</p>
+<pre><code>$( document ).bind( "mobileinit", function(){
+   <strong>$.mobile.hsvpicker.prototype.options.initSelector += ", input[type='color']";</strong>
 });
 </code></pre>
-			
-			<p>The checkbox plugin has the following custom events:</p>
 
-	<dl>
-				
-		<dt><code>create</code> triggered when a checkbox is created</dt>
-		<dd>
-			
-			<pre><code>
-$("input[type='checkbox']").checkboxradio({
-   create: function(event, ui) { ... }
-});		
-			</code></pre>
-		</dd>
-		
+		<h2>Calling the hsvpicker plugin</h2>
 
-	</dl>
-	    
-	</form>
+<p>This plugin will auto initialize on any page that contains a div with the <code>data-role="hsvpicker"</code> attribute. However, if needed you can directly call the <code>hsvpicker</code> plugin on any selector, just like any jQuery plugin:</p>
+<pre><code>
+$('input').hsvpicker();
+</code></pre>
+
+<p>Here's how you can add an hsvpicker-enhanced color input to your form:</p>
+
+<pre><code>
+&lt;script&gt;
+$(document).bind(&quot;pagecreate&quot;, function() {$(&quot;#neededColor&quot;).hsvpicker();});
+&lt;/script&gt;
+&lt;form action=&quot;#&quot; method=&quot;get&quot;&gt;
+	&lt;div data-role=&quot;fieldcontain&quot;&gt;
+		&lt;label for=&quot;#neededColor&quot;&gt;Choose a color:&lt;/label&gt;
+		&lt;input id=&quot;neededColor&quot; type=&quot;color&quot; value=&quot;#112233&quot;&gt;&lt;/input&gt;
+	&lt;/div&gt;
+&lt;/form&gt;
+</code></pre>
+
+<p>The result:</p>
+
+<script>
+$(document).bind("pagecreate", function() {$("#neededColor").hsvpicker();});
+</script>
+<form action="#" method="get">
+	<div data-role="fieldcontain">
+		<label for="#neededColor">Choose a color:</label>
+		<input id="neededColor" type="color" value="#112233"></input>
+	</div>
+</form>
+
 	</div><!--/content-primary -->		
 	
 	<div class="content-secondary">
@@ -77,9 +99,9 @@ $("input[type='checkbox']").checkboxradio({
 					<li><a href="../slider/">Slider</a></li>
 					<li><a href="../switch/">Flip toggle switch</a></li>
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
-					<li data-theme="a"><a href="index.html">Checkboxes</a></li>
+					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
-					<li><a href="../hsvpicker/">Color picker</a></li>
+					<li data-theme="a"><a href="index.html">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/hsvpicker/methods.html
+++ b/docs/forms/hsvpicker/methods.html
@@ -3,7 +3,7 @@
 	<head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>jQuery Mobile Docs - Radio buttons</title>
+	<title>jQuery Mobile Docs - Hue/Saturation/Value Color picker methods</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
 	<script src="../../../js/jquery.js"></script>
@@ -16,7 +16,7 @@
 	<div data-role="page" class="type-interior">
 
 		<div data-role="header" data-theme="f">
-		<h1>Radio buttons</h1>
+		<h1>Color picker</h1>
 		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
 	</div><!-- /header -->
 
@@ -25,24 +25,39 @@
 
 		<form action="#" method="get">
 
-		<h2>Radio buttons</h2>
+			<h2>Color picker</h2>
 			
 			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
 				<li><a href="index.html" data-role="button" data-transition="fade">Basics</a></li>
-				<li><a href="options.html" data-role="button" data-transition="fade" class="ui-btn-active">Options</a></li>
-				<li><a href="methods.html" data-role="button" data-transition="fade">Methods</a></li>
+				<li><a href="options.html" data-role="button" data-transition="fade">Options</a></li>
+				<li><a href="methods.html" data-role="button" data-transition="fade" class="ui-btn-active">Methods</a></li>
 				<li><a href="events.html" data-role="button" data-transition="fade">Events</a></li>
 			</ul>
 			
-			<p>The radio button has the following options:</p>
+			<p>The hsvpicker plugin has the following methods:</p>
 
-		<dl>
-			
-			<dt><code>theme</code> <em>string</em></dt>
+		<dl>									
+			<dt><code>enable</code> enable a disabled color picker</dt>
 			<dd>
-				<p class="default">default: null, inherited from parent</p>
-				<p>Sets the color scheme (swatch) for all instances of this widget. It accepts a single letter from a-z that maps to the swatches included in your theme. By default, it will inherit the same swatch color as it's parent container if not explicitly set. This option is also exposed as a data attribute: <code>data-theme=&quot;a&quot;</code></p>			
-				<pre><code>$("input[type='radio']").checkboxradio(<strong>{ theme: "a" }</strong>);</code></pre>
+				<pre><code>
+$('.selector').hsvpicker('enable');
+				</code></pre>
+			</dd>
+			
+			<dt><code>disable</code> disable a color picker</dt>
+			<dd>
+				<pre><code>
+$('.selector').hsvpicker('disable');
+				</code></pre>
+			</dd>
+						
+			<dt><code>refresh</code> update the color picker</dt>
+			<dd>
+			<p>If you manipulate a color picker via JavaScript, you must call the refresh method on it to update the visual styling.</p> 				
+			
+			<pre><code>			
+$('.selector').hsvpicker('refresh');
+				</code></pre>
 			</dd>
 			
 		</dl>	
@@ -65,10 +80,10 @@
 					<li><a href="../search/">Search input</a></li>
 					<li><a href="../slider/">Slider</a></li>
 					<li><a href="../switch/">Flip toggle switch</a></li>
-					<li data-theme="a"><a href="index.html">Radio buttons</a></li>
+					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
-					<li><a href="../hsvpicker/">Color picker</a></li>
+					<li data-theme="a"><a href="index.html">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/hsvpicker/options.html
+++ b/docs/forms/hsvpicker/options.html
@@ -3,7 +3,7 @@
 	<head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>jQuery Mobile Docs - Radio buttons</title>
+	<title>jQuery Mobile Docs - Hue/Saturation/Value Color picker options</title>
 	<link rel="stylesheet"  href="../../../css/themes/default/" />
 	<link rel="stylesheet" href="../../_assets/css/jqm-docs.css"/>
 	<script src="../../../js/jquery.js"></script>
@@ -16,7 +16,7 @@
 	<div data-role="page" class="type-interior">
 
 		<div data-role="header" data-theme="f">
-		<h1>Radio buttons</h1>
+		<h1>Color picker</h1>
 		<a href="../../../" data-icon="home" data-iconpos="notext" data-direction="reverse" class="ui-btn-right jqm-home">Home</a>
 	</div><!-- /header -->
 
@@ -25,7 +25,7 @@
 
 		<form action="#" method="get">
 
-		<h2>Radio buttons</h2>
+			<h2>Color picker</h2>
 			
 			<ul data-role="controlgroup" data-type="horizontal" class="localnav">
 				<li><a href="index.html" data-role="button" data-transition="fade">Basics</a></li>
@@ -34,17 +34,33 @@
 				<li><a href="events.html" data-role="button" data-transition="fade">Events</a></li>
 			</ul>
 			
-			<p>The radio button has the following options:</p>
+			<p>The hsvpicker plugin has the following options:</p>
 
 		<dl>
-			
-			<dt><code>theme</code> <em>string</em></dt>
+			<dt><code>disabled</code> <em>string</em></dt>
 			<dd>
-				<p class="default">default: null, inherited from parent</p>
-				<p>Sets the color scheme (swatch) for all instances of this widget. It accepts a single letter from a-z that maps to the swatches included in your theme. By default, it will inherit the same swatch color as it's parent container if not explicitly set. This option is also exposed as a data attribute: <code>data-theme=&quot;a&quot;</code></p>			
-				<pre><code>$("input[type='radio']").checkboxradio(<strong>{ theme: "a" }</strong>);</code></pre>
+				<p class="default">default: false</p>
+				<p>Sets the default state of the picker to disabled when "true".</p>		
+				<pre><code>$('.selector').hsvpicker(<strong>{ disabled: "true" }</strong>);</code></pre>
 			</dd>
 			
+			<dt><code>initSelector</code> <em>CSS selector string</em></dt>
+			<dd>
+				<p class="default">default: ":jqmData(role='hsvpicker')"</p>
+				<p>This is used to define the selectors (element types, data roles, etc.) that will automatically be initialized as color pickers. To change which elements are initialized, bind this option to the <a href="../../api/globalconfig.html">mobileinit event</a>:</p>
+<pre><code>$( document ).bind( "mobileinit", function(){
+   <strong>$.mobile.hsvpicker.prototype.options.initSelector = ".myhsvpicker";</strong>
+});
+</code></pre>
+			</dd>
+						
+			<dt><code>color</code> <em>HTML color string</em></dt>
+			<dd>
+				<p class="default">default: #244224</p>
+				<p>Sets the color displayed by the widget. This option is also exposed as a data attribute: <code>data-color=&quot;#244224&quot;</code></p>			
+				<pre><code>$('.selector').hsvpicker(<strong>{ color: "#244224" }</strong>);</code></pre>
+			</dd>
+
 		</dl>	
     
 	</form>
@@ -65,10 +81,10 @@
 					<li><a href="../search/">Search input</a></li>
 					<li><a href="../slider/">Slider</a></li>
 					<li><a href="../switch/">Flip toggle switch</a></li>
-					<li data-theme="a"><a href="index.html">Radio buttons</a></li>
+					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
-					<li><a href="../hsvpicker/">Color picker</a></li>
+					<li data-theme="a"><a href="index.html">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/index.html
+++ b/docs/forms/index.html
@@ -34,6 +34,7 @@
 			<li><a href="radiobuttons/">Radio buttons</a></li>
 			<li><a href="checkboxes/">Checkboxes</a></li>
 			<li><a href="selects/">Select menus</a></li>
+			<li><a href="hsvpicker/">Color picker</a></li>
 			<li><a href="forms-themes.html">Theming forms</a></li>
 			<li><a href="forms-all-native.html">Native form elements</a></li>
 			<li><a href="forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/plugin-eventsmethods.html
+++ b/docs/forms/plugin-eventsmethods.html
@@ -51,6 +51,7 @@
 						<li><a href="radiobuttons/">Radio buttons</a></li>
 						<li><a href="checkboxes/">Checkboxes</a></li>
 						<li><a href="selects/">Select menus</a></li>
+						<li><a href="hsvpicker/">Color picker</a></li>
 						<li><a href="forms-themes.html">Theming forms</a></li>
 						<li><a href="forms-all-native.html">Native form elements</a></li>
 						<li><a href="forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/radiobuttons/events.html
+++ b/docs/forms/radiobuttons/events.html
@@ -81,6 +81,7 @@ $("input[type='radio']").checkboxradio({
 					<li data-theme="a"><a href="index.html">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/radiobuttons/index.html
+++ b/docs/forms/radiobuttons/index.html
@@ -170,6 +170,7 @@
 					<li data-theme="a"><a href="index.html">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/radiobuttons/methods.html
+++ b/docs/forms/radiobuttons/methods.html
@@ -83,6 +83,7 @@ $("input[type='radio']:first").attr("checked",true).checkboxradio("refresh");
 					<li data-theme="a"><a href="index.html">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/search/events.html
+++ b/docs/forms/search/events.html
@@ -78,6 +78,7 @@ $( ".selector" ).textinput({
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/search/index.html
+++ b/docs/forms/search/index.html
@@ -100,6 +100,7 @@ $('.mySearchInput').textinput();
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/search/methods.html
+++ b/docs/forms/search/methods.html
@@ -75,6 +75,7 @@ $('.selector').textinput('disable');
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/search/options.html
+++ b/docs/forms/search/options.html
@@ -77,6 +77,7 @@
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/selects/events.html
+++ b/docs/forms/selects/events.html
@@ -80,6 +80,7 @@ $( ".selector" ).selectmenu({
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li data-theme="a"><a href="index.html">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/selects/index.html
+++ b/docs/forms/selects/index.html
@@ -690,6 +690,7 @@ $('select').selectmenu();
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li data-theme="a"><a href="index.html">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/selects/methods.html
+++ b/docs/forms/selects/methods.html
@@ -101,6 +101,7 @@ $('select').selectmenu('refresh', true);
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li data-theme="a"><a href="index.html">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/selects/options.html
+++ b/docs/forms/selects/options.html
@@ -127,6 +127,7 @@
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li data-theme="a"><a href="index.html">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/slider/events.html
+++ b/docs/forms/slider/events.html
@@ -79,6 +79,7 @@ $( ".selector" ).slider({
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/slider/index.html
+++ b/docs/forms/slider/index.html
@@ -112,6 +112,7 @@ $('input').slider();
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/slider/methods.html
+++ b/docs/forms/slider/methods.html
@@ -83,6 +83,7 @@ $('.selector').slider('refresh');
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/slider/options.html
+++ b/docs/forms/slider/options.html
@@ -92,6 +92,7 @@
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/switch/events.html
+++ b/docs/forms/switch/events.html
@@ -79,6 +79,7 @@ $( ".selector" ).slider({
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/switch/index.html
+++ b/docs/forms/switch/index.html
@@ -135,6 +135,7 @@ $('select').slider();
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/switch/methods.html
+++ b/docs/forms/switch/methods.html
@@ -83,6 +83,7 @@ $('.selector').slider('refresh');
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/switch/options.html
+++ b/docs/forms/switch/options.html
@@ -92,6 +92,7 @@
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/textinputs/events.html
+++ b/docs/forms/textinputs/events.html
@@ -78,6 +78,7 @@ $( ".selector" ).textinput({
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/textinputs/index.html
+++ b/docs/forms/textinputs/index.html
@@ -200,6 +200,7 @@ $('input').textinput();
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/textinputs/methods.html
+++ b/docs/forms/textinputs/methods.html
@@ -75,6 +75,7 @@ $('.selector').textinput('disable');
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/docs/forms/textinputs/options.html
+++ b/docs/forms/textinputs/options.html
@@ -77,6 +77,7 @@
 					<li><a href="../radiobuttons/">Radio buttons</a></li>
 					<li><a href="../checkboxes/">Checkboxes</a></li>
 					<li><a href="../selects/">Select menus</a></li>
+					<li><a href="../hsvpicker/">Color picker</a></li>
 					<li><a href="../forms-themes.html">Theming forms</a></li>
 					<li><a href="../forms-all-native.html">Native form elements</a></li>
 					<li><a href="../forms-sample.html">Submitting forms</a></li>

--- a/js/index.php
+++ b/js/index.php
@@ -3,6 +3,7 @@ $type = 'text/javascript';
 $files = array(
 	'jquery.ui.widget.js',
 	'jquery.mobile.widget.js',
+	'jquery.mobile.forms.hsvpicker.js',
 	'jquery.mobile.media.js',
 	'jquery.mobile.support.js',
 	'jquery.mobile.vmouse.js',

--- a/js/jquery.mobile.forms.hsvpicker.js
+++ b/js/jquery.mobile.forms.hsvpicker.js
@@ -1,0 +1,516 @@
+(function($, undefined) {
+
+$.widget("mobile.hsvpicker", $.mobile.widget, {
+	options: {
+		color        : "#244224",
+		initSelector : ":jqmData(role='hsvpicker')"
+	},
+
+	_create: function() {
+		var widgetOptionNames = {
+		    	"color"    : (this.element.is("input") ? "value" : "data-" + ($.mobile.ns || "") + "color")
+		    },
+		    ui = {
+		    	container: "#hsvpicker",
+		    	hue: {
+		    		selector:    "#hsvpicker-hue-selector",
+		    		hue:         "#hsvpicker-hue-hue",
+		    		valMask:     "#hsvpicker-hue-mask-val",
+		    		eventSource: "[data-event-source='hue']"
+		    	},
+		    	sat: {
+		    		selector:    "#hsvpicker-sat-selector",
+		    		hue:         "#hsvpicker-sat-hue",
+		    		valMask:     "#hsvpicker-sat-mask-val",
+		    		eventSource: "[data-event-source='sat']"
+		    	},
+		    	val: {
+		    		selector:    "#hsvpicker-val-selector",
+		    		hue:         "#hsvpicker-val-hue",
+		    		eventSource: "[data-event-source='val']"
+		    	}
+		    },
+		    proto = $(
+"<div>" +
+"  <div id='hsvpicker' class='ui-hsvpicker'>" +
+"    <div class='hsvpicker-clrchannel-container'>" +
+"        <div class='hsvpicker-arrow-btn-container'>" +
+"            <a href='#' class='hsvpicker-arrow-btn' data-target='hue' data-location='left' data-role='button' data-inline='true' data-iconpos='notext' data-icon='arrow-l'></a>" +
+"        </div>" +
+"        <div class='hsvpicker-clrchannel-masks-container'>" +
+"            <div class='hsvpicker-clrchannel-mask hsvpicker-clrchannel-mask-white'></div>" +
+"            <div id='hsvpicker-hue-hue' class='hsvpicker-clrchannel-mask hue-gradient'></div>" +
+"            <div id='hsvpicker-hue-mask-val' class='hsvpicker-clrchannel-mask hsvpicker-clrchannel-mask-black' data-event-source='hue'></div>" +
+"            <div id='hsvpicker-hue-selector' class='hsvpicker-clrchannel-selector ui-corner-all'></div>" +
+"        </div>" +
+"        <div class='hsvpicker-arrow-btn-container'>" +
+"            <a href='#' class='hsvpicker-arrow-btn' data-target='hue' data-location='right' data-role='button' data-inline='true' data-iconpos='notext' data-icon='arrow-r'></a>" +
+"        </div>" +
+"    </div>" +
+"    <div class='hsvpicker-clrchannel-container'>" +
+"        <div class='hsvpicker-arrow-btn-container'>" +
+"            <a href='#' class='hsvpicker-arrow-btn' data-target='sat' data-location='left' data-role='button' data-inline='true' data-iconpos='notext' data-icon='arrow-l'></a>" +
+"        </div>" +
+"        <div class='hsvpicker-clrchannel-masks-container'>" +
+"            <div id='hsvpicker-sat-hue' class='hsvpicker-clrchannel-mask'></div>" +
+"            <div class='hsvpicker-clrchannel-mask  sat-gradient'></div>" +
+"            <div id='hsvpicker-sat-mask-val' class='hsvpicker-clrchannel-mask hsvpicker-clrchannel-mask-black' data-event-source='sat'></div>" +
+"            <div id='hsvpicker-sat-selector' class='hsvpicker-clrchannel-selector ui-corner-all'></div>" +
+"        </div>" +
+"        <div class='hsvpicker-arrow-btn-container'>" +
+"            <a href='#' class='hsvpicker-arrow-btn' data-target='sat' data-location='right' data-role='button' data-inline='true' data-iconpos='notext' data-icon='arrow-r'></a>" +
+"        </div>" +
+"    </div>" +
+"    <div class='hsvpicker-clrchannel-container'>" +
+"        <div class='hsvpicker-arrow-btn-container'>" +
+"            <a href='#' class='hsvpicker-arrow-btn' data-target='val' data-location='left' data-role='button' data-inline='true' data-iconpos='notext' data-icon='arrow-l'></a>" +
+"        </div>" +
+"        <div class='hsvpicker-clrchannel-masks-container'>" +
+"            <div class='hsvpicker-clrchannel-mask hsvpicker-clrchannel-mask-white'></div>" +
+"            <div id='hsvpicker-val-hue' class='hsvpicker-clrchannel-mask'></div>" +
+"            <div class='hsvpicker-clrchannel-mask val-gradient' data-event-source='val'></div>" +
+"            <div id='hsvpicker-val-selector' class='hsvpicker-clrchannel-selector ui-corner-all'></div>" +
+"        </div>" +
+"        <div class='hsvpicker-arrow-btn-container'>" +
+"            <a href='#' class='hsvpicker-arrow-btn' data-target='val' data-location='right' data-role='button' data-inline='true' data-iconpos='notext' data-icon='arrow-r'></a>" +
+"        </div>" +
+"    </div>" +
+"  </div>" +
+"</div>"
+),
+		    self = this;
+
+		// Assign the relevant parts of the proto
+		function assignElements(proto, obj) {
+			for (var key in obj)
+				if (typeof obj[key] === "string")
+					obj[key] = proto.find(obj[key]).removeAttr("id");
+				else
+				if (typeof obj[key] === "object")
+					obj[key] = assignElements(proto, obj[key]);
+			return obj;
+		}
+		ui = assignElements(proto, ui);
+
+		// Apply the proto
+		if (this.element.is("input"))
+			ui.container.insertAfter(this.element);
+		else
+			this.element.append(ui.container);
+
+		// Define instance variables
+		$.extend(this, {
+			_ui: ui,
+			_dragging_hsv: [0, 0, 0],
+			_selectorDraggingOffset: {
+				x: -1,
+				y: -1
+			},
+			_dragging: -1
+		});
+
+		// Apply options - data-* options, if present, take precedence over this.options.*
+		for (var key in this.options)
+			this._setOption(key,
+				(widgetOptionNames[key] === undefined || this.element.attr(widgetOptionNames[key]) === undefined)
+					? this.options[key]
+					: this.element.attr(widgetOptionNames[key]), true);
+
+		
+		ui.container.find(".hsvpicker-arrow-btn")
+			.buttonMarkup()
+			.bind("vclick", function(e) {
+				var chan = $(this).attr("data-target"),
+				    hsvIdx = ("hue" === chan) ? 0 :
+                     ("sat" === chan) ? 1 : 2,
+				    max = (0 == hsvIdx ? 360 : 1),
+				    step = 0.05 * max;
+
+				self._dragging_hsv[hsvIdx] = self._dragging_hsv[hsvIdx] + step * ("left" === $(this).attr("data-location") ? -1 : 1);
+				self._dragging_hsv[hsvIdx] = Math.min(max, Math.max(0.0, self._dragging_hsv[hsvIdx]));
+				self._updateSelectors(self._dragging_hsv);
+			});
+
+		if (this.element.is("input"))
+			this.element.bind("change", function(e) {
+				self._setOption("color", self.element.attr("value"));
+			});
+
+		$( document )
+			.bind( "vmousemove", function( event ) {
+				if ( self._dragging != -1 ) {
+					event.stopPropagation();
+					event.preventDefault();
+				}
+			})
+			.bind( "vmouseup", function( event ) {
+				self._dragging = -1;
+			});
+
+		this._bindElements("hue", 0);
+		this._bindElements("sat", 1);
+		this._bindElements("val", 2);
+	},
+
+	_bindElements: function(chan, idx) {
+		var self = this;
+		this._ui[chan].selector
+			.bind("mousedown vmousedown", function(e) { self._handleMouseDown(chan,  idx, e, true); })
+			.bind("vmousemove touchmove", function(e) { self._handleMouseMove(chan,  idx, e, true); })
+			.bind("vmouseup",             function(e) { self._dragging = -1; });
+		this._ui[chan].eventSource
+			.bind("mousedown vmousedown", function(e) { self._handleMouseDown(chan, idx, e, false); })
+			.bind("vmousemove touchmove", function(e) { self._handleMouseMove(chan, idx, e, false); })
+			.bind("vmouseup",             function(e) { self._dragging = -1; });
+	},
+
+	/**
+	 * Get document-relative mouse coordinates from a given event
+	 *
+	 * From: http://www.quirksmode.org/js/events_properties.html#position
+	 */
+	_documentRelativeCoordsFromEvent: function(ev) {
+		var e = ev ? ev : window.event,
+		    client = { x: e.clientX, y: e.clientY },
+		    page   = { x: e.pageX,   y: e.pageY   },
+		    posx = 0,
+		    posy = 0;
+
+		/* Grab useful coordinates from touch events */
+		if (e.type.match(/^touch/)) {
+			page = {
+				x: e.originalEvent.targetTouches[0].pageX,
+				y: e.originalEvent.targetTouches[0].pageY
+			};
+			client = {
+				x: e.originalEvent.targetTouches[0].clientX,
+				y: e.originalEvent.targetTouches[0].clientY
+			};
+		}
+
+		if (page.x || page.y) {
+			posx = page.x;
+			posy = page.y;
+		}
+		else
+		if (client.x || client.y) {
+			posx = client.x + document.body.scrollLeft + document.documentElement.scrollLeft;
+			posy = client.y + document.body.scrollTop  + document.documentElement.scrollTop;
+		}
+
+		return { x: posx, y: posy };
+	},
+
+	_targetRelativeCoordsFromEvent: function(e) {
+		var coords = { x: e.offsetX, y: e.offsetY };
+
+		if (coords.x === undefined || isNaN(coords.x) ||
+		    coords.y === undefined || isNaN(coords.y)) {
+			var offset = $(e.target).offset();
+
+			coords = this._documentRelativeCoordsFromEvent(e);
+			coords.x -= offset.left;
+			coords.y -= offset.top;
+		}
+
+		return coords;
+	},
+
+	_handleMouseDown: function(chan, idx, e, isSelector) {
+		var coords = this._targetRelativeCoordsFromEvent(e),
+		    widgetStr = (isSelector ? "selector" : "eventSource");
+
+		if (coords.x >= 0 && coords.x <= this._ui[chan][widgetStr].outerWidth() &&
+		    coords.y >= 0 && coords.y <= this._ui[chan][widgetStr].outerHeight()) {
+
+			this._dragging = idx;
+
+			if (isSelector) {
+				this._selectorDraggingOffset.x = coords.x;
+				this._selectorDraggingOffset.y = coords.y;
+			}
+
+			this._handleMouseMove(chan, idx, e, isSelector, coords);
+		}
+	},
+
+	_handleMouseMove: function(chan, idx, e, isSelector, coords) {
+		if (this._dragging === idx) {
+			if (coords === undefined)
+				var coords = this._targetRelativeCoordsFromEvent(e);
+			var factor = ((0 === idx) ? 360 : 1),
+			    potential = (isSelector
+			    	? ((this._dragging_hsv[idx] / factor) +
+	  	    		 ((coords.x - this._selectorDraggingOffset.x) / this._ui[chan].eventSource.width()))
+			    	: (coords.x / this._ui[chan].eventSource.width()));
+
+			this._dragging_hsv[idx] = Math.min(1.0, Math.max(0.0, potential)) * factor;
+
+			if (!isSelector) {
+				this._selectorDraggingOffset.x = Math.ceil(this._ui[chan].selector.outerWidth()  / 2.0);
+				this._selectorDraggingOffset.y = Math.ceil(this._ui[chan].selector.outerHeight() / 2.0);
+			}
+
+			this._updateSelectors(this._dragging_hsv);
+			e.stopPropagation();
+			e.preventDefault();
+		}
+	},
+
+	_updateSelectors: function(hsv) {
+    	var  clr = this._RGBToHTML(this._HSVToRGB(hsv)),
+			    hclr = this._RGBToHTML(this._HSVToRGB([hsv[0], 1.0, 1.0])),
+			    vclr = this._RGBToHTML(this._HSVToRGB([hsv[0], hsv[1], 1.0]));
+
+    	this._ui.hue.selector.css("left", this._ui.hue.eventSource.width() * hsv[0] / 360);
+    	this._ui.hue.selector.css("background", clr);
+    	this._ui.hue.hue.css("opacity", hsv[1]);
+    	this._ui.hue.valMask.css("opacity", 1.0 - hsv[2]);
+
+    	this._ui.sat.selector.css("left", this._ui.sat.eventSource.width() * hsv[1]);
+    	this._ui.sat.selector.css("background", clr);
+    	this._ui.sat.hue.css("background", hclr);
+    	this._ui.sat.valMask.css("opacity", 1.0 - hsv[2]);
+
+    	this._ui.val.selector.css("left", this._ui.val.eventSource.width() * hsv[2]);
+    	this._ui.val.selector.css("background", clr);
+    	this._ui.val.hue.css("background", vclr);
+
+			this._updateAttributes(clr);
+	},
+
+	/*
+	 * Converts html color string to rgb array.
+	 *
+	 * Input: string clr_str, where
+	 * clr_str is of the form "#aabbcc"
+	 *
+	 * Returns: [ r, g, b ], where
+	 * r is in [0, 1]
+	 * g is in [0, 1]
+	 * b is in [0, 1]
+	 */
+	_HTMLToRGB: function(clr_str) {
+		clr_str = (('#' == clr_str.charAt(0)) ? clr_str.substring(1) : clr_str);
+
+		return ([clr_str.substring(0, 2),
+		         clr_str.substring(2, 4),
+		         clr_str.substring(4, 6)].map(function(val) {
+   	           return parseInt(val, 16) / 255.0;
+		         }));
+	},
+
+	/*
+	 * Converts rgb array to html color string.
+	 *
+	 * Input: [ r, g, b ], where
+	 * r is in [0, 1]
+	 * g is in [0, 1]
+	 * b is in [0, 1]
+	 *
+	 * Returns: string of the form "#aabbcc"
+	 */
+	_RGBToHTML: function(rgb) {
+		return ("#" + 
+			rgb.map(function(val) {
+			    	var ret = val * 255,
+   		    	    theFloor = Math.floor(ret);
+
+			    	ret = ((ret - theFloor > 0.5) ? (theFloor + 1) : theFloor);
+			    	ret = (((ret < 16) ? "0" : "") + (ret & 0xff).toString(16));
+			    	return ret;
+ 			    })
+			   .join(""));
+	},
+
+	/*
+	 * Converts hsv to rgb.
+	 *
+	 * Input: [ h, s, v ], where
+	 * h is in [0, 360]
+	 * s is in [0,   1]
+	 * v is in [0,   1]
+	 *
+	 * Returns: [ r, g, b ], where
+	 * r is in [0, 1]
+	 * g is in [0, 1]
+	 * b is in [0, 1]
+	 */
+	_HSVToRGB: function(hsv) {
+		return this._HSLToRGB(this._HSVToHSL(hsv));
+	},
+
+	/*
+	 * Converts rgb to hsv.
+	 *
+	 * from http://coecsl.ece.illinois.edu/ge423/spring05/group8/FinalProject/HSV_writeup.pdf
+	 *
+	 * Input: [ r, g, b ], where
+	 * r is in [0,   1]
+	 * g is in [0,   1]
+	 * b is in [0,   1]
+	 *
+	 * Returns: [ h, s, v ], where
+	 * h is in [0, 360]
+	 * s is in [0,   1]
+	 * v is in [0,   1]
+	 */
+	_RGBToHSV: function(rgb) {
+		var min, max, delta, h, s, v, r = rgb[0], g = rgb[1], b = rgb[2];
+
+		min = Math.min(r, Math.min(g, b));
+		max = Math.max(r, Math.max(g, b));
+		delta = max - min;
+
+		h = 0;
+		s = 0;
+		v = max;
+
+		if (delta > 0.00001) {
+			s = delta / max;
+
+			if (r === max)
+				h = (g - b) / delta ;
+			else
+			if (g === max)
+				h = 2 + (b - r) / delta ;
+			else
+				h = 4 + (r - g) / delta ;
+
+			h *= 60 ;
+
+			if (h < 0)
+				h += 360 ;
+		}
+
+		return [h, s, v];
+	},
+
+	/*
+	 * Converts hsl to rgb.
+	 *
+	 * From http://130.113.54.154/~monger/hsl-rgb.html
+	 *
+	 * Input: [ h, s, l ], where
+	 * h is in [0, 360]
+	 * s is in [0,   1]
+	 * l is in [0,   1]
+	 *
+	 * Returns: [ r, g, b ], where
+	 * r is in [0, 1]
+	 * g is in [0, 1]
+	 * b is in [0, 1]
+	 */
+	_HSLToRGB: function(hsl) {
+   	var h = hsl[0] / 360.0, s = hsl[1], l = hsl[2];
+
+   	if (0 === s)
+			return [ l, l, l ];
+
+		var temp2 = ((l < 0.5)
+         	? l * (1.0 + s)
+         	: l + s - l * s),
+		    temp1 = 2.0 * l - temp2,
+		    temp3 = {
+		    	r: h + 1.0 / 3.0,
+		    	g: h,
+		    	b: h - 1.0 / 3.0
+		    };
+
+		temp3.r = ((temp3.r < 0) ? (temp3.r + 1.0) : ((temp3.r > 1) ? (temp3.r - 1.0) : temp3.r));
+		temp3.g = ((temp3.g < 0) ? (temp3.g + 1.0) : ((temp3.g > 1) ? (temp3.g - 1.0) : temp3.g));
+		temp3.b = ((temp3.b < 0) ? (temp3.b + 1.0) : ((temp3.b > 1) ? (temp3.b - 1.0) : temp3.b));
+
+		ret = [
+			(((6.0 * temp3.r) < 1) ? (temp1 + (temp2 - temp1) * 6.0 * temp3.r) :
+			(((2.0 * temp3.r) < 1) ? temp2 :
+			(((3.0 * temp3.r) < 2) ? (temp1 + (temp2 - temp1) * ((2.0 / 3.0) - temp3.r) * 6.0) :
+			 temp1))),
+			(((6.0 * temp3.g) < 1) ? (temp1 + (temp2 - temp1) * 6.0 * temp3.g) :
+			(((2.0 * temp3.g) < 1) ? temp2 :
+			(((3.0 * temp3.g) < 2) ? (temp1 + (temp2 - temp1) * ((2.0 / 3.0) - temp3.g) * 6.0) :
+			 temp1))),
+			(((6.0 * temp3.b) < 1) ? (temp1 + (temp2 - temp1) * 6.0 * temp3.b) :
+			(((2.0 * temp3.b) < 1) ? temp2 :
+			(((3.0 * temp3.b) < 2) ? (temp1 + (temp2 - temp1) * ((2.0 / 3.0) - temp3.b) * 6.0) :
+			 temp1)))]; 
+
+		return ret;
+	},
+
+	/*
+	 * Converts hsv to hsl.
+	 *
+	 * Input: [ h, s, v ], where
+	 * h is in [0, 360]
+	 * s is in [0,   1]
+	 * v is in [0,   1]
+	 *
+	 * Returns: [ h, s, l ], where
+	 * h is in [0, 360]
+	 * s is in [0,   1]
+	 * l is in [0,   1]
+	 */
+	_HSVToHSL: function(hsv) {
+		var max = hsv[2],
+		    delta = hsv[1] * max,
+		    min = max - delta,
+		    sum = max + min,
+		    half_sum = sum / 2,
+		    s_divisor = ((half_sum < 0.5) ? sum : (2 - max - min));
+
+		return [ hsv[0], ((0 == s_divisor) ? 0 : (delta / s_divisor)), half_sum ];
+	},
+
+	_updateAttributes: function(clr) {
+		this.options.color = clr;
+		this.element.attr("data-" + ($.mobile.ns || "") + "color", clr);
+		if (this.element.is("input")) {
+			this.element.attr("value", clr);
+			this.element.triggerHandler("change");
+		}
+		this.element.triggerHandler("colorchanged");
+	},
+
+	_set_color: function(clr, unconditional) {
+		if (clr.match(/#[0-9a-fA-F]{6}/) && (clr !== this.options.color || unconditional)) {
+			this._dragging_hsv = this._RGBToHSV(this._HTMLToRGB(clr));
+			this._updateSelectors(this._dragging_hsv);
+			this._updateAttributes(clr);
+		}
+	},
+
+	_set_disabled: function(value, unconditional) {
+		if (this.options.disabled != value || unconditional) {
+			this.options.disabled = value;
+			this._ui.container[value ? "addClass" : "removeClass"]("ui-disabled");
+		}
+	},
+
+	_setOption: function(key, value, unconditional) {
+		if (unconditional === undefined)
+			unconditional = false;
+		if (this["_set_" + key] !== undefined)
+			this["_set_" + key](value, unconditional);
+	},
+
+	enable: function() {
+		this._setOption("disabled", false, true);
+	},
+
+	disable: function() {
+		this._setOption("disabled", true, true);
+	},
+
+	refresh: function() {
+		this._setOption("color", (this.element.attr("value") || this.element.attr("data-" + ($.mobile.ns || "") + "color")), true);
+	}
+});
+
+$(document).bind("pagecreate create", function(e) {
+	$($.mobile.hsvpicker.prototype.options.initSelector, e.target)
+		.not(":jqmData(role='none'), :jqmData(role='nojs')")
+		.hsvpicker();
+});
+
+})(jQuery);


### PR DESCRIPTION
This widget can be used to select a colour. It will set the data-color attribute of the element it enhances, and it will correctly synchronize with the value attribute of the element, if that element is an input (of type color).

It does not by default auto-enhance input elements of type color, because it takes up much more room than a text box, but its documentation tells users how to do it (mobileinit event, $.mobile.hsvpicker.prototype.options.initSelector += ", input[type='color']").

When enhancing a HTML colour-selecting text box, it appears below the text box, and does not hide the text box, so the user can continue to type in HTML colour values.
