### PR TITLE
Docs: Remove unsupported data-theme-attribute from navbar-reference

### DIFF
--- a/docs/api/data-attributes.html
+++ b/docs/api/data-attributes.html
@@ -391,13 +391,10 @@
 					<th>data-iconpos</th>
 					<td>left | right | <strong>top</strong> | bottom |  notext</td>
 				</tr>
-				<tr>
-					<th>data-theme</th>
-					<td>swatch letter (a-z) - can also be set on individual LIs</td>
-				</tr>
 			</table>
 			<p>To add icons to the navbar items, the <code>data-icon</code> attribute is used, specifying a standard mobile icon for each item.</p>
-
+			<p>Navbars inherit the theme-swatch from their parent container. Setting the <code>data-theme</code> attribute to a navbar is not supported. The <code>data-theme</code> attribute can be set individual to the links inside a navbar.</p>
+			
 			<h2><a href="../pages/page-anatomy.html">Page</a></h2>
 			<p>Container with <code>data-role="page"</code></p>
 			<table>


### PR DESCRIPTION
And adding a hint about theming links in navbars.
2nd pull cause of merge conflict with #4155.
