### PR TITLE
The button's text should preserve the original css class of the select ...

### DIFF
--- a/js/jquery.mobile.forms.select.js
+++ b/js/jquery.mobile.forms.select.js
@@ -176,13 +176,16 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 	},
 
 	setButtonText: function() {
-		var self = this, selected = this.selected();
+		var self = this, selected = this.selected(), cls = [self.select.attr("class")];;
 
-		this.button.find( ".ui-btn-text" ).text( function() {
+		this.button.find( ".ui-btn-text" ).html( function() {
+			
 			if ( !self.isMultiple ) {
-				return selected.text();
+				cls.push(selected.attr("class"));
+				return $("<span/>", {"class": cls.join(' ')}).text(selected.text());
 			}
 
+			//TODO: apply the span as above to preserve the css-class of the original select
 			return selected.length ? selected.map( function() {
 				return $( this ).text();
 			}).get().join( ", " ) : self.placeholder;


### PR DESCRIPTION
...and the selected option. This way you can customize it with i.e. images.

This change is along with this one: https://github.com/jquery/jquery-mobile/pull/3480#commits-pushed-69c9ca4

For a demo: http://www.dotnetwise.com/tryAndError/jquery.mobile/select.filter/
