### PR TITLE
[popup] Restrict scope for a given button's popup to the page under enha...

### DIFF
--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -298,7 +298,7 @@ $(document).bind("pagecreate create", function(e) {
 		.not(":jqmData(role='none'), :jqmData(role='nojs')")
 		.popup();
 
-	$("a[href^='#']:jqmData(rel='popup')").each(function() {
+	$("a[href^='#']:jqmData(rel='popup')", e.target).each(function() {
 		$.mobile.popup.bindPopupToButton($(this), $($(this).attr("href")));
 
 	});


### PR DESCRIPTION
...ncement

When linking buttons to popups, the selector used for finding the buttons that are supposed to get linked needs to be restricted to the page currently under enhancement, because otherwise it will find such buttons on other pages as well. The problem is that since those pages have never been enhanced, popup widgets on those pages will not yet have been created, causing .popup("option", ...) calls to as-yet uninitialized popup widgets.

P.S.: One-liner :)
