### PR TITLE
Issue #3081: Range inputs on dialogs don't degrade

### DIFF
--- a/js/jquery.mobile.degradeInputs.js
+++ b/js/jquery.mobile.degradeInputs.js
@@ -24,7 +24,7 @@ $.mobile.page.prototype.options.degradeInputs = {
 //auto self-init widgets
 $( document ).bind( "pagecreate create", function( e ){
 
-	var page = $(e.target).closest(':jqmData(role="page")').data("page"), options;
+	var page = $(e.target).closest(':jqmData(role="page"),:jqmData(role="dialog")').data("page"), options;
 
 	if( !page ) {
 		return;

--- a/tests/unit/degradeInputs/degradeInputs.js
+++ b/tests/unit/degradeInputs/degradeInputs.js
@@ -14,15 +14,23 @@
         var degradeInputs = $.mobile.page.prototype.options.degradeInputs;
     
         expect( degradeInputs.length );
-    
+ 
+        // Initialize dialog page
+        $.mobile.changePage($('#dialog'));
+        $.mobile.changePage($('#page'));
+
         $.each(degradeInputs, function( oldType, newType ) {
             if (newType === false) {
                 newType = oldType;
             }
             
-            $('#test-container').html('<input type="' + oldType + '" />').trigger("create");
+            $('#page-test-container').html('<input type="' + oldType + '" />').trigger("create");
             
-            same($('#test-container input').attr("type"), newType);
+            same($('#page-test-container input').attr("type"), newType);
+
+            $('#dialog-test-container').html('<input type="' + oldType + '" />').trigger("create");
+
+            same($('#dialog-test-container input').attr("type"), newType);
         });
     });
 	

--- a/tests/unit/degradeInputs/index.html
+++ b/tests/unit/degradeInputs/index.html
@@ -25,11 +25,18 @@
 <ol id="qunit-tests">
 </ol>
 
-<div id="foo"  data-nstest-role="page">
+<div id="page" data-nstest-role="page">
 	
 	<input id="not-to-be-degraded" type="range" data-nstest-role="nojs" />
 	
-	<div id="test-container">
+	<div id="page-test-container">
+	</div>
+	
+</div>
+
+<div id="dialog" data-nstest-role="dialog">
+	
+	<div id="dialog-test-container">
 	</div>
 	
 </div>


### PR DESCRIPTION
The degradeInputs plugin bails early for pages that do not have data-role="page". This behavior prevents range inputs (for slider widgets) from degrading properly when used in dialogs.

The attached commit enables input degradation for dialog pages and updates the degradeInputs unit tests to check dialogs, too.
