### PR TITLE
fix position of searchbar in touchOverflow mode

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -51,6 +51,13 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 .ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview-inset {
 	margin-top: 1em;
 }
+.ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview-filter {
+	margin-top: .2em;
+	margin-bottom: 0;
+}
+.ui-mobile-touch-overflow.ui-native-fixed .ui-content .ui-listview-filter-inset {
+	margin-bottom: -.9em;
+}
 .ui-mobile-touch-overflow.ui-native-fixed .ui-header .ui-btn { 
 	z-index: 10;
 }


### PR DESCRIPTION
The problem was mentioned by @JFK99 in #3178:

without fix:
http://mazdermind.de/temp/jqmobile/touch-overflow-search/without-fix.html
http://mazdermind.de/temp/jqmobile/touch-overflow-search/without-fix.png (iPhone 4s)

http://mazdermind.de/temp/jqmobile/touch-overflow-search/without-fix-inset.html
http://mazdermind.de/temp/jqmobile/touch-overflow-search/without-fix-inset.png (iPhone 4s)

with fix:
http://mazdermind.de/temp/jqmobile/touch-overflow-search/with-fix.html
http://mazdermind.de/temp/jqmobile/touch-overflow-search/with-fix.png (iPhone 4s)

http://mazdermind.de/temp/jqmobile/touch-overflow-search/with-fix-inset.html
http://mazdermind.de/temp/jqmobile/touch-overflow-search/with-fix-inset.png (iPhone 4s)
