### PR TITLE
Collapsible doesn't honor the data-iconpos

### DIFF
--- a/docs/content/content-collapsible-set.html
+++ b/docs/content/content-collapsible-set.html
@@ -72,6 +72,32 @@
 			</div>
 		</div>
 
+		<h2>Header's icon positioning</h2>
+		<p>The usual <code>data-iconpos</code> attribute (See <b>Icon positioning</b> section in <a href="../buttons/buttons-icons.html">Button Icons</a> page to see other possible options) can be used to set the default icon positioning through out the set. A specific collapsible item still can override the positioning by specifiying <code>data-iconpos</code> inside it.</p>
+
+
+<pre><code>		
+&lt;div data-role=&quot;collapsible-set&quot; <strong>data-iconpos=&quot;right&quot;</strong>&gt;
+</code></pre>	
+
+		<div data-role="collapsible-set" data-iconpos="right">
+			<div data-role="collapsible">
+				<h3>Section 1</h3>
+				<p>Collapsible content with default icon positioning set by the set.</p>
+			</div>
+			<div data-role="collapsible" data-iconpos="left">
+				<h3>Section 2</h3>
+                <p>The heading has <code>data-iconpos</code> attribute set to <code>left</code> so the icon is displayed on the left.</p>
+
+			</div>
+			<div data-role="collapsible">
+				<h3>Section 3</h3>
+				<p>Collapsible content with default icon positioning set by the set.</p>
+			</div>
+		</div>
+
+
+
 		<h2>Theming collapsible content</h2>
 		<p>The standard <code>data-theme</code> attribute can be used to set the color of each collapsible in a set. To provide a clearer visual grouping of the content with the headers, add the <code>data-content-theme</code> attribute with a swatch letter. This adds a themed background color and border to the content block. For consistent theming, add these attributes to the parent collapsible set.</p>
 

--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -41,6 +41,10 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 			if ( !o.contentTheme ) {
 				o.contentTheme = collapsibleSet.jqmData( "content-theme" );
 			}
+            // Gets the preference icon position in the set
+            if ( !o.iconPos ) {
+                o.iconPos = collapsibleSet.jqmData( "iconpos" );
+            }
 		}
 
 		collapsibleContent.addClass( ( o.contentTheme ) ? ( "ui-body-" + o.contentTheme ) : "");
@@ -57,7 +61,9 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 				.buttonMarkup({
 					shadow: false,
 					corners: false,
-					iconPos: "left",
+                    //specific collapsible icon position takes priority over the set's position, 
+                    //otherwise, use 'left' position as default
+					iconpos: $el.jqmData( "iconpos" ) || o.iconPos || "left",
 					icon: "plus",
 					theme: o.theme
 				})


### PR DESCRIPTION
The patch makes collapsible honors the data-iconpos specified either in the collapsibleset or in the collapsible itself. 

Also the it contains update to the documentation reflecting the change.
