### PR TITLE
fix css in touch-overflow example

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -29,6 +29,8 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 .ui-mobile-touch-overflow.ui-native-fixed .ui-content {
 	overflow: auto;
 	height: 100%;
+	left: 0;
+	right: 0;
 	-webkit-overflow-scrolling: touch;
 	-moz-overflow-scrolling: touch;
 	-o-overflow-scrolling: touch;


### PR DESCRIPTION
Hi

This fixes a bug with lists not beeing fit into the viewport width anymore when using touchOverflowEnabled on iOS5.

With 1.0 it looks like this:
http://mazdermind.de/temp/jqmobile/touch-overflow/with-1.0.html
http://mazdermind.de/temp/jqmobile/touch-overflow/with-1.0.png (iPhone 4s)

With this pull it looks like this:
http://mazdermind.de/temp/jqmobile/touch-overflow/with-fix.html
http://mazdermind.de/temp/jqmobile/touch-overflow/with-fix.png (iPhone 4s)

Possibly this fixes #2744, too.

Regards, 
Peter
