### PR TITLE
Issue 3984: jumping fixed header IOS & Android RC2

### DIFF
--- a/js/jquery.mobile.fixedToolbar.js
+++ b/js/jquery.mobile.fixedToolbar.js
@@ -122,6 +122,11 @@ define( [ "jquery", "./jquery.mobile.widget", "./jquery.mobile.core", "./jquery.
 			// This method is meant to disable zoom while a fixed-positioned toolbar page is visible
 			$el.closest( ".ui-page" )
 				.bind( "pagebeforeshow", function(){
+					//https://github.com/jquery/jquery-mobile/issues/3984
+					//scrollTop(0) apparently forces Safari viewport to the top of the page
+					//which prevents the position:fixed toolbar from blinking during page transition
+					$('body, html').scrollTop(0);
+					
 					if( o.disablePageZoom ){
 						$.mobile.zoom.disable( true );
 					}


### PR DESCRIPTION
Fix for
https://github.com/jquery/jquery-mobile/issues/3984

I've done some searching and the problem appears to be a Safari bug; however it's hard to say that for sure . The fix is to do scrollTop(0) between page transitions which probably resets Safari viewport and prevents nasty jumps/blinks/etc when Safari tries to settle down the newly loaded position:fixed header/footer.

I'd appreciate if someone with more JQM experience could review the fix and confirm that it doesn't break anything. I am new to this framework and don't have a clear picture of every JQM feature so I could have easily broken something.
