### PR TITLE
Docs: Fix typo which := with; change button to link button (lists-themes)

### DIFF
--- a/docs/lists/lists-themes.html
+++ b/docs/lists/lists-themes.html
@@ -111,7 +111,7 @@
 		
 		<h2>Theming split buttons</h2>
 		
-		<p>For split lists which a second button, the framework default to &quot;b&quot; for the theme swatch (blue in the default theme)  Here is a default split list:</p>
+		<p>For split lists with a second link button, the framework default to &quot;b&quot; for the theme swatch (blue in the default theme). Here is a default split list:</p>
 		
 		<ul data-role="listview" data-inset="true">
 			<li><a href="index.html">


### PR DESCRIPTION
Also I've added a point (br: full stop) after a bracket. I hope there is no rule that forbids this.
