### PR TITLE
Issue 3885 nested checkbox/radio inputs within labels

### DIFF
--- a/js/jquery.mobile.forms.checkboxradio.js
+++ b/js/jquery.mobile.forms.checkboxradio.js
@@ -42,6 +42,15 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 			return;
 		}
 
+		// check for <label><input /></label> structure
+		if (!label.length) {
+		  label = $(input).closest('label');
+		  // <label> is only implicitly for its first label-able descendant
+		  if (!label.find('button, input[type!="hidden"], keygen, meter, output, progress, select, textarea').first().is(input)) {
+		    label = $('');
+		  }
+		}
+		
 		if( !label.length ){
 			this.raise( inputtype + " inputs require a label for enhancement" );
 		}

--- a/tests/unit/checkboxradio/checkboxradio_core.js
+++ b/tests/unit/checkboxradio/checkboxradio_core.js
@@ -129,7 +129,7 @@
 		ok( !$("input.should-be-native").parent().is("div.ui-checkbox") );
 	});
 
-	test( "Elements with â€œdata-mini='true'â€� should have â€œui-miniâ€� class attached to enhanced element.", function(){
+	test( "Elements with \u201cdata-mini='true'\u201d should have \u201cui-mini\u201d class attached to enhanced element.", function(){
 		var full = document.getElementById("radio-full"),
 			$fulllbl = $('[for="radio-full"]'),
 			mini = document.getElementById("radio-mini"),

--- a/tests/unit/checkboxradio/checkboxradio_core.js
+++ b/tests/unit/checkboxradio/checkboxradio_core.js
@@ -129,7 +129,7 @@
 		ok( !$("input.should-be-native").parent().is("div.ui-checkbox") );
 	});
 
-	test( "Elements with “data-mini='true'” should have “ui-mini” class attached to enhanced element.", function(){
+	test( "Elements with â€œdata-mini='true'â€� should have â€œui-miniâ€� class attached to enhanced element.", function(){
 		var full = document.getElementById("radio-full"),
 			$fulllbl = $('[for="radio-full"]'),
 			mini = document.getElementById("radio-mini"),
@@ -249,18 +249,30 @@
 		}
 	});
 
-	test( "nested label checkbox still renders", function() {
-		var $checkbox = $( "#checkbox-nested-label" );
+  test( "nested label checkbox still renders", function() {
+    var $checkbox = $( "#checkbox-nested-label" );
 
-		try {
-			$checkbox.checkboxradio();
-		} catch (e) {
-			ok( false, "checkboxradio exception raised: " + e.toString());
-		}
+    try {
+      $checkbox.checkboxradio();
+    } catch (e) {
+      ok( false, "checkboxradio exception raised: " + e.toString());
+    }
 
-		ok( $checkbox.parent().hasClass("ui-checkbox"), "enhancement has occured");
-	});
-	
+    ok( $checkbox.parent().hasClass("ui-checkbox"), "enhancement has occured");
+  });
+  
+  test( "nested label (no [for]) checkbox still renders", function() {
+    var $checkbox = $( "#checkbox-nested-label-no-for" );
+
+    try {
+      $checkbox.checkboxradio();
+    } catch (e) {
+      ok( false, "checkboxradio exception raised: " + e.toString());
+    }
+
+    ok( $checkbox.parent().hasClass("ui-checkbox"), "enhancement has occured");
+  });
+  
 	test( "Icon positioning", function() {
 		var bottomicon = $("[for='bottomicon']")
 			topicon = $("[for='topicon']");

--- a/tests/unit/checkboxradio/index.html
+++ b/tests/unit/checkboxradio/index.html
@@ -190,5 +190,13 @@
 		</label>
 	</form>
 </div>
+
+<div id="nested-label-no-for-test">
+  <form>
+    <label>
+      <input type="checkbox" name="checkbox-nested-label-no-for" id="checkbox-nested-label-no-for" class="custom"/>
+    </label>
+  </form>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Here's my very first pull request so go easy on me. :)

This should (fingers crossed) help jQuery Mobile to deal with checkbox and radio input elements that are nested within their corresponding label element WITHOUT the usual id/for attribute relationship.

I've added a new unit test and made sure that all existing unit tests run.

Note that this only addresses checkbox and radio. I noticed that there are also potentially too-strict label assumptions being made in:
- jquery.mobile.forms.select.js
- jquery.mobile.forms.slider.js
- jquery.mobile.forms.textinput.js

The original ticket I filed (https://github.com/jquery/jquery-mobile/issues/3885) should probably not be closed until the fate of these other input fields has been decided. I did not feel comfortable fixing them in this pull request (a good commit is a small commit) and understand that there are likely some problematic layout concerns.
