### PR TITLE
Fixes #4185 - When leaving from a page contains nested listview, pageremove event does not fire

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -380,13 +380,17 @@ $.widget( "mobile.listview", $.mobile.widget, {
 			parentPage.data("page").options.domCache === false ) {
 
 			var newRemove = function( e, ui ){
-				var nextPage = ui.nextPage, npURL;
+				var nextPage = ui.nextPage, npURL,
+					prEvent = new $.Event( "pageremove" );
 
 				if( ui.nextPage ){
 					npURL = nextPage.jqmData( "url" );
 					if( npURL.indexOf( parentUrl + "&" + $.mobile.subPageUrlKey ) !== 0 ){
 						self.childPages().remove();
-						parentPage.remove();
+						parentPage.trigger( prEvent );
+						if( !prEvent.isDefaultPrevented() ){
+							parentPage.removeWithDependents();
+						}
 					}
 				}
 			};


### PR DESCRIPTION
Issue: If a page contains a listview with a nested list the pageremove event does not fire when you leave the page, although the page and its subpages do get removed from the DOM.
Solved by adjusting the 'specialized' page remove function.

Fixes #4185

Passed the unit test. Live test page: http://ugomobi.github.com/pageremove/

Note: When you leave a nested/subpage no pages are removed from the DOM. See my comments on issue 4185.
