### PR TITLE
CSS Transition Flickering Patch

### DIFF
--- a/css/structure/jquery.mobile.transition.slide.css
+++ b/css/structure/jquery.mobile.transition.slide.css
@@ -12,6 +12,7 @@
 	-webkit-animation-name: slideouttoleft;
 	-moz-transform: translateX(-100%);
 	-moz-animation-name: slideouttoleft;
+	overflow: hidden;
 }
 
 .slide.in {

--- a/css/structure/jquery.mobile.transition.slideout.keyframes.css
+++ b/css/structure/jquery.mobile.transition.slideout.keyframes.css
@@ -1,18 +1,18 @@
 /* keyframes for slideout to sides */
 @-webkit-keyframes slideouttoleft {
-    from { -webkit-transform: translateX(0); }
-    to { -webkit-transform: translateX(-100%); }
+    from { width: 100%; }
+    to { width: 0; }
 }
 @-moz-keyframes slideouttoleft {
-    from { -moz-transform: translateX(0); }
-    to { -moz-transform: translateX(-100%); }
+    from { -moz-transform: translate3d(0,0,0); }
+    to { -moz-transform: translate3d(-100%,0,0); }
 }
 
 @-webkit-keyframes slideouttoright {
-    from { -webkit-transform: translateX(0); }
-    to { -webkit-transform: translateX(100%); }
+    from { -webkit-transform: translate3d(0,0,0); }
+    to { -webkit-transform: translate3d(100%,0,0); }
 }
 @-moz-keyframes slideouttoright {
-    from { -moz-transform: translateX(0); }
-    to { -moz-transform: translateX(100%); }
+    from { -moz-transform: translate3d(0,0,0); }
+    to { -moz-transform: translate3d(100%,0,0); }
 }


### PR DESCRIPTION
I'm developing a PhoneGap / jQuery Mobile app for my company, Filter Foundry. For some reason, sliding right worked fine but sliding left was flickery and laggy. This patch uses width with overflow:hidden to simulate the same effect, with better performance.
