### PR TITLE
conform to stict mode

### DIFF
--- a/js/jquery.hashchange.js
+++ b/js/jquery.hashchange.js
@@ -376,4 +376,4 @@
     return self;
   })();
   
-})(jQuery,this);
+})( jQuery, window );

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -344,7 +344,7 @@ define( [ "jquery", "../external/requirejs/text!../version.txt", "./jquery.mobil
 	$.find.matchesSelector = function( node, expr ) {
 		return $.find( expr, null, null, [ node ] ).length > 0;
 	};
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.dialog.js
+++ b/js/jquery.mobile.dialog.js
@@ -94,7 +94,7 @@ $( document ).delegate( $.mobile.dialog.prototype.options.initSelector, "pagecre
 	$.mobile.dialog.prototype.enhance( this );
 });
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.event.js
+++ b/js/jquery.mobile.event.js
@@ -371,7 +371,7 @@ $.each({
 	};
 });
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.forms.textinput.js
+++ b/js/jquery.mobile.forms.textinput.js
@@ -68,7 +68,7 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 					mini: mini
 				});
 
-			function toggleClear() {
+			var toggleClear = function() {
 				setTimeout(function() {
 					clearbtn.toggleClass( "ui-input-clear-hidden", !input.val() );
 				}, 0);

--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -219,7 +219,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.support", "./jquery
 		// hide iOS browser chrome on load
 		$window.load( $.mobile.silentScroll );
 	});
-}( jQuery, this ));
+}( jQuery, window ));
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.navigation.pushstate.js
+++ b/js/jquery.mobile.navigation.pushstate.js
@@ -143,7 +143,7 @@ define( [ "jquery", "./jquery.mobile.navigation", "../external/requirejs/depend!
 			pushStateHandler.init();
 		}
 	});
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.flip.js
+++ b/js/jquery.mobile.transition.flip.js
@@ -14,7 +14,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.flip = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.flow.js
+++ b/js/jquery.mobile.transition.flow.js
@@ -14,7 +14,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.flow = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.js
+++ b/js/jquery.mobile.transition.js
@@ -159,7 +159,7 @@ $.mobile._maybeDegradeTransition = function( transition ) {
 		return transition;
 };
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.pop.js
+++ b/js/jquery.mobile.transition.pop.js
@@ -14,7 +14,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.pop = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.slide.js
+++ b/js/jquery.mobile.transition.slide.js
@@ -18,7 +18,7 @@ $.mobile.transitionHandlers.slide = $.mobile.transitionHandlers.simultaneous;
 // Set the slide transition's fallback to "fade"
 $.mobile.transitionFallbacks.slide = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.slidedown.js
+++ b/js/jquery.mobile.transition.slidedown.js
@@ -14,7 +14,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.slidedown = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.slidefade.js
+++ b/js/jquery.mobile.transition.slidefade.js
@@ -15,7 +15,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 // Set the slide transition's fallback to "fade"
 $.mobile.transitionFallbacks.slidefade = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.slideup.js
+++ b/js/jquery.mobile.transition.slideup.js
@@ -14,7 +14,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.slideup = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.transition.turn.js
+++ b/js/jquery.mobile.transition.turn.js
@@ -14,7 +14,7 @@ define( [ "jquery", "./jquery.mobile.transition" ], function( $ ) {
 
 $.mobile.transitionFallbacks.turn = "fade";
 
-})( jQuery, this );
+})( jQuery, window );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");

--- a/js/jquery.mobile.zoom.iosorientationfix.js
+++ b/js/jquery.mobile.zoom.iosorientationfix.js
@@ -38,7 +38,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.zoom" ], function( 
 		.bind( "orientationchange.iosorientationfix", zoom.enable )
 		.bind( "devicemotion.iosorientationfix", checkTilt );
 
-}( jQuery, this ));
+}( jQuery, window ));
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });
 //>>excludeEnd("jqmBuildExclude");


### PR DESCRIPTION
I checked jQuery mobile with a prepended "use strict"; in Chrome.
Though I didn't leave it there, I fixed all errors preventing strict mode.
In my experience, strict mode serves as a very good alternative to a linter.
