### PR TITLE
Docs: Fix some typos in example code and code itself  (select menus)

### DIFF
--- a/docs/forms/selects/index.html
+++ b/docs/forms/selects/index.html
@@ -46,7 +46,7 @@
 			
 <pre><code>
 &lt;label for=&quot;select-choice-0&quot; class=&quot;select&quot;&gt;Shipping method:&lt;/label&gt;
-&lt;select name=&quot;select-choice-0&quot; id=&quot;select-choice-1&quot;&gt;
+&lt;select name=&quot;select-choice-0&quot; id=&quot;select-choice-0&quot;&gt;
    &lt;option value=&quot;standard&quot;&gt;Standard: 7 day&lt;/option&gt;
    &lt;option value=&quot;rush&quot;&gt;Rush: 3 days&lt;/option&gt;
    &lt;option value=&quot;express&quot;&gt;Express: next day&lt;/option&gt;
@@ -57,7 +57,7 @@
 			<p>This will produce a basic select menu. The default styles set the width of the input to 100% of the parent container and stacks the label on a separate line.</p>
 
 			<label for="select-choice-0" class="select">Shipping method:</label>
-			<select name="select-choice-0" id="select-choice-1">
+			<select name="select-choice-0" id="select-choice-0">
 				<option value="standard">Standard: 7 day</option>
 				<option value="rush">Rush: 3 days</option>
 				<option value="express">Express: next day</option>
@@ -70,7 +70,7 @@
 
 <pre><code>	
 &lt;label for=&quot;select-choice-min&quot; class=&quot;select&quot;&gt;Shipping method:&lt;/label&gt;
-&lt;select name=&quot;select-choice-min&quot; id=&quot;select-choice-1&quot; <strong>data-mini=&quot;true&quot;</strong>&gt;
+&lt;select name=&quot;select-choice-min&quot; id=&quot;select-choice-min&quot; <strong>data-mini=&quot;true&quot;</strong>&gt;
    &lt;option value=&quot;standard&quot;&gt;Standard: 7 day&lt;/option&gt;
    &lt;option value=&quot;rush&quot;&gt;Rush: 3 days&lt;/option&gt;
    &lt;option value=&quot;express&quot;&gt;Express: next day&lt;/option&gt;
@@ -80,7 +80,7 @@
 			
 			<p>This will produce a select that a not as tall as the standard version and has a smaller text size.</p>
 			<label for="select-choice-min" class="select">Shipping method:</label>
-			<select name="select-choice-0" id="select-choice-min" data-mini="true">
+			<select name="select-choice-min" id="select-choice-min" data-mini="true">
 				<option value="standard">Standard: 7 day</option>
 				<option value="rush">Rush: 3 days</option>
 				<option value="express">Express: next day</option>


### PR DESCRIPTION
labels-for-id and select ids does not match
