### PR TITLE
Docs: Removing data-position="inline" from the code description (docs-header)

### DIFF
--- a/docs/toolbars/docs-headers.html
+++ b/docs/toolbars/docs-headers.html
@@ -64,7 +64,7 @@
 			
 
 <pre><code>			
-&lt;div data-role=&quot;header&quot; data-position=&quot;inline&quot;&gt;
+&lt;div data-role=&quot;header&quot;&gt;
 	&lt;a href=&quot;index.html&quot; data-icon=&quot;delete&quot;&gt;Cancel&lt;/a&gt;
 	&lt;h1&gt;Edit Contact&lt;/h1&gt;
 	&lt;a href=&quot;index.html&quot; data-icon=&quot;check&quot;&gt;Save&lt;/a&gt;
@@ -83,7 +83,7 @@
 			<p>Buttons automatically adopt the swatch color of the bar they sit in, so a link in a header bar with the "a" color will also be styled as "a" colored buttons. It's simple to make a button visually stand out. Here, we add the <code> data-theme</code> attribute and set the color swatch for the button to "b" to make the "Save" button pop.</p>
 			
 			<pre><code>			
-&lt;div data-role=&quot;header&quot; data-position=&quot;inline&quot;&gt;
+&lt;div data-role=&quot;header&quot;&gt;
 	&lt;a href=&quot;index.html&quot; data-icon=&quot;delete&quot;&gt;Cancel&lt;/a&gt;
 	&lt;h1&gt;Edit Contact&lt;/h1&gt;
 	&lt;a href=&quot;index.html&quot; data-icon=&quot;check&quot; data-theme=&quot;b&quot;&gt;Save&lt;/a&gt;
@@ -106,7 +106,7 @@
 
 <div class="highlight"> 
 <pre><code>
-&lt;div data-role=&quot;header&quot; data-position=&quot;inline&quot;&gt; 
+&lt;div data-role=&quot;header&quot;&gt;
 	&lt;h1&gt;Page Title&lt;/h1&gt;
 	&lt;a href=&quot;index.html&quot; data-icon=&quot;gear&quot; class=&quot;ui-btn-right&quot;&gt;Options&lt;/a&gt;
 &lt;/div&gt;
@@ -126,7 +126,7 @@
 		
 <div class="highlight"> 
 <pre><code>
-&lt;div data-role=&quot;header&quot; data-position=&quot;inline&quot;&gt; 
+&lt;div data-role=&quot;header&quot;&gt;
 	&lt;a href=&quot;index.html&quot; data-icon=&quot;gear&quot; class=&quot;ui-btn-right&quot;&gt;Options&lt;/a&gt;
 	&lt;span class=&quot;ui-title&quot; /&gt;
 &lt;/div&gt;


### PR DESCRIPTION
It seems, `data-position="inline"` for toolbars is not applicable or senseless.
