### PR TITLE
Fixes #3496 - Styling of added checkbox incorrect when in controlgroup

### DIFF
--- a/js/jquery.mobile.controlGroup.js
+++ b/js/jquery.mobile.controlGroup.js
@@ -10,7 +10,7 @@ define( [ "jquery", "./jquery.mobile.buttonMarkup" ], function( $ ) {
 
 $.fn.controlgroup = function( options ) {
 	function flipClasses( els, flCorners  ) {
-		els.removeClass( "ui-btn-corner-all ui-shadow" )
+		els.removeClass( "ui-btn-corner-all ui-corner-top ui-corner-bottom ui-corner-left ui-corner-right ui-controlgroup-last ui-shadow" )
 			.eq( 0 ).addClass( flCorners[ 0 ] )
 			.end()
 			.last().addClass( flCorners[ 1 ] ).addClass( "ui-controlgroup-last" );


### PR DESCRIPTION
Issue: When a new controlgroup item (button, selectmenu, checkbox/radio) is dynamically injected, the controlgroup corner styling can't be refreshed.
Cause: The controlgroup function doesn't consider situations where the controlgroup element is already styled as a controlgroup.
Fix: Added classes to the list of classes that have to be removed before corner classes getting assigned (again).

Passed all unit tests. Live test page: http://ugomobi.github.com/controlgroup/

Fixes: #3496
