### PR TITLE
Issue #3749 - missing css for ui-footer

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -46,7 +46,9 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 
 .ui-header, .ui-footer { position: relative; overflow: hidden; border-left-width: 0; border-right-width: 0; }
 .ui-header .ui-btn-left,
-.ui-header .ui-btn-right { position: absolute; top: -5px; }
+.ui-header .ui-btn-right,
+.ui-footer .ui-btn-left,
+.ui-footer .ui-btn-right { position: absolute; top: -5px; }
 .ui-header .ui-btn-left,
 .ui-footer .ui-btn-left { left: 5px; }
 .ui-header .ui-btn-right,


### PR DESCRIPTION
Looks like the css was missing references to these two?

I tried adding this inline to the above example, and took care of it.

<pre>
   <style>
  .ui-footer .ui-btn-left, .ui-footer .ui-btn-right {
    position: absolute;
    top: -5px;
}
    </style>
</pre>


Here's my quick little css change to base.
