### PR TITLE
Fix to bug #3141 (https://github.com/jquery/jquery-mobile/issues/3141)

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -29,6 +29,9 @@ $.fn.buttonMarkup = function( options ) {
 			buttonText = document.createElement( o.wrapperEls ),
 			buttonIcon = o.icon ? document.createElement( "span" ) : null;
 
+		// if so, prevent double enhancement, and continue with rest of the elements.
+		if( e.tagName === 'INPUT' && e.getAttribute('data-role') === 'button') continue;
+		
 		if ( attachEvents ) {
 			attachEvents();
 		}

--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -30,7 +30,7 @@ $.fn.buttonMarkup = function( options ) {
 			buttonIcon = o.icon ? document.createElement( "span" ) : null;
 
 		// if so, prevent double enhancement, and continue with rest of the elements.
-		if( e.tagName === 'INPUT' && e.getAttribute('data-role') === 'button') continue;
+		if( e.tagName === "INPUT" && e.getAttribute( "data-role" ) === "button" ) continue;
 		
 		if ( attachEvents ) {
 			attachEvents();

--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -33,7 +33,10 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 		// this must be an anonymous function so that select menu dialogs can replace
 		// the close method. This is a change from previously just defining data-rel=back
 		// on the button and letting nav handle it
-		headerCloseButton.bind( "vclick", function() {
+		//
+		// Use click rather than vclick in order to prevent the possibility of unintentionally
+		// reopening the dialog if the dialog opening item was directly under the close button.
+		headerCloseButton.bind( "click", function() {
 			self.close();
 		});
 


### PR DESCRIPTION
Prevents double enhancing input buttons that contain unnecessary "button" data-role attribute.
