### PR TITLE
Documentation: Remove obsolete "until 1.0" information

### DIFF
--- a/docs/pages/page-transitions.html
+++ b/docs/pages/page-transitions.html
@@ -97,7 +97,7 @@
 &lt;a href=&quot;index.html&quot; <strong>data-transition=&quot;pop&quot;</strong>&gt;I'll pop&lt;/a&gt;
 </code></code>
 		
-		<p>When the Back button is pressed, the framework will automatically apply the reverse version of the transition that was used to show the page. To specify that the reverse version of a transition should be used, add the <code>data-direction="reverse"</code> attribute to a link. Note: (this was formerly <code>data-back="true"</code>, which will remain supported until 1.0)</p>
+		<p>When the Back button is pressed, the framework will automatically apply the reverse version of the transition that was used to show the page. To specify that the reverse version of a transition should be used, add the <code>data-direction="reverse"</code> attribute to a link.</p>
 				
 		<h2>Global configuration of transitions</h2>
 		


### PR DESCRIPTION
Removing sentence from page-transitions.html about something that "will remain supported until 1.0"
