### PR TITLE
Suggestion for #3981 - use existing label-id if there, otherwise generate ID from sliders ID

### DIFF
--- a/js/jquery.mobile.forms.slider.js
+++ b/js/jquery.mobile.forms.slider.js
@@ -36,7 +36,7 @@ $.widget( "mobile.slider", $.mobile.widget, {
 
 			controlID = control.attr( "id" ),
 
-			labelID = controlID + "-label",
+			labelID = $( "[for='"+ controlID +"']" ).attr( "id" ) || controlID + "-label",
 
 			label = $( "[for='"+ controlID +"']" ).attr( "id", labelID ),
 


### PR DESCRIPTION
Prevent overwriting an existing ID of a sliders label.
Sliders unit tests run successfully, but it seems, there is no test for the label and its ID.
