### PR TITLE
[buttonMarkup] Remember applied classes so as to unapply only those at t...

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -41,6 +41,7 @@ $.fn.buttonMarkup = function( options ) {
 
 		$.each(o, function(key, value) {
 			e.setAttribute( "data-" + $.mobile.ns + key, value );
+			el.jqmData(key, value);
 		});
 
 		// Check if this element is already enhanced
@@ -110,6 +111,8 @@ $.fn.buttonMarkup = function( options ) {
 			buttonClass += " ui-shadow";
 		}
 
+		if (buttonElements)
+			el.removeClass((buttonElements.bcls || ""));
 		el.removeClass( "ui-link" ).addClass( buttonClass );
 				
 		buttonInner.className = innerClass;
@@ -133,6 +136,7 @@ $.fn.buttonMarkup = function( options ) {
 		// Assign a structure containing the elements of this button to the elements of this button. This
 		// will allow us to recognize this as an already-enhanced button in future calls to buttonMarkup().
 		buttonElements = {
+			bcls  : buttonClass,
 			outer : e,
 			inner : buttonInner,
 			text  : buttonText,

--- a/tests/unit/buttonMarkup/buttonMarkup_core.js
+++ b/tests/unit/buttonMarkup/buttonMarkup_core.js
@@ -4,13 +4,13 @@
 (function($){
 	module("jquery.mobile.buttonMarkup.js");
 
-        test( "header buttons should have the header class", function() {
-            var headerButton1 = $("#header-button-1"),
-                headerButton2 = $("#header-button-2");
+	test( "header buttons should have the header class", function() {
+		var headerButton1 = $("#header-button-1"),
+		    headerButton2 = $("#header-button-2");
 
-            ok((headerButton1.hasClass("ui-btn-left") &&
-                headerButton2.hasClass("ui-btn-right")), "first header button should have class 'ui-btn-left' and the second one should have 'ui-btn-right'");
-        });
+		ok((headerButton1.hasClass("ui-btn-left") &&
+		    headerButton2.hasClass("ui-btn-right")), "first header button should have class 'ui-btn-left' and the second one should have 'ui-btn-right'");
+	});
 
 	test( "control group buttons should be enhanced inside a footer", function(){
 		var group, linkCount;

--- a/tests/unit/buttonMarkup/buttonMarkup_core.js
+++ b/tests/unit/buttonMarkup/buttonMarkup_core.js
@@ -5,13 +5,11 @@
 	module("jquery.mobile.buttonMarkup.js");
 
         test( "header buttons should have the header class", function() {
-            var isOk = true;
+            var headerButton1 = $("#header-button-1"),
+                headerButton2 = $("#header-button-2");
 
-            $.each($("#page-header").find("a"), function(key, value) {
-                if (!($(value).hasClass("ui-btn-left") || $(value).hasClass("ui-btn-right")))
-                    isOk = false;
-            });
-            ok(isOk, "links in the header should have either 'ui-btn-left' or 'ui-btn-right' among their classes");
+            ok((headerButton1.hasClass("ui-btn-left") &&
+                headerButton2.hasClass("ui-btn-right")), "first header button should have class 'ui-btn-left' and the second one should have 'ui-btn-right'");
         });
 
 	test( "control group buttons should be enhanced inside a footer", function(){

--- a/tests/unit/buttonMarkup/buttonMarkup_core.js
+++ b/tests/unit/buttonMarkup/buttonMarkup_core.js
@@ -4,6 +4,16 @@
 (function($){
 	module("jquery.mobile.buttonMarkup.js");
 
+        test( "header buttons should have the header class", function() {
+            var isOk = true;
+
+            $.each($("#page-header").find("a"), function(key, value) {
+                if (!($(value).hasClass("ui-btn-left") || $(value).hasClass("ui-btn-right")))
+                    isOk = false;
+            });
+            ok(isOk, "links in the header should have either 'ui-btn-left' or 'ui-btn-right' among their classes");
+        });
+
 	test( "control group buttons should be enhanced inside a footer", function(){
 		var group, linkCount;
 

--- a/tests/unit/buttonMarkup/index.html
+++ b/tests/unit/buttonMarkup/index.html
@@ -39,7 +39,8 @@
 
 <div data-nstest-role="page" id="default">
   <div data-nstest-role="header" id="page-header">
-    <a data-role="button" href="index.html">Header button</a>
+    <a id="header-button-1" data-role="button" href="index.html">Header button 1</a>
+    <a id="header-button-2" data-role="button" href="index.html">Header button 2</a>
   </div>
   <div data-nstest-role="content" id="control-group-content">
     <input type="submit" data-nstest-role="button" value="Double Enhanced?" id="double-enhanced" />

--- a/tests/unit/buttonMarkup/index.html
+++ b/tests/unit/buttonMarkup/index.html
@@ -38,6 +38,9 @@
 </ol>
 
 <div data-nstest-role="page" id="default">
+  <div data-nstest-role="header" id="page-header">
+    <a data-role="button" href="index.html">Header button</a>
+  </div>
   <div data-nstest-role="content" id="control-group-content">
     <input type="submit" data-nstest-role="button" value="Double Enhanced?" id="double-enhanced" />
     <a href="index.html" data-nstest-role="button" data-nstest-shadow="false">No shadow</a>


### PR DESCRIPTION
...he next call

Also fixes another bug:

In the functional test, perform these steps:
1. Set icon to "arrow-r" and inline to true - apply these two.
2. Set shadow to false and apply this one.
3. Set icon to "arrow-r" and apply this one.

At this point, the &lt;a&gt;-based button gets a shadow, whereas the other two do not. I found that this is because at the top, where the options are merged, el.jqmData("shadow") returns true even though I have set .attr("data-" + $.mobile.ns + "shadow", false) ... the fix is to also set el.jqmData(key, value) for all resulting options.
