### PR TITLE
Tests fix: wrong variable name in unit\fixedToolbar suppresses error messages

### DIFF
--- a/tests/unit/fixedToolbar/fixedToolbar.js
+++ b/tests/unit/fixedToolbar/fixedToolbar.js
@@ -331,7 +331,7 @@
 			function() {
 				var $footer = $.mobile.activePage.find( ".ui-footer" ),
 					$header = $.mobile.activePage.find( ".ui-header" ),
-					hidden = areHidden ? "hidden" : "visible";
+					hiddenStr = areHidden ? "hidden" : "visible";
 
 				equal( $footer.length, 1, "there should be one footer" );
 				equal( $header.length, 1, "there should be one header" );


### PR DESCRIPTION
Error messages thrown in 1.1.0 of the following tests are silently suppressed:
12: data-visible-on-page-show hides toolbars when false
13: data-visible-on-page-show shows toolbars when explicitly true 
14: data-visible-on-page-show shows toolbars when undefined 
