### PR TITLE
Docs: Remove unsupported data-theme-attribute from navbar (attribute-reference)

### DIFF
--- a/docs/api/data-attributes.html
+++ b/docs/api/data-attributes.html
@@ -380,12 +380,10 @@
 					<th>data-iconpos</th>
 					<td>left | right | <strong>top</strong> | bottom |  notext</td>
 				</tr>
-				<tr>
-					<th>data-theme</th>
-					<td>swatch letter (a-z) - can also be set on individual LIs</td>
-				</tr>
 			</table>
-			<h2><a href="../pages/page-anatomy.html">Page</a></h2>
+			<p>Navbars inherit the theme-swatch from their parent container. Setting the <code>data-theme</code> attribute to a navbar is not supported. The <code>data-theme</code> attribute can be set individual to the links inside a navbar.</p>
+
+<h2><a href="../pages/page-anatomy.html">Page</a></h2>
 			<p>Container with <code>data-role="page"</code></p>
 			<table>
 				<tr>


### PR DESCRIPTION
As described at http://jquerymobile.com/test/docs/toolbars/docs-navbar.html and tested with a fiddle at
http://jsfiddle.net/MauriceG/Mp2Vk/ setting a <code>data-theme</code> to a navbar is not supported.
