### PR TITLE
Fixes #3998 - All buttons, regardless of markup, should be mini by default in toolbars

### DIFF
--- a/css/structure/jquery.mobile.button.css
+++ b/css/structure/jquery.mobile.button.css
@@ -7,6 +7,10 @@
 
 .ui-header .ui-btn,
 .ui-footer .ui-btn { display: inline-block; margin: 0; }
+.ui-header .ui-btn-block,
+.ui-footer .ui-btn-block { display: block; margin: .25em 5px; }
+.ui-header .ui-btn-block.ui-fullsize,
+.ui-footer .ui-btn-block.ui-fullsize { margin: .5em 5px; }
 
 .ui-header .ui-btn-inner,
 .ui-footer .ui-btn-inner,

--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -80,10 +80,9 @@ $.fn.buttonMarkup = function( options ) {
 		}
 		
 		if ( o.inline !== undefined ) {			
-			// Used to control styling in headers/footers, where buttons default to `mini` style.
-			buttonClass += o.inline === false ? " ui-btn-block" : " ui-btn-inline";
+			// Used to control styling in headers/footers, where buttons default to `inline` style.
+			buttonClass += o.inline ? " ui-btn-inline" : " ui-btn-block";
 		}
-		
 		
 		if ( o.icon ) {
 			o.icon = "ui-icon-" + o.icon;
@@ -241,7 +240,7 @@ var attachEvents = function() {
 $( document ).bind( "pagecreate create", function( e ){
 
 	$( ":jqmData(role='button'), .ui-bar > a, .ui-header > a, .ui-footer > a, .ui-bar > :jqmData(role='controlgroup') > a", e.target )
-		.not( ".ui-btn, :jqmData(role='none'), :jqmData(role='nojs')" )
+		.not( "button, .ui-btn, :jqmData(role='none'), :jqmData(role='nojs')" )
 		.buttonMarkup();
 });
 

--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -240,7 +240,7 @@ var attachEvents = function() {
 $( document ).bind( "pagecreate create", function( e ){
 
 	$( ":jqmData(role='button'), .ui-bar > a, .ui-header > a, .ui-footer > a, .ui-bar > :jqmData(role='controlgroup') > a", e.target )
-		.not( "button, .ui-btn, :jqmData(role='none'), :jqmData(role='nojs')" )
+		.not( "button, input, .ui-btn, :jqmData(role='none'), :jqmData(role='nojs')" )
 		.buttonMarkup();
 });
 

--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -70,18 +70,17 @@ $.fn.buttonMarkup = function( options ) {
 		}		
 
 		buttonClass = "ui-btn ui-btn-up-" + o.theme;
-		buttonClass += o.inline ? " ui-btn-inline" : "";
 		buttonClass += o.shadow ? " ui-shadow" : "";
 		buttonClass += o.corners ? " ui-btn-corner-all" : "";
 
 		if ( o.mini !== undefined ) {
 			// Used to control styling in headers/footers, where buttons default to `mini` style.
-			buttonClass += o.mini ? " ui-mini" : " ui-fullsize";
+			buttonClass += o.mini === true ? " ui-mini" : " ui-fullsize";
 		}
 		
 		if ( o.inline !== undefined ) {			
 			// Used to control styling in headers/footers, where buttons default to `inline` style.
-			buttonClass += o.inline ? " ui-btn-inline" : " ui-btn-block";
+			buttonClass += o.inline === true ? " ui-btn-inline" : " ui-btn-block";
 		}
 		
 		if ( o.icon ) {

--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -13,12 +13,10 @@ $.widget( "mobile.button", $.mobile.widget, {
 		theme: null,
 		icon: null,
 		iconpos: null,
-		inline: false,
 		corners: true,
 		shadow: true,
 		iconshadow: true,
-		initSelector: "button, [type='button'], [type='submit'], [type='reset'], [type='image']",
-		mini: false
+		initSelector: "button, [type='button'], [type='submit'], [type='reset'], [type='image']"
 	},
 	_create: function() {
 		var $el = this.element,
@@ -26,6 +24,8 @@ $.widget( "mobile.button", $.mobile.widget, {
 			o = this.options,
 			type,
 			name,
+			inline = $el.jqmData( "inline" ),
+			mini = $el.jqmData( "mini" ),
 			classes = "",
 			$buttonPlaceholder;
 
@@ -61,11 +61,11 @@ $.widget( "mobile.button", $.mobile.widget, {
 				theme: o.theme,
 				icon: o.icon,
 				iconpos: o.iconpos,
-				inline: o.inline,
+				inline: inline,
 				corners: o.corners,
 				shadow: o.shadow,
 				iconshadow: o.iconshadow,
-				mini: o.mini
+				mini: mini
 			})
 			.addClass( classes )
 			.append( $el.addClass( "ui-btn-hidden" ) );

--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -24,8 +24,8 @@ $.widget( "mobile.button", $.mobile.widget, {
 			o = this.options,
 			type,
 			name,
-			inline = $el.jqmData( "inline" ),
-			mini = $el.jqmData( "mini" ),
+			inline = o.inline || $el.jqmData( "inline" ),
+			mini = o.mini || $el.jqmData( "mini" ),
 			classes = "",
 			$buttonPlaceholder;
 


### PR DESCRIPTION
This is a copy of PR #4291 which already has a thread but commits were lost

Issue: Buttons with <button> as markup do not default to mini in header and footer.
Cause: The button widget sets mini by default to false. The buttonMarkup function provides in an option to control the styling of buttons in headers/footer; when mini is set to false ui-fullsize class is added and the default mini style won't apply.
Fix: Removed default from button widget in forms.button.js

Additional 1:
The same goes for inline style. When set to false the class ui-btn-block is added and the default inline style won't apply.
Issues: There are no rules for .ui-header/footer .ui-btn-block in the CSS so this doesn't work at all. The button widget also sets inline by default to false.
Fix: Added ui-btn-block rules to button.css and removed default from button widget in form.button.js

Additional 2:
Issue: When data-role="button" is added to a <button> element the buttonMarkup function will be initialized by the element itself as well as the button widget which results in a button wrapped in another button.
Fix: Excluded <button> element from auto initialization in buttonMarkup.js

[Update:] Problem as mentioned at Additional 2 also applies to input elements. I pushed another commit to exclude those as well. This fixes: #3005

Passed all unit tests. Live test page: http://ugomobi.github.com/toolbar-button/

This PR fixes #3998
