### PR TITLE
Don't need the version number output for deploys on the files themselves...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,6 @@ OUTPUT = compiled
 # The name of the files
 NAME = jquery.mobile
 STRUCTURE = jquery.mobile.structure
-deploy: NAME = jquery.mobile-${VER_OFFICIAL}
-deploy: STRUCTURE = jquery.mobile.structure-${VER_OFFICIAL}
 
 # The CSS theme being used
 THEME = default


### PR DESCRIPTION
.... Should be on the folder.

http://code.jquery.com/mobile/1.0rc3/jquery.mobile.min.js instead of
http://code.jquery.com/mobile/1.0rc3/jquery.mobile-1.0rc3.min.js
Excessive duplication.
