### PR TITLE
Documentation: Minor copyedit for grammar and punctuation 

### DIFF
--- a/docs/pages/page-links.html
+++ b/docs/pages/page-links.html
@@ -38,7 +38,7 @@
 			
 			<p>If the Ajax request fails, the framework will display a small error message overlay (styled in the "e" swatch) that disappears after a brief time so this doesn't break the navigation flow. View an <a href="notapage.html">example of the error message</a>.</p>
 			
-			<p><strong>Note:</strong> that you cannot link <strong>to</strong> multipage document with Ajax navigation active because the framework will only load the first page it finds, not the full set of internal pages. In these cases, you must link without Ajax (see next section) for a full page refresh to prevent potential hash collisions. There is currently a <a href="https://github.com/ToddThomson/jQuery-Mobile-Subpage-Widget" rel="external">subpage plugin</a> that makes it possible to load in multi-page documents.</p>
+			<p><strong>Note:</strong> You cannot link <strong>to</strong> a multipage document with Ajax navigation active because the framework will only load the first page it finds, not the full set of internal pages. In these cases, you must link without Ajax (see next section) for a full page refresh to prevent potential hash collisions. There is currently a <a href="https://github.com/ToddThomson/jQuery-Mobile-Subpage-Widget" rel="external">subpage plugin</a> that makes it possible to load in multi-page documents.</p>
 
 
 <h2>Linking without Ajax</h2>


### PR DESCRIPTION
Minor copyedit for grammar and punctuation in documentation file page-links.html 
