### PR TITLE
[buttonMarkup] $.mobile.enhanceable is no longer being called

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -7,8 +7,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.vmouse" ], function
 ( function( $, undefined ) {
 
 $.fn.buttonMarkup = function( options ) {
-	var self = this,
-	    $workingSet = $.mobile.enhanceable( this );
+	var $workingSet = this;
 
 	// Enforce options to be of type string
 	options = ( options && ( $.type( options ) == "object" ) )? options : {};


### PR DESCRIPTION
In the commit just prior to the PR #3604 merge (d0e82cdc0df498695f9a08a129543d45391d5337), $.mobile.enhanceable is no longer called to filter the list of buttons to be enhanced, however, the merge of PR#3604 caused that call to be re-introduced.

This fixes that.
