### PR TITLE
Collapsible adds top, bottom corner classes to all .ui-btn-inner elements

### DIFF
--- a/js/jquery.mobile.collapsible.js
+++ b/js/jquery.mobile.collapsible.js
@@ -71,7 +71,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 					mini: o.mini,
 					theme: o.theme
 				})
-			.add( ".ui-btn-inner" )
+			.add( ".ui-btn-inner", $el )
 				.addClass( "ui-corner-top ui-corner-bottom" );
 
 		//events


### PR DESCRIPTION
Creating a collapsible widget adds "ui-corner-top" and "ui-corner-bottom" classes to all "ui-btn-inner" elements in the DOM, rather than just to the collapsible header. Setting the context for which ui-btn-inner to change the class on fixes the problem for me.

Example with 1.0.1: http://jsbin.com/ucijek/4
"Collapsible" in the navbar opens a page with collapsible widgets. When you return to the first page, the corners on the navbar buttons are rounded.

Example with the fix: http://jsbin.com/odexog/2
