### PR TITLE
Issue 3508: changed children( el ) to find( el ).not( div > el ) to more closely match the docs

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -206,8 +206,8 @@ var attachEvents = function() {
 //links in bars, or those with  data-role become buttons
 //auto self-init widgets
 $( document ).bind( "pagecreate create", function( e ){
-
-	$( ":jqmData(role='button'), .ui-bar > a, .ui-header > a, .ui-footer > a, .ui-bar > :jqmData(role='controlgroup') > a", e.target )
+	// removed parent > child limitation from .ui-header > a to allow header content to be wrapped in a non-div tag
+	$( ":jqmData(role='button'), .ui-bar > a, .ui-header  a, .ui-footer > a, .ui-bar > :jqmData(role='controlgroup') > a", e.target )
 		.not( ".ui-btn, :jqmData(role='none'), :jqmData(role='nojs')" )
 		.buttonMarkup();
 });

--- a/js/jquery.mobile.page.sections.js
+++ b/js/jquery.mobile.page.sections.js
@@ -44,7 +44,10 @@ $( document ).delegate( ":jqmData(role='page'), :jqmData(role='dialog')", "pagec
 				.attr( "role", role === "header" ? "banner" : "contentinfo" );
 
 			// Right,left buttons
-			$headeranchors	= $this.children( "a" );
+			// $headeranchors	= $this.children( "a" );
+			// probably a better way to do this, but to go along with the docs
+			// non-div "a" descendants
+			$headeranchors	= $this.find( "a" ).not( "div > a" );
 			leftbtn	= $headeranchors.hasClass( "ui-btn-left" );
 			rightbtn = $headeranchors.hasClass( "ui-btn-right" );
 
@@ -66,7 +69,11 @@ $( document ).delegate( ":jqmData(role='page'), :jqmData(role='dialog')", "pagec
 			}
 
 			// Page title
-			$this.children( "h1, h2, h3, h4, h5, h6" )
+			// $this.children( "h1, h2, h3, h4, h5, h6" )
+			// probably a better way to do this, but to go along with the docs
+			// non-div "h1, h2, h3, h4, h5, h6" descendants
+			$this.find( "h1, h2, h3, h4, h5, h6" )
+				.not( "div > h1, div > h2, div > h3, div > h4, div > h5, div > h6" )
 				.addClass( "ui-title" )
 				// Regardless of h element number in src, it becomes h1 for the enhanced page
 				.attr({


### PR DESCRIPTION
changed children( el ) to find( el ).not( div > el ) to more closely reflect the [docs](http://jquerymobile.com/test/docs/toolbars/docs-headers.html)

the docs read:

> If you need to to create a header that doesn't follow the default configuration, simply wrap your custom styled markup in a container div inside the header container and the plugin won't apply the automatic button logic so you can write custom styles for laying out the content in your header.

the actual code however, is only checking the children and therefore if it's wrapped in any tag (not just a div), it will not have the automatic styling applied.
