### PR TITLE
conform to strict mode

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -294,7 +294,7 @@ define( [ "jquery", "../external/requirejs/text!../version.txt", "./jquery.mobil
 	$.find.matchesSelector = function( node, expr ) {
 		return $.find( expr, null, null, [ node ] ).length > 0;
 	};
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -92,7 +92,7 @@ $( document ).delegate( $.mobile.dialog.prototype.options.initSelector, "pagecre
 	$.mobile.dialog.prototype.enhance( this );
 });
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -349,7 +349,7 @@ $.each({
 	};
 });
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -64,7 +64,7 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 					mini: mini
 				});
 
-			function toggleClear() {
+			var toggleClear = function() {
 				setTimeout(function() {
 					clearbtn.toggleClass( "ui-input-clear-hidden", !input.val() );
 				}, 0);

--- a/js/jquery.mobile.hashchange.js
+++ b/js/jquery.mobile.hashchange.js
@@ -382,4 +382,4 @@
     return self;
   })();
   
-})(jQuery,window);
+})( jQuery, window );

--- a/js/jquery.mobile.hashchange.js
+++ b/js/jquery.mobile.hashchange.js
@@ -382,4 +382,4 @@
     return self;
   })();
   
-})(jQuery,this);
+})(jQuery,window);

--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -182,7 +182,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.support", "./jquery
 		// hide iOS browser chrome on load
 		$window.load( $.mobile.silentScroll );
 	});
-}( jQuery, this ));
+}( jQuery, window ));
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.navigation.pushstate.js
+++ b/js/jquery.mobile.navigation.pushstate.js
@@ -156,7 +156,7 @@ define( [ "jquery", "./jquery.mobile.navigation", "../external/requirejs/depend!
 			pushStateHandler.init();
 		}
 	});
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -49,7 +49,7 @@ function validStyle( prop, value, check_vend ) {
 		check_vends = check_vend ? [ check_vend ] : vendors,
 		ret;
 
-	for( i = 0; i < check_vends.length; i++ ) {
+	for( var i = 0; i < check_vends.length; i++ ) {
 		check_style( check_vends[i] );
 	}
 	return !!ret;

--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -47,9 +47,10 @@ function validStyle( prop, value, check_vend ) {
 			}
 		},
 		check_vends = check_vend ? [ check_vend ] : vendors,
+		check_vends_length = check_vends.length,
 		ret;
 
-	for( var i = 0; i < check_vends.length; i++ ) {
+	for( var i = 0; i < check_vends_length; i++ ) {
 		check_style( check_vends[i] );
 	}
 	return !!ret;

--- a/js/jquery.mobile.transition.flip.js
+++ b/js/jquery.mobile.transition.flip.js
@@ -12,7 +12,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.flip = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.flow.js
+++ b/js/jquery.mobile.transition.flow.js
@@ -12,7 +12,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.flow = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.js
+++ b/js/jquery.mobile.transition.js
@@ -1,4 +1,3 @@
-
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 //>>description: Page change transition core
 //>>label: Transition Core
@@ -84,7 +83,7 @@ $.mobile.transitionHandlers = {
 
 $.mobile.transitionFallbacks = {};
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.pop.js
+++ b/js/jquery.mobile.transition.pop.js
@@ -12,7 +12,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.pop = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.slide.js
+++ b/js/jquery.mobile.transition.slide.js
@@ -12,7 +12,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.slide = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.slidedown.js
+++ b/js/jquery.mobile.transition.slidedown.js
@@ -12,7 +12,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.slidedown = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.slideup.js
+++ b/js/jquery.mobile.transition.slideup.js
@@ -12,7 +12,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.slideup = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.turn.js
+++ b/js/jquery.mobile.transition.turn.js
@@ -13,7 +13,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.turn = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.zoom.iosorientationfix.js
+++ b/js/jquery.mobile.zoom.iosorientationfix.js
@@ -37,7 +37,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.zoom" ], function( 
 		.bind( "orientationchange.iosorientationfix", zoom.enable )
 		.bind( "devicemotion.iosorientationfix", checkTilt );
 
-}( jQuery, this ));
+}( jQuery, window ));
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");


### PR DESCRIPTION
I checked jQuery mobile with a prepended "use strict"; in Chrome.
Though I didn't leave it there, I fixed all errors preventing strict mode.
In my experience, strict mode serves as a very good alternative to a linter.
The most important change was in jquery.mobile.support.js, where the for-loops increment variable leaked into the global namespace.
