### PR TITLE
Disabled browser default outline for listview buttons on focus

### DIFF
--- a/css/themes/default/jquery.mobile.theme.css
+++ b/css/themes/default/jquery.mobile.theme.css
@@ -1132,7 +1132,7 @@ a.ui-link-inherit {
 /* Focus state - set here for specificity (note: these classes are added by JavaScript)
 -----------------------------------------------------------------------------------------------------------*/
 
-.ui-btn:focus {
+.ui-btn:focus, .ui-link-inherit:focus {
 	outline: 0;
 }
 


### PR DESCRIPTION
Issue: Listview and custom selectmenu items still have the default browser outline on focus (together with box-shadow of ui-focus class) while outline is set to 0 for all other buttons. See #2214

Fix: Added .ui-link-inherit:focus selector to the .ui-btn:focus { outline: 0; } rule.
