### PR TITLE
Change config test for jQuery Core version to always use latest

### DIFF
--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -75,8 +75,8 @@
 				</a>
 			</li>
 			<li>
-				<a href="jq17b1.html" data-ajax="false">
-				<h3>jQuery core version 1.7 Beta 1</h3>
+				<a href="jqCoreLatest.html" data-ajax="false">
+				<h3>jQuery core latest version</h3>
 				<p>Test the docs with the latest jQuery core version</p>
 				</a>
 			</li>

--- a/docs/config/jqCoreLatest.html
+++ b/docs/config/jqCoreLatest.html
@@ -6,7 +6,7 @@
 	<title>jQuery Mobile Docs - Configuration</title> 
 	<link rel="stylesheet"  href="../../css/themes/default/" />  
 	<link rel="stylesheet" href="../_assets/css/jqm-docs.css"/>
-	<script src="http://code.jquery.com/jquery-1.7b1.js"></script>
+	<script src="http://code.jquery.com/jquery.js"></script>
 	<script src="../../experiments/themeswitcher/jquery.mobile.themeswitcher.js"></script>
 	<script src="../_assets/js/jqm-docs.js"></script>
 	<script src="../../js/"></script>
@@ -22,7 +22,7 @@
 
 	<div data-role="content">
 		
-		<h2>jQuery core version 1.7 Beta 1</h2>
+		<h2>jQuery core latest version</h2>
 		<p>To test, hit the button below and browse the docs. Note that if a link causes a refresh, this setting will be lost and the default settings will be seen.</p>
 		<a href="../../index.html" data-role="button" data-icon="arrow-r" data-iconpos="right">Browse docs</a>
 


### PR DESCRIPTION
This will allow users to easily browse the docs using the latest version of jQuery Core.  Removes the test for using a specific version, 1.7b1.
