### PR TITLE
Custom taphold event missing target property

### DIFF
--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -111,7 +111,7 @@ $.event.special.tap = {
 			$( document ).bind( "vmousecancel", clearTapHandlers );
 
 			timer = setTimeout(function() {
-					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold" ) );
+					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold", { target: origTarget } ) );
 			}, 750 );
 		});
 	}


### PR DESCRIPTION
May be related: https://forum.jquery.com/topic/taphold-don-t-work

When the taphold is bound with a live the jQuery liveHandler will attempt to execute the following line of code:
    if ( event.liveFired === this || !events || !events.live || event.target.disabled || event.button && event.type === "click" ) {

Unless the target is set in the newly created event the jQuery code will throw an exception
