### PR TITLE
Update docs/_assets/css/jqm-docs.css

### DIFF
--- a/docs/_assets/css/jqm-docs.css
+++ b/docs/_assets/css/jqm-docs.css
@@ -14,6 +14,7 @@ body { background: #dddddd; }
 
 h2 { margin:1.2em 0 .4em 0; }
 p code { font-size:1.2em; font-weight:bold; } 
+h4 code {font-size:1.2em; font-weight:bold; }
 
 dt { font-weight: bold; margin: 2em 0 .5em; }
 dt code, dd code { font-size:1.3em; line-height:150%; }


### PR DESCRIPTION
added code text height for h4 so that code in h4 (used as title for warning divs) gets displayed with the correct font size (currently much smaller)
