### PR TITLE
Reusable button markup

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -27,17 +27,34 @@ $.fn.buttonMarkup = function( options ) {
 			textClass = "ui-btn-text",
 			buttonClass, iconClass,
 			// Button inner markup
-			buttonInner = document.createElement( o.wrapperEls ),
-			buttonText = document.createElement( o.wrapperEls ),
-			buttonIcon = o.icon ? document.createElement( "span" ) : null;
+			buttonInner,
+			buttonText,
+			buttonIcon,
+			buttonElements;
 
-		// if this is a button, check if it's been enhanced and, if not, use the right function
-		if( e.tagName === "BUTTON" ) {
-	 	 	if ( !$( e.parentNode ).hasClass( "ui-btn" ) ) $( e ).button();
-	 	 	continue;
- 	 	}
+		$.each(o, function(key, value) {
+			e.setAttribute( "data-" + $.mobile.ns + key, value );
+		});
 
-		if ( attachEvents ) {
+		// Check if this element is already enhanced
+		buttonElements = $.data(((e.tagName === "INPUT" || e.tagName === "BUTTON") ? e.parentNode : e), "buttonElements")
+
+		if (buttonElements) {
+			e = buttonElements.outer;
+			el = $(e);
+			buttonInner = buttonElements.inner;
+			buttonText = buttonElements.text;
+			// We will recreate this icon below
+			$(buttonElements.icon).remove();
+			buttonElements.icon = null;
+		}
+		else {
+			buttonInner = document.createElement( o.wrapperEls );
+			buttonText = document.createElement( o.wrapperEls );
+		}
+		buttonIcon = o.icon ? document.createElement( "span" ) : null;
+
+		if ( attachEvents && !buttonElements) {
 			attachEvents();
 		}
 
@@ -84,29 +101,48 @@ $.fn.buttonMarkup = function( options ) {
 			buttonClass += " ui-shadow";
 		}
 
-		e.setAttribute( "data-" + $.mobile.ns + "theme", o.theme );
-		el.removeClass( "ui-link" ).addClass( buttonClass );
+		// Remove all button-related classes and re-add the ones calculated this time
+		el.removeClass( function(idx, klass) {
+			var newClass = "";
+			$.each((klass || "").split(" "), function(key, value) {
+				if (value.substring(0, 6) === "ui-btn" || value === "ui-shadow" || value === "ui-link")
+					newClass += value + " ";
+			});
+			return newClass;
+		}).addClass( buttonClass );
 
 		buttonInner.className = innerClass;
 
 		buttonText.className = textClass;
-		buttonInner.appendChild( buttonText );
-
+		if (!buttonElements)
+			buttonInner.appendChild( buttonText );
 		if ( buttonIcon ) {
 			buttonIcon.className = iconClass;
-			buttonInner.appendChild( buttonIcon );
+			if (!(buttonElements && buttonElements.icon))
+				buttonInner.appendChild( buttonIcon );
 		}
 
-		while ( e.firstChild ) {
+		while ( e.firstChild && !buttonElements) {
 			buttonText.appendChild( e.firstChild );
 		}
 
-		e.appendChild( buttonInner );
+		if (!buttonElements)
+			e.appendChild( buttonInner );
 
-		// TODO obviously it would be nice to pull this element out instead of
-		// retrieving it from the DOM again, but this change is much less obtrusive
-		// and 1.0 draws nigh
-		$.data( e, 'textWrapper', $( buttonText ) );
+		// Assign a structure containing the elements of this button to the elements of this button. This
+		// will allow us to recognize this as an already-enhanced button in future calls to buttonMarkup().
+		buttonElements = {
+			outer : e,
+			inner : buttonInner,
+			text  : buttonText,
+			icon  : buttonIcon
+		};
+
+		$.data(e,           'buttonElements', buttonElements);
+		$.data(buttonInner, 'buttonElements', buttonElements);
+		$.data(buttonText,  'buttonElements', buttonElements);
+		if (buttonIcon)
+			$.data(buttonIcon, 'buttonElements', buttonElements);
 	}
 
 	return this;

--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -110,9 +110,8 @@ $.widget( "mobile.button", $.mobile.widget, {
 			this.enable();
 		}
 
-		// the textWrapper is stored as a data element on the button object
-		// to prevent referencing by it's implementation details (eg 'class')
-		this.button.data( 'textWrapper' ).text( $el.text() || $el.val() );
+                // Grab the button's text element from its implementation-independent data item
+		$(this.button.data( 'buttonElements' ).text).text( $el.text() || $el.val() );
 	}
 });
 

--- a/tests/functional/button-markup.html
+++ b/tests/functional/button-markup.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Button Markup Tester</title>
+	<link rel="stylesheet"  href="../../css/themes/default/jquery.mobile.css" />
+	<link rel="stylesheet" href="../../docs/_assets/css/jqm-docs.css" />
+	<script src="../../js/jquery.tag.inserter.js"></script>
+	<script src="../../js"></script>
+<script>
+$(document).bind("pagecreate", function() {
+	$("#button-apply").bind("vclick", function() {
+		var options = {empty: true};
+
+		$("[data-setter]").each(function() {
+			var self = $(this),
+			    val = ($(this).is("[type='checkbox']") ? $(this).is(":checked") : $(this).val()),
+			    key = $(this).parent().find("label").text(),
+			    apply = $("#button-" + key + "-apply").is(":checked");
+
+			if (apply) {
+				options.empty = false;
+				options[key] = val;
+			}
+		});
+		if (!options.empty) {
+			delete options.empty;
+			$("#sample-link,#sample-input-button,#sample-button").buttonMarkup(options);
+		}
+	});
+});
+</script>
+<style>
+.ui-field-contain {
+	margin-top: 0px;
+	margin-bottom: 0px;
+}
+</style>
+</head>
+
+<body>
+	<div data-role="page">
+		<div data-role="header">
+			<h1>jQuery Mobile Widget Option Tester</h1>
+		</div>
+		<div data-role="contents">
+			<a id="sample-link" data-role="button">Sample Link</a>
+			<input id="sample-input-button" type="button" name="Input Button" value="Sample Input Button"></input>
+			<button id="sample-button" name="Button">Sample Button</button>
+
+			<form id="button-settings" name="button-settings" action="#" method="get" style="display: table;">
+				<table><tr><td>
+					<div data-role="fieldcontain">
+						<label for="button-icon">icon</label>
+						<input data-setter="true" type="text" id="button-icon"></input>
+					</div>
+                    		</td><td>
+					<div data-role="fieldcontain">
+						<label for="button-icon-apply">Apply</label>
+						<input data-apply="true" type="checkbox" id="button-icon-apply"></input>
+					</div>
+				</td></tr><tr><td>
+					<div data-role="fieldcontain">
+			                        <label for="button-iconpos">iconpos</label>
+                        			<input data-setter="true" type="text" id="button-iconpos"></input>
+					</div>
+				</td><td>
+					<div data-role="fieldcontain">
+						<label for="button-iconpos-apply">Apply</label>
+						<input data-apply="true" type="checkbox" id="button-iconpos-apply"></input>
+					</div>
+				</td></tr><tr><td>
+					<div data-role="fieldcontain">
+						<label for="button-theme">theme</label>
+						<input data-setter="true" type="text" id="button-theme"></input>
+					</div>
+				</td><td>
+					<div data-role="fieldcontain">
+						<label for="button-theme-apply">Apply</label>
+						<input data-apply="true" type="checkbox" id="button-theme-apply"></input>
+					</div>
+				</td></tr><tr><td>
+					<div data-role="fieldcontain">
+						<label for="button-inline">inline</label>
+						<input data-setter="true" type="checkbox" id="button-inline"></input>
+					</div>
+				</td><td>
+					<div data-role="fieldcontain">
+			   			<label for="button-inline-apply">Apply</label>
+						<input data-apply="true" type="checkbox" id="button-inline-apply"></input>
+					</div>
+				</td></tr><tr><td>
+					<div data-role="fieldcontain">
+						<label for="button-shadow">shadow</label>
+						<input data-setter="true" type="checkbox" id="button-shadow"></input>
+					</div>
+				</td><td>
+					<div data-role="fieldcontain">
+						<label for="button-shadow-apply">Apply</label>
+						<input data-apply="true" type="checkbox" id="button-shadow-apply"></input>
+					</div>
+				</td></tr><tr><td>
+					<div data-role="fieldcontain">
+						<label for="button-corners">corners</label>
+						<input data-setter="true" type="checkbox" id="button-corners"></input>
+					</div>
+				</td><td>
+					<div data-role="fieldcontain">
+						<label for="button-corners-apply">Apply</label>
+						<input data-apply="true" type="checkbox" id="button-corners-apply"></input>
+					</div>
+				</td></tr><tr><td>
+					<div data-role="fieldcontain">
+						<label for="button-iconshadow">iconshadow</label>
+						<input data-setter="true" type="checkbox" id="button-iconshadow"></input>
+					</div>
+				</td><td>
+					<div data-role="fieldcontain">
+						<label for="button-iconshadow-apply">Apply</_label>
+						<input data-apply="true" type="checkbox" id="button-iconshadow-apply"></input>
+					</div>
+				</td></tr>
+				<tr><td colspan="2">
+					<input type="button" name="button-apply" value="Apply" id="button-apply"></input>
+				</td></tr></table>
+			</form>
+		</div>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
When calling $.mobile.buttonMarkup on an existing anchor, button-type input, or button tag, it creates several divs which represent the button widget. Upon subsequent calls, it now picks up those divs and modifies their classes to reflect the options passed in, instead of just skipping the whole operation.
