### PR TITLE
Update css/structure/jquery.mobile.core.css 

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -62,11 +62,6 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 /* icons sizing */
 .ui-icon { width: 18px; height: 18px; }
 
-/* fluid images */
-.ui-mobile img {
-	max-width: 100%;
-}
-
 /* non-js content hiding */
 .ui-nojs { position: absolute; left: -9999px; }
 


### PR DESCRIPTION
removed fluid images:
/\* fluid images */
.ui-mobile img {
    max-width: 100%;
}
as this was causing a conflict with google maps api v3. 
I will add this to the docs.css

should fix #3624
