### PR TITLE
disable text-shadow for selected text

### DIFF
--- a/css/themes/default/jquery.mobile.theme.css
+++ b/css/themes/default/jquery.mobile.theme.css
@@ -1158,3 +1158,6 @@ a.ui-link-inherit {
 	outline-width: 1px;
 	outline-style: dotted;
 }
+
+::-moz-selection { text-shadow: none; }
+::selection { text-shadow: none; }


### PR DESCRIPTION
I know it's detail but still... text-shadow doesn't look good on selected text.

BTW - I was thinking about proposing hot pink as global selected text highlight color :-)
https://github.com/h5bp/html5-boilerplate/commit/1d320b59a390041f25cf87d790f6472a25a512ef
