### PR TITLE
Issue #3340

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -1,4 +1,4 @@
-/* 
+/*
 * "events" plugin - Handles events
 */
 
@@ -71,7 +71,8 @@ $.event.special.scrollstart = {
 $.event.special.tap = {
 	setup: function() {
 		var thisObject = this,
-			$this = $( thisObject );
+			$this = $( thisObject ),
+			lastEvent;
 
 		$this.bind( "vmousedown", function( event ) {
 
@@ -100,9 +101,11 @@ $.event.special.tap = {
 
 				// ONLY trigger a 'tap' event if the start target is
 				// the same as the stop target.
-				if ( origTarget == event.target ) {
+				if ( origTarget == event.target && lastEvent !== event ) {
 					triggerCustomEvent( thisObject, "tap", event );
 				}
+
+				lastEvent = event;
 			}
 
 			$this.bind( "vmousecancel", clearTapHandlers )


### PR DESCRIPTION
I've got the same behavior (double fire) in Chrome 16.
To reproduce: press LMB on the button, move the cursor outside button (so it will became like crossed circle), release LMB, then click on the button. Handler will be executed twice.
The problem is that the previous vclick handler wasn't unbinded. Patched so it checks if the exactly same event comes twice: ignore the second one if so.
