### PR TITLE
Prevented ugly wrapping of option text on wider flip switch example

### DIFF
--- a/docs/forms/switch/index.html
+++ b/docs/forms/switch/index.html
@@ -60,7 +60,7 @@
 			<p>The control is proportionally scaled, so if you're using longer words with it, you can just add a line of CSS to set it to the width you desire. For example, <code>div.ui-slider-switch { width: 9em }</code> will produce:</p>
 		
 			<style type="text/css" media="screen">
-			.switch-longdesc div.ui-slider-switch { width: 9em; }
+			.switch-longdesc div.ui-slider-switch { width: 9em; white-space: nowrap; }
 			</style>
 			<div class="switch-longdesc">
 				<label for="flip-min">Flip switch:</label>


### PR DESCRIPTION
To reproduce, go [here](http://jquerymobile.com/test/docs/forms/switch/) and drag the second example back and forth.  The words "on" and "off" drop down below the flip switch because of the breakable space that precedes them.
