### PR TITLE
Resetting ignoreNextHashChange without a timer in poppedState ~ follow up #3980 and #4094

### DIFF
--- a/js/jquery.mobile.navigation.pushstate.js
+++ b/js/jquery.mobile.navigation.pushstate.js
@@ -68,6 +68,7 @@ define( [ "jquery", "./jquery.mobile.navigation", "../external/requirejs/depend!
 		onHashChange: function( e ) {
 			// disable this hash change
 			if( self.onHashChangeDisabled ){
+				self.onHashChangeDisabled = false;
 				return;
 			}
 

--- a/js/jquery.mobile.navigation.pushstate.js
+++ b/js/jquery.mobile.navigation.pushstate.js
@@ -28,11 +28,7 @@ define( [ "jquery", "./jquery.mobile.navigation", "../external/requirejs/depend!
 		// TODO move to a path helper, this is rather common functionality
 		initialFilePath: (function() {
 			return url.pathname + url.search;
-		})(),
-
-		hashChangeTimeout: 200,
-
-		hashChangeEnableTimer: undefined,
+		})(),	
 
 		initialHref: url.hrefNoHash,
 
@@ -109,29 +105,17 @@ define( [ "jquery", "./jquery.mobile.navigation", "../external/requirejs/depend!
 		// on popstate (ie back or forward) we need to replace the hash that was there previously
 		// cleaned up by the additional hash handling
 		onPopState: function( e ) {
-			var poppedState = e.originalEvent.state,
-				fromHash, toHash, hashChanged;
+			var poppedState = e.originalEvent.state;
 
 			// if there's no state its not a popstate we care about, eg chrome's initial popstate
 			if( poppedState ) {
-				// if we get two pop states in under this.hashChangeTimeout
-				// make sure to clear any timer set for the previous change
-				clearTimeout( self.hashChangeEnableTimer );
 
-				// make sure to enable hash handling for the the _handleHashChange call
-				self.nextHashChangePrevented( false );
-
-				// change the page based on the hash in the popped state
 				$.mobile._handleHashChange( poppedState.hash );
 
-				// prevent any hashchange in the next self.hashChangeTimeout
-				self.nextHashChangePrevented( true );
-
-				// re-enable hash change handling after swallowing a possible hash
-				// change event that comes on all popstates courtesy of browsers like Android
-				self.hashChangeEnableTimer = setTimeout( function() {
-					self.nextHashChangePrevented( false );
-				}, self.hashChangeTimeout);
+				// if ignore is false, set to true, otherwise keep false
+				if( $.mobile.urlHistory.ignoreNextHashChange == false ) { 
+					self.nextHashChangePrevented( true );					   
+				}
 			}
 		},
 


### PR DESCRIPTION
Follow up to [3980-fix](https://github.com/jquery/jquery-mobile/commit/714266d60d5e9cd4c4e0cbec4b3ad7bf1152fe92#-P0) and [4094](https://github.com/jquery/jquery-mobile/issues/4094)

This should work without a 200ms timer, too (I'm having trouble with the 200ms and pagebeforechange)

ignoreNextHashChange is not set/reset very often. So consider this:

1) ignoreNextHashChange (= ignore) is initially set to FALSE.

2) On forward transitions it's set to ignore=TRUE inside changepage (line 3608, latest), so the trailing hashchange enters poppedState with ignore=TRUE, which is blocked in _handleHashChange and reset to ignore="FALSE". The if-clause here just "double-sets" to ignore=TRUE.

3a) On backwards transitions, _handleHashChange thus should always receive ignore=FALSE (either initially... can't be... or following a forward transition when ignore=FALSE was set from the blocked trailing hashchange of the previous forward/backward transition.

3b) Therefore simply firing _handleHashChange should pass ignore=FALSE, which lets this "first" iteration run through. The if-clause sets ignore=TRUE after firing _handleHashChange. The hashchange triggered from the changePage call in _handleHashChange will now enter popped state with ignore="TRUE" and will be blocked inside _handleHashChange and reset to "FALSE". 

Makes sense and works in my mini-setup [test](http://www.franckreich.de/jqm/sample.html)
