### PR TITLE
Apparently IE8 does not allow nested DOM objects within a <INPUT>.

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -90,7 +90,11 @@ $.fn.buttonMarkup = function( options ) {
 			buttonText.appendChild( e.firstChild );
 		}
 
-		e.appendChild( buttonInner );
+    // XXX It seems like IE8 doesn't allow placing DOM elements within
+    // inputs; which may not be a bad thing.
+    if (!( el.length == 1 && el[0].tagName == 'INPUT' )) {
+  		e.appendChild( buttonInner );
+    }
 
 		// TODO obviously it would be nice to pull this element out instead of
 		// retrieving it from the DOM again, but this change is much less obtrusive


### PR DESCRIPTION
I don't know the entire consequences for this, or if there is a more elegant solution, but it works-for-me in the situation we have.  

IE8 kept throwing an exception when trying to append children DOM objects within an input element, which other browsers, including IE9, seemed to allow.  I'm not sure if the W3C recommendations allow for children of input...
