### PR TITLE
Fix non reacting generated back buttons with touchOverflowEnabled

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -51,6 +51,9 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 .ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview-inset {
 	margin-top: 1em;
 }
+.ui-mobile-touch-overflow.ui-native-fixed .ui-header .ui-btn { 
+	z-index: 10;
+}
 
 /* loading screen */
 .ui-loading .ui-mobile-viewport { overflow: hidden !important; }


### PR DESCRIPTION
Seems that generated back buttons don't react when you click on them. I changed the z-index of .ui-btn when touchoverflow is on and it works now.

`.ui-mobile-touch-overflow.ui-native-fixed .ui-header .ui-btn { 
z-index: 10;
}`
