### PR TITLE
Fix for #3062: Disabled select menu doesn't look disabled

### DIFF
--- a/css/structure/jquery.mobile.forms.select.css
+++ b/css/structure/jquery.mobile.forms.select.css
@@ -38,3 +38,6 @@ label.ui-select { font-size: 16px; line-height: 1.4;  font-weight: normal; margi
 
 /* when no placeholder is defined in a multiple select, the header height doesn't even extend past the close button.  this shim's content in there */
 .ui-selectmenu .ui-header h1:after { content: '.'; visibility: hidden; }
+
+/* showing icons in disbled selects also like  disabled */
+.ui-select > .ui-disabled * .ui-icon { opacity:  .3; }


### PR DESCRIPTION
#3062: The icon of a disabled select didn't get opacity to look like disabled
