### PR TITLE
Popup stack management

### DIFF
--- a/docs/pages/popup/index.html
+++ b/docs/pages/popup/index.html
@@ -71,13 +71,30 @@
 
 		<div data-role="popup" id="popupMenu" data-overlay-theme="b">
 				<ul data-role="listview" data-inset="true" style="width:180px;" data-theme="b">
-					<li><a href="index.html">Add</a></li>
-					<li><a href="index.html">Edit</a></li>
-					<li><a href="index.html">Manage</a></li>
-					<li><a href="index.html">Delete</a></li>
+					<li><a data-rel="popup" href="#popupMenuLevel1">Add</a></li>
+					<li><a data-rel="popup" href="#popupMenuLevel1">Edit</a></li>
+					<li><a data-rel="popup" href="#popupMenuLevel1">Manage</a></li>
+					<li><a data-rel="popup" href="#popupMenuLevel1">Delete</a></li>
 				</ul>
 		</div>
-		
+
+		<div data-role="popup" id="popupMenuLevel1" data-overlay-theme="b">
+				<ul data-role="listview" data-inset="true" style="width:180px;" data-theme="b">
+					<li><a data-rel="popup" href="#popupMenuLevel2">Remove</a></li>
+					<li><a data-rel="popup" href="#popupMenuLevel2">Undo</a></li>
+					<li><a data-rel="popup" href="#popupMenuLevel2">Splice</a></li>
+					<li><a data-rel="popup" href="#popupMenuLevel2">Reticulate</a></li>
+				</ul>
+		</div>		
+
+		<div data-role="popup" id="popupMenuLevel2" data-overlay-theme="b">
+				<ul data-role="listview" data-inset="true" style="width:180px;" data-theme="b">
+					<li><a href="index.html">Basics</a></li>
+					<li><a href="options.html">Options</a></li>
+					<li><a href="methods.html">Methods</a></li>
+					<li><a href="events.html">Events</a></li>
+				</ul>
+		</div>		
 
 		<div data-role="popup" id="popupLogin" data-overlay-theme="b" data-theme="a" class="ui-corner-all">
 			<form>

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -199,21 +199,6 @@ define( [ "jquery",
 			$( window ).unbind( "hashchange.popup" );
 		},
 
-		_onPageBeforeChange: function( e, data ) {
-			if ( typeof( data.toPage ) === "object" && data.toPage.jqmData( "url" ) !== $.mobile.activePage.jqmData( "url" ) ) {
-				// Prevent the changePage from happening
-				e.preventDefault();
-				e.stopImmediatePropagation();
-
-				setTimeout( function() {
-					// Resume the changePage
-					$.mobile.changePage( data.toPage, data.options );
-				}, 250);
-
-				this.close();
-			}
-		},
-
 		open: function( x, y ) {
 			if ( !this._isOpen ) {
 				var self = this,
@@ -251,8 +236,6 @@ define( [ "jquery",
 				$( window ).one( "hashchange", function() {
 					self._bindHashChange();
 				});
-
-				$( window ).bind( "pagebeforechange.popup", $.proxy( this, "_onPageBeforeChange" ) );
 
 				// set hash to non-linkable dialog url
 				$.mobile.path.set( ( ( $.mobile.activePage != $.mobile.firstPage) ? $.mobile.urlHistory.getActive().url : "" ) + "&ui-state=dialog" );
@@ -294,7 +277,6 @@ define( [ "jquery",
 
 				// unbind listener that comes with opening popup
 				this._unbindHashChange();
-				$( window ).unbind( "pagebeforechange.popup" );
 
 				// if the close event did not come from an internal hash listener, reset URL back
 				if ( !fromHash ) {

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -188,17 +188,6 @@ define( [ "jquery",
 			return { x: newleft, y: newtop };
 		},
 
-		_bindHashChange: function() {
-			var self = this;
-			$( window ).one( "hashchange.popup", function() {
-				self.close( true );
-			});
-		},
-
-		_unbindHashChange: function() {
-			$( window ).unbind( "hashchange.popup" );
-		},
-
 		open: function( x, y ) {
 			if ( !this._isOpen ) {
 				var self = this,
@@ -232,19 +221,11 @@ define( [ "jquery",
 					onAnimationComplete();
 				}
 
-				// listen for hashchange that will occur when we set it to null dialog hash
-				$( window ).one( "hashchange", function() {
-					self._bindHashChange();
-				});
-
-				// set hash to non-linkable dialog url
-				$.mobile.path.set( ( ( $.mobile.activePage != $.mobile.firstPage) ? $.mobile.urlHistory.getActive().url : "" ) + "&ui-state=dialog" );
-
 				this._isOpen = true;
 			}
 		},
 
-		close: function( fromHash ) {
+		close: function( ) {
 			if ( this._isOpen ) {
 				var self = this,
 					onAnimationComplete = function() {
@@ -273,14 +254,6 @@ define( [ "jquery",
 					this._ui.screen.animate( {opacity: 0.0}, "fast", hideScreen );
 				} else {
 					hideScreen();
-				}
-
-				// unbind listener that comes with opening popup
-				this._unbindHashChange();
-
-				// if the close event did not come from an internal hash listener, reset URL back
-				if ( !fromHash ) {
-					window.history.back();
 				}
 			}
 		}

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -303,7 +303,7 @@ define( [ "jquery",
 		},
 
 		_removeListener: function() {
-			$( window ).unbind( "hashchange.popupStackBinder hashchange.popupStack pagebeforechange.popupStack" );
+			$( window ).unbind( "hashchange.popupStackBinder hashchange.popupStack" );
 		},
 
 		_installListener: function(direct) {
@@ -323,10 +323,6 @@ define( [ "jquery",
 					realInstallListener();
 				});
 			}
-
-			$( window ).bind( "pagebeforechange.popupStack", function( e, data ) {
-				self._handlePBC( e, data );
-			});
 		},
 
 		_handleHashChange: function() {
@@ -338,12 +334,6 @@ define( [ "jquery",
 			if ( this._currentPopup ) {
 				this._afterPop( this._currentPopup );
 				this._currentPopup = undefined;
-			}
-		},
-
-		_handlePBC: function( e, data ) {
-			if ( typeof data.toPage === "object" && data.toPage.jqmData( "url" ) === this._baseUrl ) {
-				$.mobile.urlHistory.activeIndex = Math.max( 0, $.mobile.urlHistory.activeIndex - 1 );
 			}
 		}
 	};

--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -271,11 +271,15 @@ define( [ "jquery",
 			this._stack.push( popup );
 
 			if ( 1 === this._stack.length ) {
-				var activeEntry = $.mobile.urlHistory.getActive();
+				var activeEntry = $.mobile.urlHistory.getActive(),
+				    hasHash = ( activeEntry.url.indexOf( $.mobile.dialogHashKey ) > -1 );
 
-				this._installListener();
-				$.mobile.path.set( this._getPathPrefix() + $.mobile.dialogHashKey );
-				$.mobile.urlHistory.addNew( activeEntry.url + $.mobile.dialogHashKey, activeEntry.transition, activeEntry.title, activeEntry.pageUrl, activeEntry.role );
+				this._installListener(hasHash);
+
+				if ( !hasHash ) {
+					$.mobile.path.set( $.mobile.urlHistory.getActive().url + $.mobile.dialogHashKey );
+					$.mobile.urlHistory.addNew( activeEntry.url + $.mobile.dialogHashKey, activeEntry.transition, activeEntry.title, activeEntry.pageUrl, activeEntry.role );
+				}
 			}
 		},
 
@@ -302,22 +306,27 @@ define( [ "jquery",
 			$( window ).unbind( "hashchange.popupStackBinder hashchange.popupStack pagebeforechange.popupStack" );
 		},
 
-		_installListener: function() {
+		_installListener: function(direct) {
 			var self = this;
 
-			$( window ).one( "hashchange.popupStackBinder", function() {
+			function realInstallListener() {
 				$( window ).one( "hashchange.popupStack", function() {
 					self._handleHashChange();
 				});
-			});
+			}
+
+			if ( direct ) {
+				realInstallListener();
+			}
+			else {
+				$( window ).one( "hashchange.popupStackBinder", function() {
+					realInstallListener();
+				});
+			}
 
 			$( window ).bind( "pagebeforechange.popupStack", function( e, data ) {
 				self._handlePBC( e, data );
 			});
-		},
-
-		_getPathPrefix: function() {
-			return ( ( $.mobile.activePage != $.mobile.firstPage ) ? $.mobile.urlHistory.getActive().url : "" );
 		},
 
 		_handleHashChange: function() {


### PR DESCRIPTION
When opening one popup from another popup, correctly set the history, and make it possible to close popups by clicking "Back". This is done in one of two ways:
1. When the first popup is shown, `#&ui-state=dialog` is appended to the location, and all subsequent popups do not modify the location further. When the user clicks "Back", all popups disappear. Otherwise, if the last popup is closed, `window.history.back()` is called to restore the pre-hash-change URL.
2. When the first popup is shown, `#jqmNPopups=1` is appended to the location, and all subsequent popups modify this location by replacing the hash with `#jqmNPopups=n`, where n is the number of popups currently in the stack. When the user clicks "Back", the last popup in the stack is removed. Similarly, when the user closes a popup, `window.history.back()` is called.

Both of these methods are implemented, and both support the closing of popups out of stack order. One can be chosen by setting `$.mobile.popupsHaveOneHistoryEntry` to either true or false.
