### PR TITLE
[buttonMarkup] Correctly re-enhance links

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -8,11 +8,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.vmouse" ], function
 
 $.fn.buttonMarkup = function( options ) {
 	var self = this,
-	    $workingSet = this.filter( function( i, el ) {
-	        return !self.eq( i ).hasClass( "ui-btn" );
-	    });
-
-	$workingSet = $.mobile.enhanceable( $workingSet );
+	    $workingSet = $.mobile.enhanceable( this );
 
 	// Enforce options to be of type string
 	options = ( options && ( $.type( options ) == "object" ) )? options : {};


### PR DESCRIPTION
There should be no reason to filter stuff that's already enhanced, since buttonMarkup now correctly handles the case where the elements passed in have been enhanced in a previous call.
