### PR TITLE
Fixes #2804 unwanted margin between vertically grouped select inputs on FF

### DIFF
--- a/css/structure/jquery.mobile.controlgroup.css
+++ b/css/structure/jquery.mobile.controlgroup.css
@@ -25,6 +25,6 @@
 @media all and (min-width: 450px){
 	.ui-field-contain .ui-controlgroup-label { vertical-align: top; display: inline-block;  width: 20%;  margin: 0 2% 0 0;  }
 	.ui-field-contain .ui-controlgroup-controls { width: 60%; display: inline-block; }
-	.ui-field-contain .ui-controlgroup .ui-select { width: 100%; } 
-	.ui-field-contain .ui-controlgroup-horizontal .ui-select { width: auto; }
+	.ui-field-contain .ui-controlgroup .ui-select { width: 100%; display: block; } 
+	.ui-field-contain .ui-controlgroup-horizontal .ui-select { width: auto; display: inline-block; }
 }	


### PR DESCRIPTION
ui-select within ui-field-contain has width 60% and display inline-block (@media min-width 450px). For controlgroups the width of ui-select is 100% but inline-block still applies. Because of that Firefox shows an unwanted margin between the vertically grouped select input buttons.

Added display block and set it back to inline-block for horizontal controlgroups.
