### PR TITLE
fixing two other issues at docs/pages/pages-themes/theme-a and theme-e

### DIFF
--- a/docs/pages/pages-themes/theme-a.html
+++ b/docs/pages/pages-themes/theme-a.html
@@ -143,7 +143,7 @@
 							<li><a href="../page-navmodel.html">Ajax, hashes &amp; history</a></li>
 							<li><a href="../page-dynamic.html">Dynamically Injecting Pages</a></li>
 							<li><a href="../page-scripting.html">Scripting pages</a></li>
-							<li data-theme="a"><a href="../pages-themes.html">Theming pages</a></li>
+							<li data-theme="b"><a href="../pages-themes.html">Theming pages</a></li>
 						</ul>
 					</div>
 				</div>	

--- a/docs/pages/pages-themes/theme-e.html
+++ b/docs/pages/pages-themes/theme-e.html
@@ -131,7 +131,7 @@
 
 						<h3>More in this section</h3>
 
-							<ul data-role="listview" data-theme="a" data-dividertheme="a">
+							<ul data-role="listview" data-theme="e" data-dividertheme="e">
 								<li data-role="list-divider">Pages &amp; Dialogs</li>
 								<li><a href="../../page-anatomy.html">Anatomy of a page</a></li>
 								<li><a href="../../page-template.html" data-ajax="false">Single page template</a></li>


### PR DESCRIPTION
theme-a page had no visible active button in the left-menu
theme-e page now gets the e-swatch at the menu for consistency
