### PR TITLE
Dialog: Make the dialog corners-markup unbreakable 

### DIFF
--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -32,13 +32,12 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 			.children()
 				.find( ":jqmData(role='header')" )
 					.prepend( headerCloseButton )
-				.end()
-				.children( ':first-child')
+				.children( ":jqmData(role='header'), :jqmData(role='content'), :jqmData(role='footer')" )
+				.first()
 					.addClass( "ui-corner-top" )
 				.end()
-				.children( ":last-child" )
+				.last()
 					.addClass( "ui-corner-bottom" );
-
 		// this must be an anonymous function so that select menu dialogs can replace
 		// the close method. This is a change from previously just defining data-rel=back
 		// on the button and letting nav handle it

--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -32,6 +32,7 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 			.children()
 				.find( ":jqmData(role='header')" )
 					.prepend( headerCloseButton )
+				.end()
 				.children( ":jqmData(role='header'), :jqmData(role='content'), :jqmData(role='footer')" )
 				.first()
 					.addClass( "ui-corner-top" )


### PR DESCRIPTION
Addresses #4277 :  ignore all tags between header/content content/footer when adding ui-corner classes to a dialog
