### PR TITLE
Docs: added text about read-only list items being styled as buttons (theming lists page)

### DIFF
--- a/docs/lists/lists-themes.html
+++ b/docs/lists/lists-themes.html
@@ -25,7 +25,7 @@
 	<div data-role="content" class="ui-body">
 		<div class="content-primary">	
 
-		<p>All the standard button swatches can be applied to lists. A list inherits its theme swatch from its parent page/content container. So the theme swatch defaults to &quot;c&quot; (silver in the default theme), if nothing else is set to the surrounding page/content containers. List dividers are styled with bar swatch &quot;b&quot; by default (blue in the default theme). The default button swatch for count bubbles is &quot;c&quot; (silver in the default theme).</p>
+		<p>All the standard button swatches can be applied to lists. If no theme has been specified, a list inherits its theme swatch from its parent page/content container. So the theme swatch defaults to &quot;c&quot; (silver in the default theme), if nothing else is set to the surrounding page/content containers. Read-only list items get the body styling from the assigned swatch. List dividers are styled with bar swatch &quot;b&quot; by default (blue in the default theme). The default button swatch for count bubbles is &quot;c&quot; (silver in the default theme).</p>
 		
 		<p>Below is a list which inherits the default &quot;c&quot; content swatch and uses the default swatches for the list divider and the count bubbles.</p>
 		


### PR DESCRIPTION
self-explanatory
