### PR TITLE
proposed fix #2646 - fixed footer flickers to the top when switching pages

### DIFF
--- a/css/structure/jquery.mobile.collapsible.css
+++ b/css/structure/jquery.mobile.collapsible.css
@@ -18,3 +18,6 @@
 
 .ui-collapsible-set { margin: .5em 0; }
 .ui-collapsible-set .ui-collapsible { margin: -1px 0 0; }
+.ui-collapsible-set-horizontal { position: relative; overflow: visible; min-height: 200px; }			
+.ui-collapsible-set-horizontal .ui-collapsible-heading { width: 100%; margin: 0;}
+.ui-collapsible-set-horizontal .ui-collapsible-content { position: absolute; left: 0; right: 0; margin: 0;}

--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -162,28 +162,28 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 								.find( ".ui-btn-inner" ).andSelf();
 							
 						if (!isCollapse) {
-							// straighten corners on open
-							set.each(function() {							
-								$(this).is( ".ui-corner-left") ? 
-									$(this).addClass("ui-corner-tl").removeClass("ui-corner-left") : 
-										$(this).is( ".ui-corner-right") ? 
-											$(this).addClass("ui-corner-tr").removeClass("ui-corner-right") :
-												$(this).return;
-				
+							// tabview - straighten corners on open
+							set.each(function() {		
+								if ( $(this).is( ".ui-corner-left") ) {
+									$(this).addClass("ui-corner-tl").removeClass("ui-corner-left")
+									} else if ( $(this).is( ".ui-corner-right") ) {
+										$(this).addClass("ui-corner-tr").removeClass("ui-corner-right")
+										}
+
 								})
 							
 						} else if ( $el.closest('.ui-collapsible-set').find( ".ui-collapsible" ).length == $el.closest('.ui-collapsible-set').find( ".ui-collapsible-collapsed" ).length ) {
-							// curve corners when all closed
+							// tabview - curve corners if all closed
 							set.each(function() {																					
-								$(this).hasClass("ui-corner-tl") ? 
-									$(this).removeClass("ui-corner-tl").addClass("ui-corner-left") : 
-										$(this).hasClass("ui-corner-tr") ? 
-											$(this).removeClass("ui-corner-tr").addClass("ui-corner-right") :
-												$(this).return;
-												});														
+								if ( $(this).hasClass("ui-corner-tl") ) {
+									$(this).removeClass("ui-corner-tl").addClass("ui-corner-left")
+									} else if ( $(this).hasClass("ui-corner-tr") ) {
+										$(this).removeClass("ui-corner-tr").addClass("ui-corner-right")									
+										} 
+			
+								});														
 							}						
 						}
-					collapsibleContent.trigger( "updatelayout" );
 				}
 			})
 			.trigger( o.collapsed ? "collapse" : "expand" );

--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -296,7 +296,8 @@ $.mobile.fixedToolbars = (function() {
 				// Add state class
 				el.addClass( "ui-fixed-inline" ).removeClass( "ui-fixed-overlay" );
 
-				if ( thisCSStop < 0 || ( el.is( ".ui-header-fixed" ) && thisCSStop !== 0 ) ) {
+				if ( thisCSStop < 0 || ( el.is( ".ui-header-fixed" ) || 
+    					( el.is( ".ui-footer-fixed" ) && immediately != true )  ) && thisCSStop !== 0 ) ) {
 
 					if ( immediately ) {
 						el.css( "top", 0);
@@ -307,7 +308,8 @@ $.mobile.fixedToolbars = (function() {
 							classes = "out reverse";
 
 							el.animationComplete(function() {
-								el.removeClass( classes ).css( "top", 0 );
+								el.removeClass( classes ).css( "top", 
+									( el.is(".ui-footer-fixed") && thisCSStop > 0 ) ? -thisCSStop : 0 );
 							}).addClass( classes );
 						}
 					}


### PR DESCRIPTION
also see my comment in #2646.

The problem should be with _thisCSStop_

Two scenarios:
(a) document size = 2000px, screenHeight is 500px 
thisCSStop/fix-footer position will more or less equate to -(2000px-500px) = **-1500px**.
So to show the footer it's pulled up from css.top=0 to top=-1500px, and **to hide it's pushed down to top=0**

(b) document size is 100px, screenHeight is 500px
thisCSStop/fix-footer position will be -(100px-500px) = **+400px**.
The problem is on **hiding**, because **pushing down to top=0 in fact kicks the footer up to the end of the document**. On the second run of hide() it then works correclty. There's the jumping.

To fix this I include _thisCSStop > 0 && immediately != true_ in the if-clause. Otherwise the fixed-footer with top>0 will not pass. To hide the footer you can only make it jump even higher and kick it out of view on top by setting top=-thisCSStop. Awkward... but should work. Looks fine on iPad and desktop.
