### PR TITLE
Fix headers and footers with CSS instead of JavaScript

### DIFF
--- a/js/jquery.mobile.fixHeaderFooter.js
+++ b/js/jquery.mobile.fixHeaderFooter.js
@@ -7,7 +7,9 @@
 
 (function( $, undefined ) {
 
-var slideDownClass = "ui-header-fixed ui-fixed-inline fade",
+var testFixed = true,
+
+	slideDownClass = "ui-header-fixed ui-fixed-inline fade",
 	slideUpClass = "ui-footer-fixed ui-fixed-inline fade",
 
 	slideDownSelector = ".ui-header:jqmData(position='fixed')",
@@ -37,7 +39,7 @@ $.fn.fixHeaderFooter = function( options ) {
 // single controller for all showing,hiding,toggling
 $.mobile.fixedToolbars = (function() {
 
-	if ( !$.support.scrollTop ) {
+	if ( !$.support.scrollTop || testFixed ) {
 		return;
 	}
 

--- a/themes/default/jquery.mobile.headerfooter.css
+++ b/themes/default/jquery.mobile.headerfooter.css
@@ -5,9 +5,7 @@
 */
 /* fixed page header & footer configuration */
 .ui-header, .ui-footer, .ui-page-fullscreen .ui-header, .ui-page-fullscreen .ui-footer  { position: absolute;  overflow: hidden; width: 100%; border-left-width: 0; border-right-width: 0; }
-.ui-header-fixed, .ui-footer-fixed {
-	z-index: 1000;
-	-webkit-transform: translateZ(0); /* Force header/footer rendering to go through the same rendering pipeline as native page scrolling. */
-}
+.ui-page .ui-header-fixed { top: 0px; position: fixed; }
+.ui-page .ui-footer-fixed { bottom: 0px; position: fixed; }
 .ui-footer-duplicate, .ui-page-fullscreen .ui-fixed-inline { display: none; }
 .ui-page-fullscreen .ui-header, .ui-page-fullscreen .ui-footer { opacity: .9; }


### PR DESCRIPTION
The JS is all still there, but should be switched off.
