### PR TITLE
#2167 Implementing auto scroll to top of expanded collapsible section

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -63,7 +63,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 				})
 			.add( ".ui-btn-inner" )
 				.addClass( "ui-corner-top ui-corner-bottom" );
-
+	
 		//events
 		collapsible
 			.bind( "expand collapse", function( event ) {
@@ -93,10 +93,35 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 							.toggleClass( "ui-corner-bottom", isCollapse );
 						collapsibleContent.toggleClass( "ui-corner-bottom", !isCollapse );
 					}
+					
 					collapsibleContent.trigger( "updatelayout" );
 				}
 			})
 			.trigger( o.collapsed ? "collapse" : "expand" );
+			
+		var lastExpanded;
+		// auto scroll to top of expanded section
+		collapsible.bind( "expand", function() {
+			var $expandable = $(this);
+			// wait until the lastExpanded has been collapsed, check each 200ms
+			var intervalId = setInterval(function() {
+				if (lastExpanded && lastExpanded.has( ".ui-collapsible-heading-collapsed" )) {
+					var expandableTop = $expandable.offset().top,
+					$window = $(window),
+					targetPos = expandableTop - $window.scrollTop() + $expandable.height();
+					// a) if collapsable does not fit within displayable area or 
+					// b) if the window scrolled below the top of the collapsable section
+					if (targetPos > $window.height() || expandableTop < $window.scrollTop()) {
+	 					$.mobile.silentScroll(expandableTop);
+					}
+					// once last section collapsed and processed clear check interval
+					clearInterval(intervalId);
+					lastExpanded = $expandable;
+				} else {
+					lastExpanded = $expandable;
+				}
+			}, 200);
+		}); 
 
 		collapsibleHeading
 			.bind( "click", function( event ) {

--- a/tests/functional/collapsiblesetautoscroll.html
+++ b/tests/functional/collapsiblesetautoscroll.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile: Auto Scroll Accordion Sections</title>
+	<link rel="stylesheet"  href="../../css/themes/default/jquery.mobile.css" />
+	<link rel="stylesheet" href="../../docs/_assets/css/jqm-docs.css" />
+	<script src="../../js/jquery.tag.inserter.js"></script>
+	<script data-main="../../js/jquery.mobile" src="../../external/requirejs/require.js"></script>
+
+	<script>
+	$(function(){
+		console.log("Testing auto scroll to top in accordion sections");
+	});
+	</script>
+
+</head>
+<body>
+<div  data-role="page"  data-theme="b" id="jqm-home">
+	<div  data-role="header">
+		<h1>Auto-scroll section</h1>
+	</div>
+
+	<div  data-role="content">
+		<p>Sections in this page, when expanded, should auto scroll to the top of the section</p>
+
+		<div data-role="collapsible-set">
+		
+			<div data-role="collapsible" data-collapsed="false">
+				<h3>Section 1</h3>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+			</div>
+			
+			<div data-role="collapsible">
+				<h3>Section 2</h3>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+			</div>
+			
+			<div data-role="collapsible">
+				<h3>Section 3</h3>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+				<p>This is a lot of content to ensure the section is large enough to demonstrate the functionality of autoscrolling in sections.</p>
+			</div>
+		</div>
+	</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds an event listener to enable auto scroll to the top of a
collapsible section when it is expanded. Credit is due to @ricksuggs
for the implementation of the scroll code.

I have included a functional test page to demonstrate the functionality. 

  /jquery-mobile/tests/functional/collapsiblesetautoscroll.html

Not being fully familiar with the jquery code I am not sure how you would like to handle this feature if you preferred it to be optional to users. Please amend to provide this functionality, or send me review comments so I can make the necessary changes.

I have tested this in the following browsers 
- iOS 5
- Chrome (Mac 16.0.912.77)
- Safari (Mac, 5.1.2)
- Firefox (Mac 9.0.1)
- RockMelt (Mac 0.9.68.1565)
