### PR TITLE
Bad definition to event "create" for fixed toolbars

### DIFF
--- a/docs/toolbars/bars-fixed-events.html
+++ b/docs/toolbars/bars-fixed-events.html
@@ -35,7 +35,7 @@
 
 				<dl>
 				
-					<dt><code>create</code> triggered when a select menu is created</dt>
+					<dt><code>create</code> triggered when a fixed toolbar is created</dt>
 					<dd>
 
 						<pre><code>


### PR DESCRIPTION
Bad definition to event "create" for fixed toolbars
