### PR TITLE
Soften loading spinner when text is visible

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -32,7 +32,7 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 .ui-loader-default h1 { font-size: 0; width: 0; height: 0; overflow: hidden; }
 .ui-loader-verbose h1 { font-size: 16px; margin: 0; text-align: center; }
 .ui-loader .ui-icon { background-color: #000; display: block; margin: 0; width: 44px; height: 44px; padding: 1px; -webkit-border-radius: 36px; -moz-border-radius: 36px; border-radius: 36px; }
-.ui-loader-verbose .ui-icon { margin: 0 auto 10px; }
+.ui-loader-verbose .ui-icon { margin: 0 auto 10px; opacity: .75; }
 .ui-loader-textonly { padding: 15px; margin-left: -115px;  }
 .ui-loader-textonly .ui-icon { display: none; }
 .ui-loader-fakefix { position: absolute; }


### PR DESCRIPTION
Loading spinner is a little harsh when text is visible.  Reducing opacity to soften the appearance.  See [this tweet](https://twitter.com/jquerymobile/status/170339127366131713).
