### PR TITLE
Issue #4254

### DIFF
--- a/css/structure/jquery.mobile.button.css
+++ b/css/structure/jquery.mobile.button.css
@@ -20,6 +20,8 @@
 .ui-btn-icon-notext .ui-btn-inner .ui-icon { margin: 2px 1px 2px 3px; }
 
 .ui-btn-text { position: relative; z-index: 1; width: 100%; }
+/* Fixes #4254 to prevent inherit font-size from .ui-li-divider, .ui-li-static */
+.ui-li-divider .ui-btn-text, .ui-li-static .ui-btn-text { font-size: 16px; }
 .ui-btn-icon-notext .ui-btn-text { position: absolute; left: -9999px; }
 
 .ui-btn-icon-left .ui-btn-inner { padding-left: 40px; }

--- a/css/structure/jquery.mobile.button.css
+++ b/css/structure/jquery.mobile.button.css
@@ -20,8 +20,6 @@
 .ui-btn-icon-notext .ui-btn-inner .ui-icon { margin: 2px 1px 2px 3px; }
 
 .ui-btn-text { position: relative; z-index: 1; width: 100%; }
-/* Fixes #4254 to prevent inherit font-size from .ui-li-divider, .ui-li-static */
-.ui-li-divider .ui-btn-text, .ui-li-static .ui-btn-text { font-size: 16px; }
 .ui-btn-icon-notext .ui-btn-text { position: absolute; left: -9999px; }
 
 .ui-btn-icon-left .ui-btn-inner { padding-left: 40px; }

--- a/css/structure/jquery.mobile.listview.css
+++ b/css/structure/jquery.mobile.listview.css
@@ -7,6 +7,7 @@
 .ui-li-divider, .ui-li-static { padding: .5em 15px; font-size: 14px; font-weight: bold;  }
 /* Fixes #4254 to prevent inherit font-size from .ui-li-divider, .ui-li-static */
 .ui-li-divider .ui-btn-text, .ui-li-static .ui-btn-text { font-size: 16px; }
+.ui-li-divider .ui-mini .ui-btn-text, .ui-li-static .ui-mini .ui-btn-text { font-size: inherit; }
 .ui-li-divider { counter-reset: listnumbering;  }
 ol.ui-listview .ui-link-inherit:before, ol.ui-listview .ui-li-static:before, .ui-li-dec { font-size: .8em; display: inline-block; padding-right: .3em; font-weight: normal;counter-increment: listnumbering; content: counter(listnumbering) ". "; }
 ol.ui-listview .ui-li-jsnumbering:before { content: "" !important; } /* to avoid chance of duplication */

--- a/css/structure/jquery.mobile.listview.css
+++ b/css/structure/jquery.mobile.listview.css
@@ -5,6 +5,8 @@
 .ui-li, .ui-li.ui-field-contain { display: block; margin:0; position: relative; overflow: visible; text-align: left; border-width: 0; border-top-width: 1px; }
 .ui-li .ui-btn-text a.ui-link-inherit { text-overflow: ellipsis; overflow: hidden; white-space: nowrap;  }
 .ui-li-divider, .ui-li-static { padding: .5em 15px; font-size: 14px; font-weight: bold;  }
+/* Fixes #4254 to prevent inherit font-size from .ui-li-divider, .ui-li-static */
+.ui-li-divider .ui-btn-text, .ui-li-static .ui-btn-text { font-size: 16px; }
 .ui-li-divider { counter-reset: listnumbering;  }
 ol.ui-listview .ui-link-inherit:before, ol.ui-listview .ui-li-static:before, .ui-li-dec { font-size: .8em; display: inline-block; padding-right: .3em; font-weight: normal;counter-increment: listnumbering; content: counter(listnumbering) ". "; }
 ol.ui-listview .ui-li-jsnumbering:before { content: "" !important; } /* to avoid chance of duplication */


### PR DESCRIPTION
Added CSS rule for font-size of .ui-btn-text to prevent inherit font-size from .ui-li-divider, .ui-li-static.
Moved CSS rule for font-size of .ui-btn-text nested inside the list to the appropriate css file to keep a logical order.
