### PR TITLE
Optionally allow HTML markup in $.mobile.loadingMessage

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -67,13 +67,24 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.support", "./jquery
 					// text visibility from argument takes priority
 					textVisible = textonly || $.mobile.loadingMessageTextVisible;
 					
-
-				$loader
-					.attr( "class", loaderClass + " ui-corner-all ui-body-" + ( theme || "a" ) + " ui-loader-" + ( textVisible ? "verbose" : "default" ) + ( textonly ? " ui-loader-textonly" : "" ) )
-					.find( "h1" )
-						.text( msgText || $.mobile.loadingMessage )
-						.end()
-					.appendTo( $.mobile.pageContainer );
+				// tcaddy fork customization -- optionally show HTML instead of text
+				if ( (typeof($.mobile.loadingMessageHTML)!=='undefined') && $.mobile.loadingMessageHTML ) {
+					$loader
+						.attr( "class", loaderClass + " ui-corner-all ui-body-" + ( theme || "a" ) + " ui-loader-" + ( textVisible ? "verbose" : "default" ) + ( textonly ? " ui-loader-textonly" : "" ) )
+						.find( "h1" )
+							.html( msgText || $.mobile.loadingMessage )
+							.end()
+						.appendTo( $.mobile.pageContainer );
+				} else {
+					// this is the default jQuery Mobile way of doing it
+					$loader
+						.attr( "class", loaderClass + " ui-corner-all ui-body-" + ( theme || "a" ) + " ui-loader-" + ( textVisible ? "verbose" : "default" ) + ( textonly ? " ui-loader-textonly" : "" ) )
+						.find( "h1" )
+							.text( msgText || $.mobile.loadingMessage )
+							.end()
+						.appendTo( $.mobile.pageContainer );
+				}
+				
 					
 				checkLoaderPosition();
 				$window.bind( "scroll", checkLoaderPosition );


### PR DESCRIPTION
Check to see if $.mobile.loadingMessageHTML is undefined and if it is true. If so, allow HTML markup in $.mobile.loadingMessage

By default, don't show HTML (this is how jQuery Mobile works right now anyway).
