### PR TITLE
Docs: Fix a typo custom select := checkbox

### DIFF
--- a/docs/forms/checkboxes/methods.html
+++ b/docs/forms/checkboxes/methods.html
@@ -54,7 +54,7 @@ $("input[type='checkbox']").checkboxradio('disable');
 				</code></pre>
 			</dd>
 			
-			<dt><code>refresh</code> update the custom select</dt>
+			<dt><code>refresh</code> update the checkbox</dt>
 			<dd>
       If you manipulate a checkbox via JavaScript, you must call the refresh method on it to update the visual styling.
 				<pre><code>


### PR DESCRIPTION
Sorry, I did not see this also when sending the last pull for the same page ...
