### PR TITLE
Fixes #1970 part 1 - The text inside the label of a checkbox/radio can be selected

### DIFF
--- a/css/structure/jquery.mobile.forms.checkboxradio.css
+++ b/css/structure/jquery.mobile.forms.checkboxradio.css
@@ -22,3 +22,4 @@
 
 /* input, label positioning */
 .ui-checkbox input,.ui-radio input { position:absolute; left:20px; top:50%; width: 10px; height: 10px;  margin:-5px 0 0 0; outline: 0 !important; z-index: 1; }
+.ui-checkbox label,.ui-radio label { -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none; }


### PR DESCRIPTION
Fixes #1970 

The text inside the label of a checkbox/radio cannot be selected now.
