### PR TITLE
Docs: Fix a typo custom select := radio button

### DIFF
--- a/docs/forms/radiobuttons/methods.html
+++ b/docs/forms/radiobuttons/methods.html
@@ -54,7 +54,7 @@ $("input[type='radio']").checkboxradio('disable');
 				</code></pre>
 			</dd>
 			
-			<dt><code>refresh</code> update the custom select</dt>
+			<dt><code>refresh</code> update the radio button</dt>
 			<dd>
       If you manipulate a radio button via JavaScript, you must call the refresh method on it to update the visual styling.
 				<pre><code>


### PR DESCRIPTION
Sorry, I did not see this when sending the last pull for the same page ...
