### PR TITLE
Docs: Not every click on a link search for an ID; saying # search for an internal page

### DIFF
--- a/docs/pages/page-anatomy.html
+++ b/docs/pages/page-anatomy.html
@@ -123,7 +123,7 @@
 
 		<h2>Multi-page template structure</h2> 
 		
-			<p>A single HTML document can contain multiple 'pages' that are loaded together by stacking multiple divs with a <code> data-role</code> of <code>"page"</code>. Each 'page' block needs a unique ID (<code>id="foo"</code>) that will be used to link internally between 'pages' (<code>href="#foo"</code>). When a link is clicked, the framework will look for an internal 'page' with the ID and transition it into view.</p> 
+			<p>A single HTML document can contain multiple 'pages' that are loaded together by stacking multiple divs with a <code> data-role</code> of <code>"page"</code>. Each 'page' block needs a unique ID (<code>id="foo"</code>) that will be used to link internally between 'pages' (<code>href="#foo"</code>). When such a link (starting with the hash sign: #) is clicked, the framework will look for an internal 'page' with that ID and transition it into view.</p> 
 						
 			<p>Here is an example of a 2 "page" site built with two jQuery Mobile divs navigated by linking to an ID placed on each page wrapper. Note that the IDs on the page wrappers are only needed to support the internal page linking, and are optional if each page is a separate HTML document. Here is what two pages look inside the <code>body</code> element.</p> 
 


### PR DESCRIPTION
docs page-anatomy
