### PR TITLE
Always show vertical scroll bar on .ui-mobile-viewport container

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -7,7 +7,7 @@
 .ui-mobile-viewport {  margin: 0; overflow-x: visible; -webkit-text-size-adjust: none; -ms-text-size-adjust:none; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
 /* Issue #2066 */
 body.ui-mobile-viewport,
-div.ui-mobile-viewport { overflow-x: hidden; }
+div.ui-mobile-viewport { overflow-x: hidden; overflow-y: scroll; }
 
 /* "page" containers - full-screen views, one should always be in view post-pageload */
 .ui-mobile [data-role=page], .ui-mobile [data-role=dialog], .ui-page { top: 0; left: 0; width: 100%; min-height: 100%; position: absolute; display: none; border: 0; }


### PR DESCRIPTION
This patch prevents horizontal "jumps" in desktop browsers when a transition happens between a page that is higher than the viewport (i.e. has a scoll bar) and one that is not. If the scroll bar is not enforced it appears only after the transition finishes which causes a reflow and content "jumping" to the left.
