### PR TITLE
Fixes #3724: Inaccurate documentation for fullscreen toolbars

### DIFF
--- a/docs/toolbars/bars-fullscreen.html
+++ b/docs/toolbars/bars-fullscreen.html
@@ -28,7 +28,7 @@
 	
 		<p class="ui-body">This page demonstrates the "fullscreen" toolbar mode. This toolbar treatment is used in special cases where you want the content to fill the whole screen, and you want the header and footer toolbars to appear and disappear when the page is clicked responsively &mdash; a common scenario for photo, image or video viewers.</p>
 		
-		<p class="ui-body">To enable this toolbar feature type, you apply a <code>data-fullscreen="true"</code> attribute to the <code>div</code> container that has the attribute <code>data-role="page"</code>, and the <code>data-position="fixed"</code> attribute to both the header and footer <code>div</code> elements. </p>
+		<p class="ui-body">To enable this toolbar feature type, you apply the <code>data-fullscreen="true"</code> attribute and the <code>data-position="fixed"</code> attribute to both the header and footer <code>div</code> elements. </p>
 		
 		<p class="ui-body">Keep in mind that the toolbars in this mode will sit <strong>over</strong> page content, so not all content will be accessible with the toolbars open, just as shown in this demo.</p>
 			       


### PR DESCRIPTION
To add fullscreen toolbars, data-fullscreen="true" should be added to the header and footer divs rather than to the parent page element.
