### PR TITLE
Remove ui-btn-down class on scrollstart

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -159,7 +159,7 @@ var attachEvents = function() {
 				$btn.removeClass( "ui-btn-up-" + theme ).addClass( "ui-btn-hover-" + theme );
 			}
 		},
-		"vmouseout blur": function( event ) {
+		"vmouseout blur scrollstart": function( event ) {
 			var btn = closestEnabledButton( event.target ),
 				$btn, theme;
 


### PR DESCRIPTION
Fixes #3350.  I only tested this on my iPhone 3GS, but it seems to do the trick.
