### PR TITLE
Count-bubble positioning (part 2 of 2: select form)

### DIFF
--- a/css/structure/jquery.mobile.forms.select.css
+++ b/css/structure/jquery.mobile.forms.select.css
@@ -9,9 +9,14 @@
 @-moz-document url-prefix() {.ui-select .ui-btn select { opacity: 0.0001; }}
 .ui-select .ui-btn select.ui-select-nativeonly { opacity: 1; text-indent: 0; }
 
-.ui-select .ui-btn-icon-right .ui-btn-inner { padding-right: 45px; } 
-.ui-select .ui-btn-icon-right .ui-icon { right: 15px;  }
-.ui-select .ui-mini.ui-btn-icon-right .ui-icon { right: 7px;  }
+.ui-select .ui-btn-icon-right .ui-btn-inner, .ui-select .ui-li-has-count .ui-btn-inner { padding-right: 45px; }
+.ui-select .ui-btn-icon-right.ui-li-has-count .ui-btn-inner { padding-right: 78px; }
+.ui-select .ui-mini.ui-btn-icon-right .ui-btn-inner { padding-right: 31px; }
+.ui-select .ui-mini.ui-btn-icon-right.ui-li-has-count .ui-btn-inner { padding-right: 70px; }
+.ui-select .ui-btn-icon-right .ui-icon { right: 15px; }
+.ui-select .ui-mini.ui-btn-icon-right .ui-icon { right: 7px; }
+.ui-select .ui-btn-icon-right.ui-li-has-count .ui-li-count { right: 43px; }
+.ui-select .ui-mini.ui-btn-icon-right.ui-li-has-count .ui-li-count { right: 35px; }
 
 
 /* labels */


### PR DESCRIPTION
There were no specific rules for count bubble positioning in select form button, so the same rules as used for listview buttons applied. Because there are differences between both (icon right positioning for example) I added those. Besides this I added rules for ui-select mini button with count bubble.

The rules are based on 45px (extra) padding-right if there is a count bubble and 10px space between the count bubble and the border or icon. For fullsize buttons as well as mini buttons.

The most generic rule for ui-li-count is still in the listview file for which I send a pull request as well (part 1 of 2). The changes I propose in this PR depend on the other. Together this is a fix for issue #3979.
