### PR TITLE
Popup update

### DIFF
--- a/css/structure/jquery.mobile.popup.css
+++ b/css/structure/jquery.mobile.popup.css
@@ -1,7 +1,6 @@
 .ui-popup-container {
   display: inline-block;
   position: absolute;
-  z-index: 100 !important;
   padding: 0px;
 }
 

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -33,6 +33,7 @@
 								<li><a href="page-links.html">Linking pages</a></li>
 								<li><a href="page-transitions.html" data-ajax="false">Page transitions</a></li>
 								<li><a href="page-dialogs.html">Dialogs</a></li>
+								<li><a href="popup/index.html">Popups</a></li>
 								<li><a href="page-cache.html">Prefetching &amp; caching pages</a></li>
 								<li><a href="page-navmodel.html">Ajax, hashes &amp; history</a></li>
 								<li><a href="page-dynamic.html">Dynamically injecting pages</a></li>

--- a/docs/pages/popup/index.html
+++ b/docs/pages/popup/index.html
@@ -138,6 +138,10 @@
 $('#myPopupDiv').popup();			
 </code></pre>
     
+<div data-role="popup" id="popupTester">
+    <p>This popup assumes the theme of the button that launches it.</p>
+    <p>Thus, it supports the idea that it is connected to the button.</p>
+</div>    
 
 		<h2>Theming the popup</h2>
 <p>Normally, the popup's theme will be set to align with the theme of the link that launches it. The above popup can be shown in multiple places. Each time, upon appearing, the popup's theme is set to match that of the link that launches it:</p>

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -57,13 +57,21 @@ $.widget("mobile.popup", $.mobile.widget, {
 	},
 
 	_setTheme: function(dst, theme, unconditional) {
-		var currentTheme = (dst.attr("class") || "")
-	    		.split(" ")
-	    		.filter(function(el, idx, ar) {
-	    			return el.match(/^ui-body-[a-z]$/);
-	    		});
+		var classes = (dst.attr("class") || "").split(" "),
+		    alreadyAdded = true,
+		    currentTheme = null,
+			matches;
 
-		currentTheme = ((currentTheme.length > 0) ? currentTheme[0].match(/^ui-body-([a-z])/)[1] : null);
+		while (classes.length > 0) {
+			currentTheme = classes.pop();
+			matches = currentTheme.match(/^ui-body-([a-z])$/);
+			if (matches && matches.length > 1) {
+				currentTheme = matches[1];
+				break;
+			}
+			else
+				currentTheme = null;
+		}
 
 		if (theme !== currentTheme || unconditional) {
 			dst.removeClass("ui-body-" + currentTheme);

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -204,8 +204,22 @@ $.widget("mobile.popup", $.mobile.widget, {
 		if (!this._isOpen) {
 			var self = this,
 			    coords = this._placementCoords(
-			    	(undefined === x ? window.innerWidth / 2 : x),
-			    	(undefined === y ? window.innerWidth / 2 : y));
+			    	(undefined === x ? window.innerWidth  / 2 : x),
+			    	(undefined === y ? window.innerHeight / 2 : y)),
+				zIndexMax = 0;
+
+            $(document)
+                .find("*")
+                .each(function() {
+                    var el = $(this),
+                        zIndex = parseInt(el.css("z-index"));
+
+                    if (!(el.is(self._ui.container) || el.is(self._ui.screen) || isNaN(zIndex)))
+                        zIndexMax = Math.max(zIndexMax, zIndex);
+                });
+
+            this._ui.screen.css("z-index", (zIndexMax + 1));
+            this._ui.container.css("z-index", (zIndexMax + 2));
 
 			this._ui.screen
 				.height($(document).height())
@@ -244,6 +258,7 @@ $.widget("mobile.popup", $.mobile.widget, {
 		    		self._ui.screen.addClass("ui-screen-hidden");
 		    		self._isOpen = false;
 		    		self.element.trigger("closed");
+		    		self._ui.screen.removeAttr("style");
 		    	};
 
 			this._ui.container

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -1,5 +1,5 @@
 /*
-=* jQuery Mobile Framework : "popup" plugin
+* jQuery Mobile Framework : "popup" plugin
 * Copyright (c) jQuery Project
 * Dual licensed under the MIT or GPL Version 2 licenses.
 * http://jquery.org/license

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -19,15 +19,7 @@ $.widget("mobile.popup", $.mobile.widget, {
 	},
 
 	_create: function() {
-		var widgetOptionNames = {
-		    	"overlayTheme" : "data-" + ($.mobile.ns || "") + "overlay-theme",
-					"shadow"       : "data-" + ($.mobile.ns || "") + "shadow",
-					"corners"      : "data-" + ($.mobile.ns || "") + "corners",
-					"fade"         : "data-" + ($.mobile.ns || "") + "fade",
-					"transition"   : "data-" + ($.mobile.ns || "") + "transition",
-					"theme"        : "data-" + ($.mobile.ns || "") + "theme"
-		    },
-				ui = {
+		var ui = {
 					screen    : "#ui-popup-screen",
 					container : "#ui-popup-container"
 				},
@@ -55,12 +47,9 @@ $.widget("mobile.popup", $.mobile.widget, {
 			_isOpen : false
 		});
 
-		// Apply options - data-* options, if present, take precedence over this.options.*
-		for (var key in this.options)
-			this._setOption(key,
-				(widgetOptionNames[key] === undefined || this.element.attr(widgetOptionNames[key]) === undefined)
-					? this.options[key]
-					: this.element.attr(widgetOptionNames[key]), true);
+		$.each (this.options, function(key) {
+			self._setOption(key, self.options[key], true);
+		});
 
 		ui.screen.bind("vclick", function(e) {
 			self.close();


### PR DESCRIPTION
Popup windows sometimes show up behind other elements, because those elements have high z-index values set. The first commit fixes that by collecting calculating the max of all the z-index values on the page before displaying the popup. It then assigns a z-index higher than any encountered to the popup screen, and a z-index higher still to the popup container.

The second commit restore the &lt;div id="popupTester"....&gt;&lt;/div&gt; in the docs/pages/popup/index.html file, making the theme-inheritance examples work again.

The third commit removes the awkward mapping between data-* attributes and this.options.*. This mapping is unnecessary now that data-* attributes and this.options.\* are merged correctly.

The fourth commit removes usage of .filter() from _setTheme(). This method seems to be unavailable in IE8, causing things to break there.
