### PR TITLE
Docs: Adding "turn | flow | slidefade | none" data-transitions for links (attribute reference)

### DIFF
--- a/docs/api/data-attributes.html
+++ b/docs/api/data-attributes.html
@@ -304,7 +304,7 @@
 				</tr>
 				<tr>
 					<th>data-transition</th>
-					<td><strong>slide</strong> | slideup | slidedown | pop | fade | flip</td>
+					<td><strong>fade</strong> | flip | flow | pop | slide | slidedown | slidefade | slideup | turn | none</td>
 				</tr>
 			</table>
 


### PR DESCRIPTION
and set the default transition to **fade**
Replacing #4169 which missed changed default transition for 1.1.0
