### PR TITLE
Configurable taphold

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -114,7 +114,7 @@ $.event.special.tap = {
 
 			timer = setTimeout(function() {
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold" ) );
-			}, tapholdDurationThreshold );
+			}, $.event.special.tap.tapholdDurationThreshold );
 		});
 	}
 };

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -70,6 +70,8 @@ $.event.special.scrollstart = {
 
 // also handles taphold
 $.event.special.tap = {
+	tapholdDurationThreshold: 750, // Time to detect taphold
+  
 	setup: function() {
 		var thisObject = this,
 			$this = $( thisObject );
@@ -112,7 +114,7 @@ $.event.special.tap = {
 
 			timer = setTimeout(function() {
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold" ) );
-			}, 750 );
+			}, tapholdDurationThreshold );
 		});
 	}
 };


### PR DESCRIPTION
Hi,

When use iPhone 3GS(iOS 5.0.1), I taphold the link, iOS's menu is popuped and
it prevent taphold event. I would like to more short duration for tophold for iPhone 3GS at:

```
            timer = setTimeout(function() {
                    triggerCustomEvent( thisObject, "taphold", $.Event( "taphold" ) );
            }, 750 );
```

But I depends on the situation, I propose configurable taphold duraction.

Please look it.

best regards,

Takashi Okamoto
