### PR TITLE
Select placeholder fix

### DIFF
--- a/docs/forms/selects/custom.html
+++ b/docs/forms/selects/custom.html
@@ -283,8 +283,9 @@ $.mobile.selectmenu.prototype.options.hidePlaceholderMenuItems = false;
 	<div data-role="fieldcontain">
 		<label for="select-choice-8" class="select">Shipping method:</label>
 		<select name="select-choice-8" id="select-choice-8" data-native-menu="false">
+			<option>Choose shipping method</option>
 			<optgroup label="USPS">
-				<option value="standard">Standard: 7 day</option>
+				<option value="standard" selected>Standard: 7 day</option>
 				<option value="rush">Rush: 3 days</option>
 				<option value="express">Express: next day</option>
 				<option value="overnight">Overnight</option>

--- a/js/jquery.mobile.forms.select.custom.js
+++ b/js/jquery.mobile.forms.select.custom.js
@@ -437,6 +437,7 @@ define( [
 				var self = this,
 					o = this.options,
 					placeholder = this.placeholder,
+					needPlaceholder = true,
 					optgroups = [],
 					lis = [],
 					dataIcon = self.isMultiple ? "checkbox-off" : "false";
@@ -476,15 +477,18 @@ define( [
 							fragment.appendChild(divider);
 							optGroup = optLabel;
 						}
-					}															
-										
-					if (!placeholder && (!option.getAttribute( "value" ) || text.length == 0 || $option.jqmData( "placeholder" )) ) {
+					}
+
+					if (needPlaceholder && (!option.getAttribute( "value" ) || text.length == 0 || $option.jqmData( "placeholder" ))) {
+						needPlaceholder = false;
 						if ( o.hidePlaceholderMenuItems ) {
 							classes.push( "ui-selectmenu-placeholder" );
-						}						
-						placeholder = self.placeholder = text;									
+						}
+						if (!placeholder) {
+							placeholder = self.placeholder = text;
+						}
 					}
-															
+
 					var item = document.createElement('li');															
 					if ( option.disabled ) {
 						classes.push( "ui-disabled" );

--- a/tests/unit/select/index.html
+++ b/tests/unit/select/index.html
@@ -364,6 +364,23 @@
   <select name="keep-native" id="keep-native" class="should-be-native">
     <option></option>
   </select>
+
+	<div data-nstest-role="fieldcontain" id="optgroup-and-placeholder-container">
+		<select name="optgroup-and-placeholder" id="optgroup-and-placeholder" data-nstest-native-menu="false">
+			<option>Choose shipping method</option>
+			<optgroup label="USPS">
+				<option value="standard" selected>Standard: 7 day</option>
+				<option value="rush">Rush: 3 days</option>
+				<option value="express">Express: next day</option>
+				<option value="overnight">Overnight</option>
+			</optgroup>
+			<optgroup label="FedEx">
+				<option value="firstOvernight">First Overnight</option>
+				<option value="expressSaver">Express Saver</option>
+				<option value="ground">Ground</option>
+			</optgroup>
+		</select>
+	</div>
 </div>
 
 

--- a/tests/unit/select/select_core.js
+++ b/tests/unit/select/select_core.js
@@ -27,6 +27,26 @@
 		}
 	});
 
+	asyncTest( "placeholder correctly gets ui-selectmenu-placeholder class after rebuilding", function(){
+		$.testHelper.sequence([
+			function(){
+				// bring up the optgroup menu
+				ok($("#optgroup-and-placeholder-container a").length > 0, "there is in fact a button in the page");
+				$("#optgroup-and-placeholder-container a").trigger("click");
+			},
+
+			function(){
+				//select the first menu item
+				$("#optgroup-and-placeholder-menu a:first").click();
+			},
+
+			function(){
+				ok($("#optgroup-and-placeholder-menu li:first").hasClass("ui-selectmenu-placeholder"), "the placeholder item has the ui-selectmenu-placeholder class");
+				start();
+			}
+		], 1000);
+	});
+
 	asyncTest( "firing a click at least 400 ms later on the select screen overlay does close it", function(){
 		$.testHelper.sequence([
 			function(){


### PR DESCRIPTION
The placeholder ends up in the list of choices when you have optgroups, because `_buildList()` gets called when the user makes a choice. This does not happen when there are no optgroups.

Includes a unit test to make sure the placeholder acquires the ui-selectmenu-placeholder class after the user-choice-induced rebuild.
