### PR TITLE
[popup] Trigger "closed" only when all animations have completed

### DIFF
--- a/js/jquery.mobile.popup.js
+++ b/js/jquery.mobile.popup.js
@@ -264,17 +264,29 @@ define( [ "jquery",
 		close: function( fromHash ) {
 			if ( this._isOpen ) {
 				var self = this,
+					// Count down to triggering "closed" - we have two prerequisits:
+					// 1. The popup window reverse animation completes (onAnimationComplete())
+					// 2. The screen opacity animation completes (hideScreen())
+					triggerPrereqs = 2,
+					maybeTriggerClosed = function() {
+						triggerPrereqs--;
+
+						if ( 0 === triggerPrereqs ) {
+							self.element.trigger( "closed" );
+						}
+					},
 					onAnimationComplete = function() {
 						self._ui.container
 							.removeClass( "reverse out" )
 							.addClass( "ui-selectmenu-hidden" )
 							.removeAttr( "style" );
+						maybeTriggerClosed();
 					},
 					hideScreen = function() {
 						self._ui.screen.addClass( "ui-screen-hidden" );
 						self._isOpen = false;
-						self.element.trigger( "closed" );
 						self._ui.screen.removeAttr( "style" );
+						maybeTriggerClosed();
 					};
 
 				if ( this.options.transition && this.options.transition !== "none" ) {


### PR DESCRIPTION
This is important if we're going to have mutually exclusive popups, because one popup's open() will run as the previous popup's .one("closed", ... ) callback. That way we get a nice clean, non-overlapping pop out/pop in sequence.

... and even if we don't end up with mutually exclusive popups, it's good to have an indication as to when exactly the popup has removed itself completely from the screen. After all, it's "closed", not "closed, but there's still some crap on the screen" :)
