### PR TITLE
dynamically built control groups dont have formatting

### DIFF
--- a/js/jquery.mobile.controlGroup.js
+++ b/js/jquery.mobile.controlGroup.js
@@ -38,6 +38,8 @@ $.fn.controlgroup = function( options ) {
 
 		flipClasses( $el.find( ".ui-btn" + ( o.excludeInvisible ? ":visible" : "" ) ) );
 		flipClasses( $el.find( ".ui-btn-inner" ) );
+		flipClasses( $el.find( "a" ) );
+		flipClasses( $el.find( "input" ) );
 
 		if ( o.shadow ) {
 			$el.addClass( "ui-shadow" );


### PR DESCRIPTION
if dynamically building a control group, ensures children A + input elements get properly formatted.
