### PR TITLE
Fix Issue #2084 option to not-include dialog close icon

### DIFF
--- a/docs/api/data-attributes.html
+++ b/docs/api/data-attributes.html
@@ -141,6 +141,14 @@
 					<th>data-title</th>
 					<td>string (title used when page is shown)</td>
 				</tr>
+				<tr>
+					<th>data-include-close-btn</th>
+					<td><strong>true</strong> | false</td>
+				</tr>
+				<tr>
+					<th>data-iconpos</th>
+					<td>left | right | top | bottom |  <strong>notext</strong> | none</td>
+				</tr>
 			</table>
 
 			<h2><a href="../pages/page-anatomy.html">Content</a></h2>

--- a/docs/pages/page-dialogs.html
+++ b/docs/pages/page-dialogs.html
@@ -52,10 +52,21 @@
 			<h2>Closing dialogs</h2>
 			<p>When any link is clicked within in a dialog, the framework will automatically close the dialog and transition to the requested page, just as if the dialog were a normal page. To create a "cancel" button in a dialog, just link to the page that triggered the dialog to open and add the <code>data-rel="back"</code> attribute to your link. This pattern of linking to the previous page is also usable in non-JS devices as well.</p>
 			<p>For JavaScript-generated links, you can simply set the href attribute to "#" and use the <code>data-rel="back"</code> attribute. You can also call the dialog's <code>close()</code> method to programmatically close dialogs, for example: <code>$('.ui-dialog').dialog('close')</code>. </p>
-			
-			<h3>Setting the close button text</h3>
-			<p>Just like the page plugin, you can set a dialog's close button text through an option or data attribute. The option can be configured for all dialogs by binding to the <code>mobileinit</code> event and setting the <code>$.mobile.dialog.prototype.options.closeBtnText</code> property to a string of your choosing, or you can place the data attribute <code>data-close-btn-text</code> to configure the text from your markup.</p>
-			
+
+			<h3>The close button</h3>
+			<p>By default dialogs are automatically given an icon only close button if the dialog has a header. Clicking this button triggers the dialogs close function and is identical to clicking the browsers back button.  If you prefer to not have the close button or prefer to create your own there is a data attribute <code>data-include-close-btn</code> that configures if the button should be automatically added.</p>
+
+<code>
+	&lt;div data-role="page" id="popup" data-include-close-btn="false"&gt;
+</code>
+
+			<h3>Setting the close button text and icon position</h3>
+			<p>Just like the page plugin, you can set a dialog's close button text through an option or data attribute. The option can be configured for all dialogs by binding to the <code>mobileinit</code> event and setting the <code>$.mobile.dialog.prototype.options.closeBtnText</code> property to a string of your choosing, or you can place the data attribute <code>data-close-btn-text</code> to configure the text from your markup. Additionally you can configure the icon position using the <code>data-iconpos</code> attribute. By default the iconpos attribute is set to "notext" and the button text will not be visible. Setting the iconpos to "none" will create a text only button.</p>
+
+<code>
+	&lt;div data-role="page" id="popup" data-iconpos="left" data-close-btn-text="Nevermind"&gt;
+</code>
+
 			<h2>History &amp; Back button behavior</h2>
 			<p>Since dialogs are typically used to support actions within a page, the framework does not include dialogs in the hash state history tracking. This means that dialogs will not appear in your browsing history chronology when the Back button is clicked. For example, if you are on a page, click a link to open a dialog, close the dialog, then navigate to another page, if you were to click the browser's Back button at that point you will navigate back to the first page, not the dialog.</p>
 			

--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -9,11 +9,13 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 		closeBtnText 	: "Close",
 		overlayTheme	: "a",
 		initSelector	: ":jqmData(role='dialog')"
+		iconpos		: "notext",
+		includeCloseBtn	: true
 	},
 	_create: function() {
 		var self = this,
 			$el = this.element,
-			headerCloseButton = $( "<a href='#' data-" + $.mobile.ns + "icon='delete' data-" + $.mobile.ns + "iconpos='notext'>"+ this.options.closeBtnText + "</a>" );
+			headerCloseButton = $( "<a href='#' data-" + $.mobile.ns + "icon='delete' data-" + $.mobile.ns + "iconpos=" + this.options.iconpos + ">"+ this.options.closeBtnText + "</a>" );
 
 		$el.addClass( "ui-overlay-" + this.options.overlayTheme );
 
@@ -23,7 +25,7 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 			.addClass( "ui-dialog" )
 			.find( ":jqmData(role='header')" )
 			.addClass( "ui-corner-top ui-overlay-shadow" )
-				.prepend( headerCloseButton )
+				.prepend( this.options.includeCloseBtn ? headerCloseButton : "" )
 			.end()
 			.find( ":jqmData(role='content'),:jqmData(role='footer')" )
 				.addClass( "ui-overlay-shadow" )


### PR DESCRIPTION
Two issues here. First is issue #2084 Dialog close icon is always added even if not desired.  Two, some how this slipped through over time- there is an option "close btn txt" but the text is never shown since the iconpos is hardcoded to "notext"!

Solution:
Add two new options:
1) iconpos for close button- defaults to notext.
2) includeCloseBtn- defaults to true.

Reasons why a person would not want the close icon button can vary, but window.hisory.back() is now always wanted.  Now users can do whatever they want there, no button, button on the right, button with different icon, and attach whatever event handling they want to it.
