### PR TITLE
unneeded scrolling when content is shorter then available height

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -519,9 +519,17 @@ define( [
 	function resetActivePageHeight(){
 		var aPage = $( "." + $.mobile.activePageClass ),
 			aPagePadT = parseFloat( aPage.css( "padding-top" ) ),
-			aPagePadB = parseFloat( aPage.css( "padding-bottom" ) );
-				
-		aPage.css( "min-height", getScreenHeight() - aPagePadT - aPagePadB );
+			aPagePadB = parseFloat( aPage.css( "padding-bottom" ) ),
+			headHeight = aPage.find('[data-role="header"]').height(),
+			footHeight = aPage.find('[data-role="footer"]').height(),
+			contentHeight = aPage.find('[data-role="content"]').height();
+		//check to see if content is shorter then avalible area
+		//if it is set height to avoid unneeded scrolling
+		if(contentHeight + headHeight + footHeight <= $.mobile.getScreenHeight()){
+			aPage.css({'min-height':'0',height:contentHeight});
+		} else {
+			aPage.css( "min-height", getScreenHeight() - aPagePadT - aPagePadB );
+		}
 	}
 
 	//shared page enhancements


### PR DESCRIPTION
if the content is shorter then the available height scrolling other then to reveal url bar is undesirable from a user stand point it just servers to potentially hide content for no reason. This adds a check to see if content is shorter then available space and if so sets height attribute of page to avoid scrolling.
i set up a demo of this at http://www.billdodgeautogroup.com/test notice you can scroll the 2 lines of content out of view when there is no reason for this scrolling down should be allowed to expose url but that's it.
