### PR TITLE
Update docs/pages/multipage-template.html

### DIFF
--- a/docs/pages/multipage-template.html
+++ b/docs/pages/multipage-template.html
@@ -14,13 +14,13 @@
 <body> 
 
 <!-- Start of first page: #one -->
-<div data-role="page" id="foo">
+<div data-role="page" id="one">
 
 	<div data-role="header">
 		<h1>Multi-page</h1>
 	</div><!-- /header -->
 
-	<div data-role="content" id="one">	
+	<div data-role="content" >	
 		<h2>One</h2>
 		
 		<p>I have an id of "one" on my page container. I'm first in the source order so I'm shown when the page loads.</p>	


### PR DESCRIPTION
id="one" was on content, not page, so links to it were not working
