### PR TITLE
Fixes incorrect data iconpos value for split buttons

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -219,7 +219,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 								corners: false,
 								theme: itemTheme,
 								icon: false,
-								iconpos: false
+								iconpos: "notext"
 							})
 							.find( ".ui-btn-inner" )
 								.append(


### PR DESCRIPTION
Fixes incorrect icon position data attribute for split buttons.

[update: I changed the title so it includes the issue]
