### PR TITLE
Fix for #3482: radio boxes "not working" in master ("checked" is cleared inappropriately)

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -80,6 +80,12 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				}
 
 				self._cacheVals();
+				
+				// Input set for common radio buttons will contain all the radio
+				// buttons, but will not for checkboxes. clearing the checked status
+				// of other radios ensures the active button state is applied properly
+				self._getInputSet().not( input ).removeAttr( "checked" );
+				
 				input.attr( "checked", inputtype === "radio" && true || !input.attr( "checked" ) );
 				//input.prop( "checked", inputtype === "radio" && true || !input.attr( "checked" ) );
 
@@ -89,11 +95,6 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 				//       through to the associate input. we can swallow that click at the parent
 				//       wrapper element level
 				input.triggerHandler( 'click' );
-
-				// Input set for common radio buttons will contain all the radio
-				// buttons, but will not for checkboxes. clearing the checked status
-				// of other radios ensures the active button state is applied properly
-				self._getInputSet().not( input ).removeAttr( "checked" );
 
 				self._updateAll();
 				return false;


### PR DESCRIPTION
I tested this fix on the newest master and it works well for me. Without this fix all my radiobox validation code, etc fails, because things like .filter(":checked") yield a blank list (the only time when they don't is when the form is first loaded and hasn't been changed yet, and the first radio button option is selected)
