### PR TITLE
Docs: Remove double paragraph about using data-role="controlgroup"

### DIFF
--- a/docs/forms/radiobuttons/index.html
+++ b/docs/forms/radiobuttons/index.html
@@ -136,9 +136,6 @@
 <strong>&lt;/div&gt;
 </strong>	</code></pre>
 
-
-			<p>To visually integrate multiple radio buttons into a vertically grouped button set, the framework will automatically remove all margins between buttons and round only the top and bottom corners of the set if there is a <code> data-role="controlgroup"</code> attribute on the container.</p>
-
 		<div data-role="fieldcontain">
 		    <fieldset data-role="controlgroup">
 		    	<legend>Choose a pet:</legend>


### PR DESCRIPTION
The use of data-role="controlgroup" is already described at the paragraph **Vertically grouped radio buttons**
some lines above
