### PR TITLE
Fixes issue #3966

### DIFF
--- a/css/structure/jquery.mobile.button.css
+++ b/css/structure/jquery.mobile.button.css
@@ -23,30 +23,22 @@
 .ui-btn-icon-notext .ui-btn-text { position: absolute; left: -9999px; }
 
 .ui-btn-icon-left .ui-btn-inner { padding-left: 40px; }
-.ui-mini.ui-btn-icon-left .ui-btn-inner { padding-left: 30px; }
-
 .ui-btn-icon-right .ui-btn-inner { padding-right: 40px; }
-.ui-mini.ui-btn-icon-right .ui-btn-inner { padding-right: 30px; }
-
 .ui-btn-icon-top .ui-btn-inner { padding-top: 40px; }
-.ui-mini.ui-btn-icon-top .ui-btn-inner { padding-top: 30px; }
-
 .ui-btn-icon-bottom .ui-btn-inner { padding-bottom: 40px; }
-.ui-mini.ui-btn-icon-bottom .ui-btn-inner { padding-bottom: 30px; }
-
 
 .ui-header .ui-btn-icon-left .ui-btn-inner,
 .ui-footer .ui-btn-icon-left .ui-btn-inner,
-.ui-mini .ui-btn-icon-left .ui-btn-inner { padding-left: 28px; }
+.ui-mini .ui-btn-icon-left .ui-btn-inner { padding-left: 30px; }
 .ui-header .ui-btn-icon-right .ui-btn-inner,
 .ui-footer .ui-btn-icon-right .ui-btn-inner,
-.ui-mini .ui-btn-icon-right .ui-btn-inner { padding-right: 28px; }
+.ui-mini .ui-btn-icon-right .ui-btn-inner { padding-right: 30px; }
 .ui-header .ui-btn-icon-top .ui-btn-inner,
 .ui-footer .ui-btn-icon-top .ui-btn-inner,
-.ui-mini .ui-btn-icon-top .ui-btn-inner { padding: 28px 3px .5em 3px; }
+.ui-mini .ui-btn-icon-top .ui-btn-inner { padding: 30px 3px .5em 3px; }
 .ui-header .ui-btn-icon-bottom .ui-btn-inner,
 .ui-footer .ui-btn-icon-bottom .ui-btn-inner,
-.ui-mini .ui-btn-icon-bottom .ui-btn-inner { padding: .55em 3px 33px 3px; }
+.ui-mini .ui-btn-icon-bottom .ui-btn-inner { padding: .55em 3px 30px 3px; }
 
 /*btn icon positioning*/
 .ui-btn-icon-notext .ui-icon { display: block; z-index: 0;}
@@ -59,16 +51,20 @@
 
 .ui-header .ui-btn-icon-left .ui-icon,
 .ui-footer .ui-btn-icon-left .ui-icon,
-.ui-mini.ui-btn-icon-left .ui-icon { left: 5px; }
+.ui-mini.ui-btn-icon-left .ui-icon,
+.ui-mini .ui-btn-icon-left .ui-icon { left: 5px; }
 .ui-header .ui-btn-icon-right .ui-icon,
 .ui-footer .ui-btn-icon-right .ui-icon,
-.ui-mini.ui-btn-icon-right .ui-icon { right: 5px; }
+.ui-mini.ui-btn-icon-right .ui-icon,
+.ui-mini .ui-btn-icon-right .ui-icon { right: 5px; }
 .ui-header .ui-btn-icon-top .ui-icon,
 .ui-footer .ui-btn-icon-top .ui-icon,
-.ui-mini.ui-btn-icon-top .ui-icon { top: 5px; }
+.ui-mini.ui-btn-icon-top .ui-icon,
+.ui-mini .ui-btn-icon-top .ui-icon { top: 5px; }
 .ui-header .ui-btn-icon-bottom .ui-icon,
 .ui-footer .ui-btn-icon-bottom .ui-icon,
-.ui-mini.ui-btn-icon-bottom .ui-icon { bottom: 5px; }
+.ui-mini.ui-btn-icon-bottom .ui-icon,
+.ui-mini .ui-btn-icon-bottom .ui-icon { bottom: 5px; }
 
 /*hiding native button,inputs */
 .ui-btn-hidden { position: absolute; top: 0; left: 0; width: 100%; height: 100%; -webkit-appearance: button; opacity: .1; cursor: pointer; background: #fff; background: rgba(255,255,255,0); filter: Alpha(Opacity=.0001); font-size: 1px; border: none; text-indent: -9999px; }


### PR DESCRIPTION
Removed duplicate/conflicting rules for .ui-mini.ui-btn-icon-[pos] .ui-btn-inner padding:

30px is consistent with fullsize buttons, where there is a bit more space between icon and text than between icon and border. So I used the 30px instead of 28px for all mini buttons including header/footer buttons.
Note: header/footer buttons with icon position bottom had a padding-bottom of 33px which was different from the left/right/top positioned icons (padding 28px). In case of fullsize buttons this is 40px all around. With 30px padding I don't think there is any need to adjust it for bottom positioned icons.

Added ui-icon positioning rules for ui-mini controlgroup buttons:

The checkbox/radio plugin has an inheritAttr function which provides the buttons within the controlgroup with the same date-attributes (including data-role="mini"). Since this is not the case with regular buttons, only the controlgroup has class ui-mini and not the buttons.
As a quick fix I copied the .ui-mini.ui-btn-icon-[pos] .ui-icon {[pos]: 5px; } rules and added a space after .ui-mini. Better solution would probably be having the JS adding the ui-mini class to the buttons.

One more thing. I noticed the ui-fullsize class. Looking at the JS function I suppose this class is assigned when data-mini="false" is used on header/footer buttons. Looking at the CSS I only see one generic rule:
.ui-header/footer .ui-fullsize .ui-btn-inner { font-size: 16px; padding: .6em 25px; }
Shouldn't there be specific icon position rules for this as well?
