### PR TITLE
data-prefetch=false

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1398,8 +1398,8 @@
 
 		//prefetch pages when anchors with data-prefetch are encountered
 		$( document ).delegate( ".ui-page", "pageshow.prefetch", function() {
-			var urls = [];
-			$( this ).find( "a:jqmData(prefetch)" ).each(function(){
+			var urls = [];   
+			$( this ).find( "a:jqmData(prefetch):not(:jqmData(prefetch=false))" ).each(function(){
 				var $link = $(this),
 					url = $link.attr( "href" );
 


### PR DESCRIPTION
re: feature request https://github.com/jquery/jquery-mobile/issues/3263 (mine)

pages with data-prefetch=false will no longer be preloaded.

I also went through the source and looked for other instances of elements being selected by virtue of having an attribute, no matter the value.  I don't think I know enough to say whether they too should be updated for consistency, so I'll just list them here:

```
In widget#_create:  iconpos = $navbtns.filter( ":jqmData(icon)" ).length ? this.options.iconpos : undefined;

// In listview creation: 
    if ( $( this ).jqmData( "inset" ) ) {
        wrapper.addClass( "ui-listview-filter-inset" );
    }

//And in adding dialogs: 
    // unless the data url is already set set it to the pathname
    if ( !$this.jqmData("url") ) {
        $this.attr( "data-" + $.mobile.ns + "url", $this.attr( "id" ) || location.pathname + location.search );
```

Coincidentally, in childPages:

```
return $( ":jqmData(url^='"+  parentUrl + "&" + $.mobile.subPageUrlKey +"')");
```

I couldn't figure out what ^= is does-- certainly not !=.  Is this a bug?

Cheers
