### PR TITLE
Suggestion: Fix for fixed persistent toolbar padding issues

### DIFF
--- a/js/jquery.mobile.fixedToolbar.js
+++ b/js/jquery.mobile.fixedToolbar.js
@@ -135,14 +135,10 @@ define( [ "jquery", "./jquery.mobile.widget", "./jquery.mobile.core", "./jquery.
 						self.updatePagePadding( thisPage );
 					}
 				})
-				.bind( "pageshow", function(e, ui){
+				.bind( "pageshow", function(){
 					var thisPage = this;
 					if( o.updatePagePadding ){
-						// padding on pageshow is just needed on first toolbar-page
-						if ( !ui.nextPage ) {
-							self.updatePagePadding( thisPage );
-						}
-
+						self.updatePagePadding( thisPage );
 						$( window ).bind( "throttledresize." + self.widgetName, function(){
 						 	self.updatePagePadding( thisPage );
 						});

--- a/js/jquery.mobile.fixedToolbar.js
+++ b/js/jquery.mobile.fixedToolbar.js
@@ -130,15 +130,21 @@ define( [ "jquery", "./jquery.mobile.widget", "./jquery.mobile.core", "./jquery.
 					}
 				} )
 				.bind( "webkitAnimationStart animationstart updatelayout", function(){
+					var thisPage = this;
 					if( o.updatePagePadding ){
-						self.updatePagePadding();
+						self.updatePagePadding( thisPage );
 					}
 				})
-				.bind( "pageshow", function(){
-					self.updatePagePadding();
+				.bind( "pageshow", function(e, ui){
+					var thisPage = this;
 					if( o.updatePagePadding ){
+						// padding on pageshow is just needed on first toolbar-page
+						if ( !ui.nextPage ) {
+							self.updatePagePadding( thisPage );
+						}
+
 						$( window ).bind( "throttledresize." + self.widgetName, function(){
-						 	self.updatePagePadding();
+						 	self.updatePagePadding( thisPage );
 						});
 					}
 				})
@@ -173,14 +179,14 @@ define( [ "jquery", "./jquery.mobile.widget", "./jquery.mobile.core", "./jquery.
 		_visible: true,
 
 		// This will set the content element's top or bottom padding equal to the toolbar's height
-		updatePagePadding: function() {
+		updatePagePadding: function( tbPage ) {
 			var $el = this.element,
 				header = $el.is( ".ui-header" );
 
 			// This behavior only applies to "fixed", not "fullscreen"
 			if( this.options.fullscreen ){ return; }
 
-			$el.closest( ".ui-page" ).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() );
+			$(tbPage).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() );
 		},
 		
 		_useTransition: function( notransition ){

--- a/js/jquery.mobile.fixedToolbar.js
+++ b/js/jquery.mobile.fixedToolbar.js
@@ -182,6 +182,7 @@ define( [ "jquery", "./jquery.mobile.widget", "./jquery.mobile.core", "./jquery.
 			// This behavior only applies to "fixed", not "fullscreen"
 			if( this.options.fullscreen ){ return; }
 
+			tbPage = tbPage || $el.closest( ".ui-page" );
 			$(tbPage).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() );
 		},
 		


### PR DESCRIPTION
Tested with Safari 5.0.5 on Windows, 5.1.5 on MacOS, iOS 5.1 on iPhone4 + iPad3, Chrome 15.0 + 18.0 on Win, FF 9.0.1 + 12.0 on Win, Opera 11.52 on Win, IE7, Android 2.2.1 on Archos 70 tablet

May it's superfluous here to outline how the fixed toolbar bindings behave, but it shows why the current code cannot work if the `updatePagePadding` option is true and the header and/or footer are higher than a standard toolbar.

Note: The `updatePagePadding()` function always searches its closest `.ui-page` container to calculate the necessary page-padding.

When showing the initial page, the `pageshow` event calls `updatePagePadding()` and everything works fine.

When a page navigation occurs the following happens in this order (please correct me if I'm wrong):

`pagebeforehide` searches the fixed toolbar/s of **page-to** and _moves_ them to `$.mobile.pageContainer`. Then another `pageshow` event is bound to the page-to, which will move the toolbar/s to that to-page.

The bound `animationstart` event fires on the page-from and calculates the page-padding of the page that will be left now...

The bound `animationstart` event fires on the page-to and calls `updatePagePadding()` to set the padding. But, page-to has no toolbars at this moment. They're still in the `$.mobile.pageContainer`. The paddng could not be calculated.

The bound `pageshow` event fires on the page-to and do the same again. Still no toolbars in the page.

The second `pageshow` event (bound at `pagebeforehide` in one of the steps above) fires and moves the toolbar/s from the page-container to the page-to. Too late.

The next navigation will set the proper padding to the page cause of the out-transition. When this page is shown again, the padding will be ok.

I hope my deliberations were not too boring.

Addresses #4219 + may #4259
