### PR TITLE
Fix Makefile to build on OSes where filenames are case-sensitive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ JSFILES = 	  js/jquery.ui.widget.js \
 			  js/jquery.mobile.buttonMarkup.js \
 			  js/jquery.mobile.controlGroup.js \
 			  js/jquery.mobile.links.js \
-			  js/jquery.mobile.fixedtoolbar.js \
+			  js/jquery.mobile.fixedToolbar.js \
 			  js/jquery.mobile.init.js
 
 # The files to include when compiling the CSS files


### PR DESCRIPTION
jquery.mobile.fixedtoolbar.js -> jquery.mobile.fixedToolbar.js
