### PR TITLE
Docs: Remove non-applicable "none", adding "top" and "bottom" for iconpos

### DIFF
--- a/docs/forms/selects/options.html
+++ b/docs/forms/selects/options.html
@@ -57,7 +57,7 @@
 			<dt><code>iconpos</code> <em>string</em></dt>
 			<dd>
 				<p class="default">default: "right"</p>
-				<p>Position of the icon in the select button. Possible values: left, right, none, notext. The notext value will display the select as an icon-only button with no text feedback. This option is also exposed as a data attribute: <code>data-iconpos=&quot;left&quot;</code></p>
+				<p>Position of the icon in the select button. Possible values: left, right, top, bottom, notext. The notext value will display the select as an icon-only button with no text feedback. This option is also exposed as a data attribute: <code>data-iconpos=&quot;left&quot;</code></p>
 				<pre><code>$('select').selectmenu(<strong>{ iconpos: "left" }</strong>);</code></pre>
 			</dd>
 			


### PR DESCRIPTION
select menu iconpos attribute
