### PR TITLE
Use 'reverse' option name (instead of old 'direction') in calls to changePage()

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -396,6 +396,13 @@
 		}
 	}
 
+	function hasReverseDirection( $element ) {
+		var direction = $element.jqmData( "direction" ),
+			reverse = ( direction && direction === "reverse" );
+
+		return reverse;
+	}
+
 	// Save the last scroll distance per page, before it is hidden
 	var setLastScrollEnabled = true,
 		firstScrollElem, getScrollElem, setLastScroll, delayedSetLastScroll;
@@ -1267,7 +1274,7 @@
 					type:		type && type.length && type.toLowerCase() || "get",
 					data:		$this.serialize(),
 					transition:	$this.jqmData( "transition" ),
-					direction:	$this.jqmData( "direction" ),
+					reverse:	hasReverseDirection( $this ),
 					reloadPage:	true
 				}
 			);
@@ -1380,8 +1387,7 @@
 
 			//use ajax
 			var transition = $link.jqmData( "transition" ),
-				direction = $link.jqmData( "direction" ),
-				reverse = ( direction && direction === "reverse" ) ||
+				reverse = hasReverseDirection( $link ) ||
 							// deprecated - remove by 1.0
 							$link.jqmData( "back" ),
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -396,13 +396,6 @@
 		}
 	}
 
-	function hasReverseDirection( $element ) {
-		var direction = $element.jqmData( "direction" ),
-			reverse = ( direction && direction === "reverse" );
-
-		return reverse;
-	}
-
 	// Save the last scroll distance per page, before it is hidden
 	var setLastScrollEnabled = true,
 		firstScrollElem, getScrollElem, setLastScroll, delayedSetLastScroll;
@@ -1274,7 +1267,7 @@
 					type:		type && type.length && type.toLowerCase() || "get",
 					data:		$this.serialize(),
 					transition:	$this.jqmData( "transition" ),
-					reverse:	hasReverseDirection( $this ),
+					reverse:	$this.jqmData( "direction" ) === "reverse",
 					reloadPage:	true
 				}
 			);
@@ -1387,7 +1380,7 @@
 
 			//use ajax
 			var transition = $link.jqmData( "transition" ),
-				reverse = hasReverseDirection( $link ) ||
+				reverse = $link.jqmData( "direction" ) === "reverse" ||
 							// deprecated - remove by 1.0
 							$link.jqmData( "back" ),
 


### PR DESCRIPTION
`$.mobile._registerInternalEvents()` used old option name in call to `changePage()`. This prevented making forms with reverse direction transitions.
