### PR TITLE
Docs: changed info about read-only lists (List basics & API page)

### DIFF
--- a/docs/lists/docs-lists.html
+++ b/docs/lists/docs-lists.html
@@ -59,7 +59,7 @@
 			<a href="lists-ol.html" data-role="button" data-icon="arrow-r" data-iconpos="right">Numbered list example</a>
 
 			<h2>Read-only lists</h2>
-			<p>List views can also be used to display a non-interactive list of items, usually as an inset list. This list is built from an unordered or ordered list that don't have linked list items. The framework defaults to styling these list with the "c" theme swatch and sets the text size to a smaller size than the clickable lists to save a bit of space.</p>
+			<p>List views can also be used to display a non-interactive list of items, usually as an inset list. This list is built from an unordered or ordered list that don't have linked list items. The framework styles the items of these lists as body instead of buttons and sets the text size to a smaller size than the clickable lists to save a bit of space.</p>
 
 			<a href="lists-readonly-inset.html" data-role="button" data-icon="arrow-r" data-iconpos="right">Read-only list example</a>
 


### PR DESCRIPTION
I removed the info about read-only lists getting swatch "c" by default because it is incorrect. How inheriting the page/content swatch works is explained at "theming lists" page and is the same for all types of lists.

Added info about read-only lists being styled as body and not as buttons.
