### PR TITLE
Search Docs Typo

### DIFF
--- a/docs/forms/search/index.html
+++ b/docs/forms/search/index.html
@@ -42,7 +42,7 @@
 				
 <pre><code>	
 &lt;label for=&quot;search-basic&quot;&gt;Search Input:&lt;/label&gt;
-&lt;input type=&quot;search&quot; name=&quot;search&quot; id=&quot;searc-basic&quot; value=&quot;&quot; /&gt;
+&lt;input type=&quot;search&quot; name=&quot;search&quot; id=&quot;search-basic&quot; value=&quot;&quot; /&gt;
 </code></pre>	
 
 				<p>This will produce a basic search input. The default styles set the width of the input to 100% of the parent container and stack the label on a separate line.</p>


### PR DESCRIPTION
Just a typo in the input's id; made to match the label's for attribute.
