### PR TITLE
Fix dialog double hash try2

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1044,6 +1044,9 @@ define( [
 			}
 		} catch(e) {}
 
+		// Record whether we are at a place in history where a dialog used to be - if so, do not add a new history entry and do not change the hash either
+		var alreadyThere = false;
+
 		// If we're displaying the page as a dialog, we don't want the url
 		// for the dialog content to be used in the hash. Instead, we want
 		// to append the dialogHashKey to the url of the current page.
@@ -1052,6 +1055,17 @@ define( [
 			// be an empty string. Moving the undefined -> empty string back into
 			// urlHistory.addNew seemed imprudent given undefined better represents
 			// the url state
+
+			// If we are at a place in history that once belonged to a dialog, reuse
+			// this state without adding to urlHistory and without modifying the hash.
+			// However, if a dialog is already displayed at this point, and we're
+			// about to display another dialog, then we must add another hash and
+			// history entry on top so that one may navigate back to the original dialog
+			if ( active.url.indexOf( dialogHashKey ) > -1 && !$.mobile.activePage.is( ".ui-dialog" ) ) {
+				settings.changeHash = false;
+				alreadyThere = true;
+			}
+
 			url = ( active.url || "" ) + dialogHashKey;
 		}
 
@@ -1079,7 +1093,7 @@ define( [
 			|| ( isDialog ? $.mobile.defaultDialogTransition : $.mobile.defaultPageTransition );
 
 		//add page to history stack if it's not back or forward
-		if( !historyDir ) {
+		if( !historyDir && !alreadyThere ) {
 			urlHistory.addNew( url, settings.transition, pageTitle, pageUrl, settings.role );
 		}
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1003,6 +1003,16 @@ define( [
 		if( fromPage && fromPage[0] === toPage[0] && !settings.allowSamePageTransition ) {
 			isPageTransitioning = false;
 			mpc.trigger( "pagechange", triggerData );
+
+			// Even if there is no page change to be done, we should keep the urlHistory in sync with the hash changes
+			if( settings.fromHashChange ) {
+				urlHistory.directHashChange({
+					currentUrl:	url,
+					isBack:		function() {},
+					isForward:	function() {}
+				});
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
This is another approach to avoiding the need to close a dialog twice.

The idea is: If the current urlHistory item contains &ui-state=dialog, but the current page is not a dialog, then no hash change is made and no urlHistory entry is created when changePage loads a dialog into such a state. IOW, the state is reused.

Note that the first commit of this PR (851fad0) is also useful for the popup widget, because it fixes a silent problem that's currently present: The urlHistory is moved forward to an entry of type &ui-state=dialog when the user clicks "Forward" towards a location that is no different from the current location except for &ui-state=dialog, but it is not moved back when the user clicks "Back" from such a location.

The popup widget was implementing its own version of this move-urlHistory-back-from-a-dialog-state, but putting it in navigation is better, because it helps fix #2656, and it also helps reduce the extent to which popup has to dabble in the navigation.

I ran the unit tests on this PR, and the unit test which previously failed, namely "going back from a dialog triggered from a dialog should result in the first dialog", did not fail with this fix.
