### PR TITLE
Update cached copy of data-url when page already exists in DOM.

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -673,7 +673,8 @@ define( [
 		// attribute and in need of enhancement.
 		if ( page.length === 0 && dataUrl && !path.isPath( dataUrl ) ) {
 			page = settings.pageContainer.children( "#" + dataUrl )
-				.attr( "data-" + $.mobile.ns + "url", dataUrl );
+				.attr( "data-" + $.mobile.ns + "url", dataUrl )
+				.jqmData( "url", dataUrl );
 		}
 
 		// If we failed to find a page in the DOM, check the URL to see if it


### PR DESCRIPTION
This ensures that dynamically generated pages report correct data url / set correct hash after being recycled. Simplified test case:

```
<!DOCTYPE html>
<html>
  <head>
    <link rel="stylesheet" href="compiled/jquery.mobile.css">
    <script type="text/javascript" charset="utf-8" src="jquery-1.7.1.js"></script>
    <script type="text/javascript" charset="utf-8" src="compiled/jquery.mobile.js"></script>
  </head>
  <body>
    <div data-role="page" id="overview">
      <div data-role="content">
        <a data-role="button" href="#detail?1">Page 1</a>
        <a data-role="button" href="#detail?2">Page 2</a>
        <a data-role="button" href="#detail?3">Page 3</a>
      </div>
    </div>
    <div data-role="page" id="detail">
    </div>
    <script>
      window.addEventListener("hashchange", {
        handleEvent: function(e) {
          console.log(e, window.location.hash);
        }
      });
    </script>
  </body>
</html>
```
