### PR TITLE
Issue #1524 - Taphold event fired while scrolling on Blackberry Playbook

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -92,8 +92,8 @@ $.event.special.tap = {
 				clearTapTimer();
 
 				$this.unbind( "vclick", clickHandler )
-					.unbind( "vmouseup", clearTapTimer )
-					.unbind( "vmousecancel", clearTapHandlers );
+					.unbind( "vmouseup", clearTapTimer );
+				$(document).unbind("vmousecancel", clearTapHandlers);
 			}
 
 			function clickHandler(event) {
@@ -106,9 +106,9 @@ $.event.special.tap = {
 				}
 			}
 
-			$this.bind( "vmousecancel", clearTapHandlers )
-				.bind( "vmouseup", clearTapTimer )
+			$this.bind( "vmouseup", clearTapTimer )
 				.bind( "vclick", clickHandler );
+			$(document).bind("vmousecancel", clearTapHandlers);
 
 			timer = setTimeout(function() {
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold" ) );

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -93,7 +93,7 @@ $.event.special.tap = {
 
 				$this.unbind( "vclick", clickHandler )
 					.unbind( "vmouseup", clearTapTimer );
-				$(document).unbind("vmousecancel", clearTapHandlers);
+				$( document ).unbind( "vmousecancel", clearTapHandlers );
 			}
 
 			function clickHandler(event) {
@@ -108,7 +108,7 @@ $.event.special.tap = {
 
 			$this.bind( "vmouseup", clearTapTimer )
 				.bind( "vclick", clickHandler );
-			$(document).bind("vmousecancel", clearTapHandlers);
+			$( document ).bind( "vmousecancel", clearTapHandlers );
 
 			timer = setTimeout(function() {
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold" ) );


### PR DESCRIPTION
Issue #1524 - Taphold event fired while scrolling on Blackberry Playbook

Cause: The vmousecancel event was not being fired for 'this'.

How Fixed: Bound vmousecancel event to document instead of 'this'.

How Tested: Ran the example provided with the issue
(http://jsbin.com/oruhu4/) with this change on BlackBerry Playbook v2.0
and iPad iOS 5.0.1
