### PR TITLE
Docs: Changed data-dividertheme into data-divider-theme (List basics & API page)

### DIFF
--- a/docs/lists/docs-lists.html
+++ b/docs/lists/docs-lists.html
@@ -71,7 +71,7 @@
 
 
 			<h2>List dividers</h2>
-			<p>List items can be turned into dividers to organize and group the list items. This is done by adding the <code> data-role="list-divider"</code> to any list item. These items are styled with the bar swatch "b" by default (blue in the default theme) but you can specify a theme for dividers by adding the <code>data-dividertheme</code> attribute to the list element (<code>ul</code> or <code>ol</code>) and specifying a theme swatch letter.</p>
+			<p>List items can be turned into dividers to organize and group the list items. This is done by adding the <code> data-role="list-divider"</code> to any list item. These items are styled with the bar swatch "b" by default (blue in the default theme) but you can specify a theme for dividers by adding the <code>data-divider-theme</code> attribute to the list element (<code>ul</code> or <code>ol</code>) and specifying a theme swatch letter.</p>
 
 			<a href="lists-divider.html" data-role="button" data-icon="arrow-r" data-iconpos="right">List divider example</a>
 
@@ -157,7 +157,7 @@ $("#mylistview").listview({
 
 						<h3>More in this section</h3>
 
-						<ul data-role="listview" data-theme="c" data-dividertheme="d">
+						<ul data-role="listview" data-theme="c" data-divider-theme="d">
 
 							<li data-role="list-divider">List views</li>
 							<li data-theme="a"><a href="docs-lists.html">List basics &amp; API</a></li>


### PR DESCRIPTION
In the data attribute reference and on the "theming lists" page we call this option "data-divider-theme", but on this "List basics & API" page we refer to "data-dividertheme".

While checking the JS to see what is correct I noticed that both will work. Same goes for some other options (i.e. data-count-theme or data-counttheme), but not all (data-headertheme doesn't work for example).

For consistency I think it's best to change it on this page to "data-divider-theme"
