### PR TITLE
[slider] Implement enable/disable via _setOption

### DIFF
--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -359,18 +359,25 @@ $.widget( "mobile.slider", $.mobile.widget, {
 		}
 	},
 
-	enable: function() {
-		this.element.attr( "disabled", false );
-		this.slider.removeClass( "ui-disabled" ).attr( "aria-disabled", false );
-		return this._setOption( "disabled", false );
+	_setOption: function(key, value) {
+		switch(key) {
+			case "disabled":
+				this._setDisabled(value);
+				break;
+		}
 	},
 
-	disable: function() {
-		this.element.attr( "disabled", true );
-		this.slider.addClass( "ui-disabled" ).attr( "aria-disabled", true );
-		return this._setOption( "disabled", true );
+	_setDisabled: function(value) {
+		if (value) {
+			this.element.attr( "disabled", true );
+			this.slider.addClass( "ui-disabled" ).attr( "aria-disabled", true );
+		}
+		else {
+			this.element.attr( "disabled", false );
+			this.slider.removeClass( "ui-disabled" ).attr( "aria-disabled", false );
+		}
+		return $.mobile.widget.prototype._setOption.call(this, "disabled", value);
 	}
-
 });
 
 //auto self-init widgets


### PR DESCRIPTION
$.ui.widget already implements methods "enable" and "disable" via calls to
_setOption("disabled", ...). Thus, it is better to implement enable/disable by
overriding the default _setOption("disabled", ...) method and then chaining up
to $.ui.widget, because that way both the "enable"/"disable" pair of methods and
.slider("option", "disabled", value) work.
