### PR TITLE
Docs: API/Events - removed line about <html> getting class portrait/landscape

### DIFF
--- a/docs/api/events.html
+++ b/docs/api/events.html
@@ -100,7 +100,7 @@
 		<h2>Orientation change event</h2>
 		<dl>
 			<dt><code>orientationchange</code></dt>
-			<dd>Triggers when a device orientation changes (by turning it vertically or horizontally). When bound to this event, your callback function can leverage a second argument, which contains an <code>orientation</code> property equal to either "portrait" or "landscape". These values are also added as classes to the HTML element, allowing you to leverage them in your CSS selectors. Note that we currently bind to the resize event when <code>orientationchange</code> is not natively supported, or when <code>$.mobile.orientationChangeEnabled</code> is set to false.</dd>
+			<dd>Triggers when a device orientation changes (by turning it vertically or horizontally). When bound to this event, your callback function can leverage a second argument, which contains an <code>orientation</code> property equal to either "portrait" or "landscape". Note that we currently bind to the resize event when <code>orientationchange</code> is not natively supported, or when <code>$.mobile.orientationChangeEnabled</code> is set to false.</dd>
 			<div class="ui-body ui-body-e">
 				<h4>orientationchange timing</h4>
 


### PR DESCRIPTION
Removed line about the current orientation being added as class to the HTML element. This is no longer applicable since 1.0 if I'm not mistaken.
