### PR TITLE
fix for duplicate/incorrect enhancement of buttons

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -30,6 +30,12 @@ $.fn.buttonMarkup = function( options ) {
 			buttonText = document.createElement( o.wrapperEls ),
 			buttonIcon = o.icon ? document.createElement( "span" ) : null;
 
+		// if this is a button, check if it's been enhanced and, if not, use the right function
+		if( e.tagName === "BUTTON" ) {
+	 	 	if ( !$( e.parentNode ).hasClass( "ui-btn" ) ) $( e ).button();
+	 	 	continue;
+ 	 	}
+
 		if ( attachEvents ) {
 			attachEvents();
 		}

--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -19,11 +19,17 @@ $.widget( "mobile.button", $.mobile.widget, {
 	},
 	_create: function() {
 		var $el = this.element,
-            $button,
+			$button,
 			o = this.options,
 			type,
 			name,
 			$buttonPlaceholder;
+
+		// if this is a link, check if it's been enhanced and, if not, use the right function
+		if( $el[ 0 ].tagName === "A" ) {
+	 	 	if ( !$el.hasClass( "ui-btn" ) ) $el.buttonMarkup();
+	 	 	return;
+ 	 	}
 
 		// Add ARIA role
 		this.button = $( "<div></div>" )


### PR DESCRIPTION
builds on @imjoshdean's PR, but instead of canceling out, redirect to the right function if the element hasn't been enhanced yet, and do that for both links and buttons
