### PR TITLE
Fix for issue with #2214

### DIFF
--- a/css/structure/jquery.mobile.forms.slider.css
+++ b/css/structure/jquery.mobile.forms.slider.css
@@ -4,7 +4,7 @@ input.ui-slider-input,
 select.ui-slider-switch { display: none; }
 div.ui-slider { position: relative; display: inline-block; overflow: visible; height: 15px; padding: 0; margin: 0 2% 0 20px; top: 4px; width: 60%; }
 div.ui-slider-switch { width: 99.8%; }
-a.ui-slider-handle { position: absolute; z-index: 10;  top: 50%; width: 28px; height: 28px; margin-top: -15px; margin-left: -15px; }
+a.ui-slider-handle { position: absolute; z-index: 10;  top: 50%; width: 28px; height: 28px; margin-top: -15px; margin-left: -15px; outline: 0; }
 a.ui-slider-handle .ui-btn-inner { padding-left: 0; padding-right: 0; }
 @media all and (min-width: 480px){
 	.ui-field-contain label.ui-slider { vertical-align: top;  display: inline-block;  width: 20%;  margin: 0 2% 0 0; }

--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -1,5 +1,5 @@
 label.ui-input-text { font-size: 16px; line-height: 1.4; display: block; font-weight: normal; margin: 0 0 .3em; }
-input.ui-input-text, textarea.ui-input-text { background-image: none; padding: .4em; line-height: 1.4; font-size: 16px; display: block; width: 97%; }
+input.ui-input-text, textarea.ui-input-text { background-image: none; padding: .4em; line-height: 1.4; font-size: 16px; display: block; width: 97%; outline: 0; }
 input.ui-input-text { -webkit-appearance: none; }
 textarea.ui-input-text { height: 50px; -webkit-transition: height 200ms linear; -moz-transition: height 200ms linear; -o-transition: height 200ms linear; transition: height 200ms linear; }
 .ui-input-search { padding: 0 30px; background-image: none; position: relative; }

--- a/css/themes/default/jquery.mobile.theme.css
+++ b/css/themes/default/jquery.mobile.theme.css
@@ -1109,7 +1109,7 @@ a.ui-link-inherit {
 	box-shadow: 0px 1px 0 					rgba(255,255,255,.4);
 }
 
-/* Focus state - set here for specificity
+/* Focus state - set here for specificity (note: these classes are added by JavaScript)
 -----------------------------------------------------------------------------------------------------------*/
 
 .ui-btn:focus {
@@ -1135,5 +1135,6 @@ a.ui-link-inherit {
 /* ...and bring back focus */
 .ui-mobile-nosupport-boxshadow .ui-focus,
 .ui-mobile-nosupport-boxshadow .ui-btn:focus {
-	outline-width: 2px;
+	outline-width: 1px;
+	outline-style: dotted;
 }

--- a/css/themes/default/jquery.mobile.theme.css
+++ b/css/themes/default/jquery.mobile.theme.css
@@ -1112,7 +1112,12 @@ a.ui-link-inherit {
 /* Focus state - set here for specificity
 -----------------------------------------------------------------------------------------------------------*/
 
-.ui-focus {
+.ui-btn:focus {
+	outline: 0;
+}
+
+.ui-focus,
+.ui-btn:focus {
 	-moz-box-shadow: 0px 0px 12px 		#387bbe /*{global-active-background-color}*/;
 	-webkit-box-shadow: 0px 0px 12px 	#387bbe /*{global-active-background-color}*/;
 	box-shadow: 0px 0px 12px 			#387bbe /*{global-active-background-color}*/;
@@ -1128,6 +1133,7 @@ a.ui-link-inherit {
 }
 
 /* ...and bring back focus */
-.ui-mobile-nosupport-boxshadow .ui-focus {
+.ui-mobile-nosupport-boxshadow .ui-focus,
+.ui-mobile-nosupport-boxshadow .ui-btn:focus {
 	outline-width: 2px;
 }

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -23,6 +23,9 @@
 		// Class used for "active" button state, from CSS framework
 		activeBtnClass: "ui-btn-active",
 
+        // Class used for "focus" form element state, from CSS framework
+        focusClass: "ui-focus",
+
 		// Automatically handle clicks and form submissions through Ajax, when same-domain
 		ajaxEnabled: true,
 

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -1,4 +1,4 @@
-/* 
+/*
 * "core" - The base file for jQm
 */
 
@@ -23,8 +23,8 @@
 		// Class used for "active" button state, from CSS framework
 		activeBtnClass: "ui-btn-active",
 
-        // Class used for "focus" form element state, from CSS framework
-        focusClass: "ui-focus",
+		// Class used for "focus" form element state, from CSS framework
+		focusClass: "ui-focus",
 
 		// Automatically handle clicks and form submissions through Ajax, when same-domain
 		ajaxEnabled: true,
@@ -155,7 +155,7 @@
 				}
 				e = e.parentNode;
 			}
-			
+
 			// Return the theme letter we found, if none, return the
 			// specified default.
 

--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -17,6 +17,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 	},
 	_create: function() {
 		var $el = this.element,
+            $button,
 			o = this.options,
 			type,
 			name,
@@ -37,6 +38,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 			})
 			.append( $el.addClass( "ui-btn-hidden" ) );
 
+        $button = this.button;
 		type = $el.attr( "type" );
 		name = $el.attr( "name" );
 
@@ -62,6 +64,16 @@ $.widget( "mobile.button", $.mobile.widget, {
 					}
 				});
 		}
+
+        $el.bind({
+            focus: function() {
+                $button.addClass( $.mobile.focusClass );
+            },
+
+            blur: function() {
+                $button.removeClass( $.mobile.focusClass );
+            }
+        });
 
 		this.refresh();
 	},

--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -112,11 +112,11 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				},
 
 				focus: function() {
-					label.addClass( "ui-focus" );
+					label.addClass( $.mobile.focusClass );
 				},
 
 				blur: function() {
-					label.removeClass( "ui-focus" );
+					label.removeClass( $.mobile.focusClass );
 				}
 			});
 

--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -126,6 +126,12 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 				// Add active class to button
 				self.button.addClass( $.mobile.activeBtnClass );
 			})
+            .bind( "focus", function() {
+                self.button.addClass( $.mobile.focusClass );
+            })
+            .bind( "blur", function() {
+                self.button.removeClass( $.mobile.focusClass );
+            })
 			.bind( "focus vmouseover", function() {
 				self.button.trigger( "vmouseover" );
 			})

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -185,11 +185,11 @@ $.widget( "mobile.slider", $.mobile.widget, {
 		if( cType == 'select' ) {
 			this.handle.bind({
 				focus: function() {
-					( $.support.boxShadow ? slider : $( this ) ).addClass( $.mobile.focusClass );
+					slider.addClass( $.mobile.focusClass );
 				},
 
 				blur: function() {
-					( $.support.boxShadow ? slider : $( this ) ).removeClass( $.mobile.focusClass );
+					slider.removeClass( $.mobile.focusClass );
 				}
 			});
 		}

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -184,11 +184,11 @@ $.widget( "mobile.slider", $.mobile.widget, {
 		// NOTE force focus on handle
 		this.handle.bind({
 			focus: function() {
-				slider.addClass( $.mobile.focusClass );
+				( cType == 'select' ? slider : $( this ) ).addClass( $.mobile.focusClass );
 			},
 
 			blur: function() {
-				slider.removeClass( $.mobile.focusClass );
+				( cType == 'select' ? slider : $( this ) ).removeClass( $.mobile.focusClass );
 			},
 
 			vmousedown: function() {

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -181,16 +181,21 @@ $.widget( "mobile.slider", $.mobile.widget, {
 
 		slider.insertAfter( control );
 
-		// NOTE force focus on handle
+		// Only add focus class to toggle switch, sliders get it automatically from ui-btn
+		if( cType == 'select' ) {
+			this.handle.bind({
+				focus: function() {
+					( $.support.boxShadow ? slider : $( this ) ).addClass( $.mobile.focusClass );
+				},
+
+				blur: function() {
+					( $.support.boxShadow ? slider : $( this ) ).removeClass( $.mobile.focusClass );
+				}
+			});
+		}
+
 		this.handle.bind({
-			focus: function() {
-				( cType == 'select' ? slider : $( this ) ).addClass( $.mobile.focusClass );
-			},
-
-			blur: function() {
-				( cType == 'select' ? slider : $( this ) ).removeClass( $.mobile.focusClass );
-			},
-
+			// NOTE force focus on handle
 			vmousedown: function() {
 				$( this ).focus();
 			},

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -183,74 +183,74 @@ $.widget( "mobile.slider", $.mobile.widget, {
 
 		// NOTE force focus on handle
 		this.handle.bind({
-                focus: function() {
-                    slider.addClass( $.mobile.focusClass );
-                },
+			focus: function() {
+				slider.addClass( $.mobile.focusClass );
+			},
 
-                blur: function() {
-                    slider.removeClass( $.mobile.focusClass );
-                },
+			blur: function() {
+				slider.removeClass( $.mobile.focusClass );
+			},
 
-                vmousedown: function() {
-                    $( this ).focus();
-                },
+			vmousedown: function() {
+				$( this ).focus();
+			},
 
-                vclick: false,
+			vclick: false,
 
-                keydown: function( event ) {
-                    var index = val();
-    
-                    if ( self.options.disabled ) {
-                        return;
-                    }
-    
-                    // In all cases prevent the default and mark the handle as active
-                    switch ( event.keyCode ) {
-                     case $.mobile.keyCode.HOME:
-                     case $.mobile.keyCode.END:
-                     case $.mobile.keyCode.PAGE_UP:
-                     case $.mobile.keyCode.PAGE_DOWN:
-                     case $.mobile.keyCode.UP:
-                     case $.mobile.keyCode.RIGHT:
-                     case $.mobile.keyCode.DOWN:
-                     case $.mobile.keyCode.LEFT:
-                        event.preventDefault();
-    
-                        if ( !self._keySliding ) {
-                            self._keySliding = true;
-                            $( this ).addClass( "ui-state-active" );
-                        }
-                        break;
-                    }
-    
-                    // move the slider according to the keypress
-                    switch ( event.keyCode ) {
-                     case $.mobile.keyCode.HOME:
-                        self.refresh( min );
-                        break;
-                     case $.mobile.keyCode.END:
-                        self.refresh( max );
-                        break;
-                     case $.mobile.keyCode.PAGE_UP:
-                     case $.mobile.keyCode.UP:
-                     case $.mobile.keyCode.RIGHT:
-                        self.refresh( index + step );
-                        break;
-                     case $.mobile.keyCode.PAGE_DOWN:
-                     case $.mobile.keyCode.DOWN:
-                     case $.mobile.keyCode.LEFT:
-                        self.refresh( index - step );
-                        break;
-                    }
-                }, // remove active mark
+			keydown: function( event ) {
+				var index = val();
 
-                keyup: function( event ) {
-                    if ( self._keySliding ) {
-                        self._keySliding = false;
-                        $( this ).removeClass( "ui-state-active" );
-                    }
-                }
-            });
+				if ( self.options.disabled ) {
+					return;
+				}
+
+				// In all cases prevent the default and mark the handle as active
+				switch ( event.keyCode ) {
+					case $.mobile.keyCode.HOME:
+					case $.mobile.keyCode.END:
+					case $.mobile.keyCode.PAGE_UP:
+					case $.mobile.keyCode.PAGE_DOWN:
+					case $.mobile.keyCode.UP:
+					case $.mobile.keyCode.RIGHT:
+					case $.mobile.keyCode.DOWN:
+					case $.mobile.keyCode.LEFT:
+						event.preventDefault();
+
+						if ( !self._keySliding ) {
+							self._keySliding = true;
+							$( this ).addClass( "ui-state-active" );
+						}
+						break;
+				}
+
+				// move the slider according to the keypress
+				switch ( event.keyCode ) {
+					case $.mobile.keyCode.HOME:
+						self.refresh( min );
+						break;
+					case $.mobile.keyCode.END:
+						self.refresh( max );
+						break;
+					case $.mobile.keyCode.PAGE_UP:
+					case $.mobile.keyCode.UP:
+					case $.mobile.keyCode.RIGHT:
+						self.refresh( index + step );
+						break;
+					case $.mobile.keyCode.PAGE_DOWN:
+					case $.mobile.keyCode.DOWN:
+					case $.mobile.keyCode.LEFT:
+						self.refresh( index - step );
+						break;
+				}
+			}, // remove active mark
+
+			keyup: function( event ) {
+				if ( self._keySliding ) {
+					self._keySliding = false;
+					$( this ).removeClass( "ui-state-active" );
+				}
+			}
+			});
 
 		this.refresh(undefined, undefined, true);
 	},

--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -182,65 +182,75 @@ $.widget( "mobile.slider", $.mobile.widget, {
 		slider.insertAfter( control );
 
 		// NOTE force focus on handle
-		this.handle
-			.bind( "vmousedown", function() {
-				$( this ).focus();
-			})
-			.bind( "vclick", false );
+		this.handle.bind({
+                focus: function() {
+                    slider.addClass( $.mobile.focusClass );
+                },
 
-		this.handle
-			.bind( "keydown", function( event ) {
-				var index = val();
+                blur: function() {
+                    slider.removeClass( $.mobile.focusClass );
+                },
 
-				if ( self.options.disabled ) {
-					return;
-				}
+                vmousedown: function() {
+                    $( this ).focus();
+                },
 
-				// In all cases prevent the default and mark the handle as active
-				switch ( event.keyCode ) {
-				 case $.mobile.keyCode.HOME:
-				 case $.mobile.keyCode.END:
-				 case $.mobile.keyCode.PAGE_UP:
-				 case $.mobile.keyCode.PAGE_DOWN:
-				 case $.mobile.keyCode.UP:
-				 case $.mobile.keyCode.RIGHT:
-				 case $.mobile.keyCode.DOWN:
-				 case $.mobile.keyCode.LEFT:
-					event.preventDefault();
+                vclick: false,
 
-					if ( !self._keySliding ) {
-						self._keySliding = true;
-						$( this ).addClass( "ui-state-active" );
-					}
-					break;
-				}
+                keydown: function( event ) {
+                    var index = val();
+    
+                    if ( self.options.disabled ) {
+                        return;
+                    }
+    
+                    // In all cases prevent the default and mark the handle as active
+                    switch ( event.keyCode ) {
+                     case $.mobile.keyCode.HOME:
+                     case $.mobile.keyCode.END:
+                     case $.mobile.keyCode.PAGE_UP:
+                     case $.mobile.keyCode.PAGE_DOWN:
+                     case $.mobile.keyCode.UP:
+                     case $.mobile.keyCode.RIGHT:
+                     case $.mobile.keyCode.DOWN:
+                     case $.mobile.keyCode.LEFT:
+                        event.preventDefault();
+    
+                        if ( !self._keySliding ) {
+                            self._keySliding = true;
+                            $( this ).addClass( "ui-state-active" );
+                        }
+                        break;
+                    }
+    
+                    // move the slider according to the keypress
+                    switch ( event.keyCode ) {
+                     case $.mobile.keyCode.HOME:
+                        self.refresh( min );
+                        break;
+                     case $.mobile.keyCode.END:
+                        self.refresh( max );
+                        break;
+                     case $.mobile.keyCode.PAGE_UP:
+                     case $.mobile.keyCode.UP:
+                     case $.mobile.keyCode.RIGHT:
+                        self.refresh( index + step );
+                        break;
+                     case $.mobile.keyCode.PAGE_DOWN:
+                     case $.mobile.keyCode.DOWN:
+                     case $.mobile.keyCode.LEFT:
+                        self.refresh( index - step );
+                        break;
+                    }
+                }, // remove active mark
 
-				// move the slider according to the keypress
-				switch ( event.keyCode ) {
-				 case $.mobile.keyCode.HOME:
-					self.refresh( min );
-					break;
-				 case $.mobile.keyCode.END:
-					self.refresh( max );
-					break;
-				 case $.mobile.keyCode.PAGE_UP:
-				 case $.mobile.keyCode.UP:
-				 case $.mobile.keyCode.RIGHT:
-					self.refresh( index + step );
-					break;
-				 case $.mobile.keyCode.PAGE_DOWN:
-				 case $.mobile.keyCode.DOWN:
-				 case $.mobile.keyCode.LEFT:
-					self.refresh( index - step );
-					break;
-				}
-			}) // remove active mark
-			.keyup( function( event ) {
-				if ( self._keySliding ) {
-					self._keySliding = false;
-					$( this ).removeClass( "ui-state-active" );
-				}
-			});
+                keyup: function( event ) {
+                    if ( self._keySliding ) {
+                        self._keySliding = false;
+                        $( this ).removeClass( "ui-state-active" );
+                    }
+                }
+            });
 
 		this.refresh(undefined, undefined, true);
 	},

--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -71,10 +71,10 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 		}
 
 		input.focus(function() {
-				focusedEl.addClass( "ui-focus" );
+				focusedEl.addClass( $.mobile.focusClass );
 			})
 			.blur(function(){
-				focusedEl.removeClass( "ui-focus" );
+				focusedEl.removeClass( $.mobile.focusClass );
 			});
 
 		// Autogrow


### PR DESCRIPTION
Consistent use of focus `box-shadow` instead of `outline` on textinput, slider, checkboxradio, and select form elements.

Does not yet fix the other issues referenced by toddparker in 2214.
