### PR TITLE
Docs: Remove non applicable data-icon attribute from navbar + adding a hint about adding icons

### DIFF
--- a/docs/api/data-attributes.html
+++ b/docs/api/data-attributes.html
@@ -373,10 +373,6 @@
 			<p>A number of LIs wrapped in a container with <code>data-role="navbar"</code></p>
 			<table>
 				<tr>
-					<th>data-icon</th>
-					<td>home | delete | plus | arrow-u | arrow-d | check | gear | grid | star | custom | arrow-r | arrow-l | minus | refresh | forward | back | alert | info | search</td>
-				</tr>
-				<tr>
 					<th>data-iconpos</th>
 					<td>left | right | <strong>top</strong> | bottom |  notext</td>
 				</tr>
@@ -385,6 +381,8 @@
 					<td>swatch letter (a-z) - can also be set on individual LIs</td>
 				</tr>
 			</table>
+			<p>To add icons to the navbar items, the <code>data-icon</code> attribute is used, specifying a standard mobile icon for each item.</p>
+
 			<h2><a href="../pages/page-anatomy.html">Page</a></h2>
 			<p>Container with <code>data-role="page"</code></p>
 			<table>


### PR DESCRIPTION
replacing pull #4132
