### PR TITLE
Docs: Fix typo at return value examples of path.get() (api/methods)

### DIFF
--- a/docs/api/methods.html
+++ b/docs/api/methods.html
@@ -560,10 +560,10 @@ var dirName = $.mobile.path.get("//foo.com/a/file.html");
 <strong>// Returns: /a/</strong>
 var dirName = $.mobile.path.get("/a/file.html");
 
-<strong>// Returns: /</strong>
+<strong>// Returns: ""</strong>
 var dirName = $.mobile.path.get("file.html");
 
-<strong>// Returns: ""</strong>
+<strong>// Returns: /</strong>
 var dirName = $.mobile.path.get("/file.html");
 
 <strong>// Returns: ?a=1&amp;b=2</strong>


### PR DESCRIPTION
@toddparker
Thanks for pull-in #4141!
Now I can correct my own typos and copy/paste happenings ...
Sorry for that ...
