### PR TITLE
Docs: Remove data-iconpos="notext" from Collapsible as it seems not really applicable

### DIFF
--- a/docs/api/data-attributes.html
+++ b/docs/api/data-attributes.html
@@ -103,7 +103,7 @@
 				</tr>
 				<tr>
 					<th>data-iconpos</th>
-					<td><strong>left</strong> | right | top | bottom |  notext</td>
+					<td><strong>left</strong> | right | top | bottom</td>
 				</tr>
 				<tr>
 					<th>data-mini</th>


### PR DESCRIPTION
Collapsibles may should not consider data-iconpos="notext"  http://jsfiddle.net/MauriceG/nhG4J/2/
