### PR TITLE
Listview-Filter Placeholder - Allow override

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -48,6 +48,9 @@
 		// Error response message - appears when an Ajax page request fails
 		pageLoadErrorMessage: "Error Loading Page",
 
+		// Placeholder for listview filter
+		filterPlaceholder: "Filter items...",
+
 		//automatically initialize the DOM when it's ready
 		autoInitializePage: true,
 

--- a/js/jquery.mobile.listview.filter.js
+++ b/js/jquery.mobile.listview.filter.js
@@ -5,7 +5,6 @@
 (function( $, undefined ) {
 
 $.mobile.listview.prototype.options.filter = false;
-$.mobile.listview.prototype.options.filterPlaceholder = "Filter items...";
 $.mobile.listview.prototype.options.filterTheme = "c";
 $.mobile.listview.prototype.options.filterCallback = function( text, searchValue ){
 	return text.toLowerCase().indexOf( searchValue ) === -1;
@@ -25,7 +24,7 @@ $( document ).delegate( ":jqmData(role='listview')", "listviewcreate", function(
 			"role": "search"
 		}),
 		search = $( "<input>", {
-			placeholder: listview.options.filterPlaceholder
+			placeholder: $.mobile.filterPlaceholder
 		})
 		.attr( "data-" + $.mobile.ns + "type", "search" )
 		.jqmData( "lastval", "" )


### PR DESCRIPTION
Using $.mobile.filterPlaceholder instead of local $.mobile.listview.prototype.options.filterPlaceholder
