### PR TITLE
Remove superfluous type-index class

### DIFF
--- a/docs/config/dialogTransition.html
+++ b/docs/config/dialogTransition.html
@@ -22,7 +22,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>Config applied</h1>

--- a/docs/config/iOSFullscreen.html
+++ b/docs/config/iOSFullscreen.html
@@ -29,7 +29,7 @@
 </head>
 <body>
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>jQuery Mobile</h1>

--- a/docs/config/jq17b1.html
+++ b/docs/config/jq17b1.html
@@ -13,7 +13,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>jQuery version</h1>

--- a/docs/config/loadingMessage.html
+++ b/docs/config/loadingMessage.html
@@ -23,7 +23,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>Config applied</h1>

--- a/docs/config/minScrollBack.html
+++ b/docs/config/minScrollBack.html
@@ -23,7 +23,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>Config applied</h1>

--- a/docs/config/pageLoadErrorMessage.html
+++ b/docs/config/pageLoadErrorMessage.html
@@ -23,7 +23,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>Config applied</h1>

--- a/docs/config/pageTransition.html
+++ b/docs/config/pageTransition.html
@@ -22,7 +22,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>Config applied</h1>

--- a/docs/config/pushState.html
+++ b/docs/config/pushState.html
@@ -23,7 +23,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f">
 		<h1>Config applied</h1>

--- a/docs/config/touchOverflow.html
+++ b/docs/config/touchOverflow.html
@@ -23,7 +23,7 @@
 </head> 
 <body> 
 
-	<div data-role="page" class="type-index">
+	<div data-role="page">
 
 		<div data-role="header" data-theme="f" data-position="fixed">
 		<h1>Config applied</h1>


### PR DESCRIPTION
The `data-role="page"` div's on the global config test pages have a class of `type-index`.  I think these got in here by accident since the only other page div's that have that class are on the various index.html pages.  This patch removes the class from the global config test pages.

Edit: better description
