### PR TITLE
Passing parameters between pages which are already exists in DOM

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -698,6 +698,7 @@ define( [
 		if ( page.length ) {
 			if ( !settings.reloadPage ) {
 				enhancePage( page, settings.role );
+				page.jqmData( "url", dataUrl );
 				deferred.resolve( absUrl, options, page );
 				return deferred.promise();
 			}


### PR DESCRIPTION
Hi

I've located the problem in the following part of jquery.navigation.js on line 977:

```
url = ( settings.dataUrl && path.convertUrlToDataUrl( settings.dataUrl ) ) || toPage.jqmData( "url" ),
```

I simply added page.jqmData("url", dataUrl) to the part of loadPage where it is decided to navigate to an existing page in the DOM.

The issue is described here https://github.com/azicchetti/jquerymobile-router/issues/31
