### PR TITLE
Dont output errors to js file, increase cache size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,13 @@ js: init
 	@@cat ${JSFILES} >> ${OUTPUT}/${NAME}.js
 	# ..... and then minify it
 	@@echo ${VER_MIN} > ${OUTPUT}/${NAME}.min.js
-	@@java -jar build/google-compiler-20111003.jar --js ${OUTPUT}/${NAME}.js --warning_level QUIET >> ${OUTPUT}/${NAME}.min.js
+	@@java -XX:ReservedCodeCacheSize=64m \
+				-jar build/google-compiler-20111003.jar \
+				--js ${OUTPUT}/${NAME}.js \
+				--warning_level QUIET \
+				--js_output_file ${OUTPUT}/${NAME}.tmp.js
+	@@cat ${OUTPUT}/${NAME}.tmp.js >> ${OUTPUT}/${NAME}.min.js
+	@@rm ${OUTPUT}/${NAME}.tmp.js
 	# -------------------------------------------------
 
 

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ js: init
 	@@java -XX:ReservedCodeCacheSize=64m \
 				-jar build/google-compiler-20111003.jar \
 				--js ${OUTPUT}/${NAME}.js \
-				--warning_level QUIET \
 				--js_output_file ${OUTPUT}/${NAME}.tmp.js
 	@@cat ${OUTPUT}/${NAME}.tmp.js >> ${OUTPUT}/${NAME}.min.js
 	@@rm ${OUTPUT}/${NAME}.tmp.js


### PR DESCRIPTION
Increase the cache size slightly to hopefully get rid of the java cache errors.
Make compiler output to a temp file so the output isnt streamed directly to the min file
Cat the tmp file to the min file
Remove the tmp file
