### PR TITLE
Docs: Fix a typo select := checkbox and remove a double paragraph

### DIFF
--- a/docs/forms/checkboxes/index.html
+++ b/docs/forms/checkboxes/index.html
@@ -66,7 +66,7 @@
 &lt;label for=&quot;checkbox-mini-0&quot;&gt;I agree&lt;/label&gt;
 </code></pre>
 		
-		<p>This will produce a select that is not as tall as the standard version and has a smaller text size.</p>
+		<p>This will produce a checkbox that is not as tall as the standard version and has a smaller text size.</p>
 		<input type="checkbox" name="checkbox-0" id="checkbox-mini-0" class="custom" data-mini="true" />
 		<label for="checkbox-mini-0">I agree</label>
 
@@ -74,9 +74,6 @@
 		<h2>Field containers &amp; Legends</h2>
 		<p>Because checkboxes use the <code>label</code> element for the text displayed next to the checkbox form element, we recommend wrapping the checkbox in a <code>fieldset</code> element that has a <code>legend</code> which acts as the title for the question. Add the  <code> data-role="controlgroup"</code> attribute to the <code>fieldset</code> so it can be styled in a parallel way as text inputs, selects or other form elements.</p>
 		
-		<p>Wrap the <code>fieldset</code> in a <code>div</code> with <code> data-role="fieldcontain"</code> attribute so it can be styled in a parallel way as text inputs, selects or other form elements.</p>
-
-
 <pre><code>	
 &lt;div data-role=&quot;fieldcontain&quot;&gt;
     <strong>&lt;fieldset data-role=&quot;controlgroup&quot;&gt;


### PR DESCRIPTION
The paragraph "_...fieldset in a div with data-role="fieldcontain" ..._" is repeated
