### PR TITLE
Update js/jquery.mobile.support.js

### DIFF
--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -111,7 +111,7 @@ $.extend( $.support, {
 	cssPseudoElement: !!propExists( "content" ),
 	touchOverflow: !!propExists( "overflowScrolling" ),
 	cssTransform3d: transform3dTest(),
-	boxShadow: !!propExists( "boxShadow" ) && !bb,
+	boxShadow: !!propExists( "boxShadow" ) && !bb && !operamini,
 	scrollTop: ( "pageXOffset" in window || "scrollTop" in document.documentElement || "scrollTop" in fakeBody[ 0 ] ) && !webos && !operamini,
 	dynamicBaseTag: baseTagTest()
 });


### PR DESCRIPTION
Opera Mini does not support box shadow, but it is passing the test anyway.
