### PR TITLE
Fix touch overflow with lists

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -49,7 +49,7 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 	margin-top: 0;
 }
 .ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview-inset {
-	margin-top: 2em;
+	margin-top: 1em;
 }
 
 /* loading screen */

--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -49,8 +49,7 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 	margin-top: 0;
 }
 .ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview-inset {
-	margin-top: 1em;
-	margin-bottom: 0;
+	margin-top: 2em;
 }
 
 /* loading screen */

--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -45,6 +45,13 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 .ui-page.ui-mobile-pre-transition {
 	display: block;
 }
+.ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview {
+	margin-top: 0;
+}
+.ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview-inset {
+	margin-top: 1em;
+	margin-bottom: 0;
+}
 
 /* loading screen */
 .ui-loading .ui-mobile-viewport { overflow: hidden !important; }


### PR DESCRIPTION
fix not-inset-list top position, while keeping inset-lists as they are in touchOverflow mode:

without fix:
http://mazdermind.de/temp/jqmobile/touch-overflow-top/without-fix.html
http://mazdermind.de/temp/jqmobile/touch-overflow-top/without-fix.png (iPhone 4s)

http://mazdermind.de/temp/jqmobile/touch-overflow-top/without-fix-inset.html
http://mazdermind.de/temp/jqmobile/touch-overflow-top/without-fix-inset.png (iPhone 4s)

with fix:
http://mazdermind.de/temp/jqmobile/touch-overflow-top/with-fix.html
http://mazdermind.de/temp/jqmobile/touch-overflow-top/with-fix.png (iPhone 4s)

http://mazdermind.de/temp/jqmobile/touch-overflow-top/with-fix-inset.html
http://mazdermind.de/temp/jqmobile/touch-overflow-top/with-fix-inset.png (iPhone 4s)

all lists are scrolled to to the top.

explanation:
In normal mode ui-content has 15px padding. the none-inset ui-listview has a margin of -15px to overcome this. in touchOverflow mode the padding on the ui-content doesn't apply, so the negative margin on the ui-listview moves it 15px too far up. the first three line of this patch resets this margin to 0 and fixes this issue.

ui-listview-inset overrides the default margin of -15px with a new value of 1em, which makes up the inset view. the lines from above would override this to 0, placing the inset list at the top. The next 3 lines of the patch reenables this margin of 1em.
