### PR TITLE
Fixes #4196 - Collapsibles nested in an accordion set are always treated as accordions

### DIFF
--- a/js/jquery.mobile.collapsibleSet.js
+++ b/js/jquery.mobile.collapsibleSet.js
@@ -47,10 +47,13 @@ $.widget( "mobile.collapsibleset", $.mobile.widget, {
 					}
 				})
 				.bind( "expand", function( event ) {
-					$( event.target )
-						.closest( ".ui-collapsible" )
-						.siblings( ".ui-collapsible" )
-						.trigger( "collapse" );
+					var closestCollapsible = $( event.target )
+						.closest( ".ui-collapsible" );
+					if( closestCollapsible.parent().is( ":jqmData(role='collapsible-set')" ) ) {
+						closestCollapsible
+							.siblings( ".ui-collapsible" )
+							.trigger( "collapse" );
+					}
 				});
 		}
 	},


### PR DESCRIPTION
Fixes #4196

How fixed: Checked if the closest parent is a collapsible-set before triggering the collapse event.

How tested: http://jsbin.com/omacox/100 and Docs
