### PR TITLE
Fixes issue #2425: Set navbar buttons to the active state

### DIFF
--- a/docs/toolbars/footer-persist-a.html
+++ b/docs/toolbars/footer-persist-a.html
@@ -100,7 +100,7 @@
 	<div data-role="footer" data-id="foo1" data-position="fixed">
 		<div data-role="navbar">
 			<ul>
-				<li><a href="footer-persist-a.html" data-prefetch="true" class="ui-btn-active ui-state-persist">Friends</a></li>
+				<li><a href="footer-persist-a.html" data-prefetch="true" class="ui-btn-active">Friends</a></li>
 				<li><a href="footer-persist-b.html" data-prefetch="true">Albums</a></li>
 				<li><a href="footer-persist-c.html" data-prefetch="true">Emails</a></li>
 				<li><a href="footer-persist-d.html" data-prefetch="true" data-transition="slideup">Info</a></li>

--- a/docs/toolbars/footer-persist-b.html
+++ b/docs/toolbars/footer-persist-b.html
@@ -127,7 +127,7 @@
 			<div data-role="navbar">
 				<ul>
 					<li><a href="footer-persist-a.html" data-prefetch="true">Friends</a></li>
-					<li><a href="footer-persist-b.html" data-prefetch="true" class="ui-btn-active ui-state-persist">Albums</a></li>
+					<li><a href="footer-persist-b.html" data-prefetch="true" class="ui-btn-active">Albums</a></li>
 					<li><a href="footer-persist-c.html" data-prefetch="true">Emails</a></li>
 					<li><a href="footer-persist-d.html" data-prefetch="true" data-transition="slideup">Info</a></li>
 				</ul>

--- a/docs/toolbars/footer-persist-c.html
+++ b/docs/toolbars/footer-persist-c.html
@@ -109,7 +109,7 @@
 				<ul>
 					<li><a href="footer-persist-a.html" data-prefetch="true">Friends</a></li>
 					<li><a href="footer-persist-b.html" data-prefetch="true">Albums</a></li>
-					<li><a href="footer-persist-c.html" data-prefetch="true" class="ui-btn-active ui-state-persist">Emails</a></li>
+					<li><a href="footer-persist-c.html" data-prefetch="true" class="ui-btn-active">Emails</a></li>
 					<li><a href="footer-persist-d.html" data-prefetch="true" data-transition="slideup">Info</a></li>
 				</ul>
 			</div><!-- /navbar -->

--- a/docs/toolbars/footer-persist-d.html
+++ b/docs/toolbars/footer-persist-d.html
@@ -36,15 +36,15 @@
 			&lt;li&gt;&lt;a href=&quot;a.html&quot;&gt;Friends&lt;/a&gt;&lt;/li&gt;
 			&lt;li&gt;&lt;a href=&quot;b.html&quot;&gt;Albums&lt;/a&gt;&lt;/li&gt;
 			&lt;li&gt;&lt;a href=&quot;c.html&quot;&gt;Emails&lt;/a&gt;&lt;/li&gt;
-			&lt;li&gt;&lt;a href=&quot;d.html&quot; &gt;Info&lt;/a&gt;&lt;/li&gt;
+			&lt;li&gt;&lt;a href=&quot;d.html&quot;&gt;Info&lt;/a&gt;&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;&lt;!-- /navbar --&gt;
 &lt;/div&gt;&lt;!-- /footer --&gt;
 </code></pre>
-		<p>To set the active state of an item in a persistent toolbar, add a class of <code>ui-state-persist</code> in addition to <code>ui-btn-active</code> to the corresponding anchor.</p>
+		<p>To set one of the navbar buttons to the active (selected) state, add <code>class="ui-btn-active"</code> to the corresponding anchor.</p>
 		
 <pre><code>	
-&lt;li&gt;&lt;a href=&quot;d.html&quot; <strong>class=&quot;ui-btn-active ui-state-persist&quot;</strong>&gt;Info&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&quot;d.html&quot; <strong>class=&quot;ui-btn-active&quot;</strong>&gt;Info&lt;/a&gt;&lt;/li&gt;
 </code></pre>
 
 		<h3>A note about transitions</h3>
@@ -81,7 +81,7 @@
 					<li><a href="footer-persist-a.html" data-prefetch="true">Friends</a></li>
 					<li><a href="footer-persist-b.html" data-prefetch="true">Albums</a></li>
 					<li><a href="footer-persist-c.html" data-prefetch="true">Emails</a></li>
-					<li><a href="footer-persist-d.html" data-prefetch="true" data-transition="slideup" class="ui-btn-active ui-state-persist">Info</a></li>
+					<li><a href="footer-persist-d.html" data-prefetch="true" data-transition="slideup" class="ui-btn-active">Info</a></li>
 				</ul>
 			</div><!-- /navbar -->
 		</div><!-- /footer -->

--- a/js/jquery.mobile.navbar.js
+++ b/js/jquery.mobile.navbar.js
@@ -32,6 +32,8 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 		if ( !iconpos ) {
 			$navbar.addClass( "ui-navbar-noicons" );
 		}
+		
+		$navbtns.filter( ".ui-btn-active" ).addClass( "ui-state-persist" );
 
 		$navbtns.buttonMarkup({
 			corners:	false,
@@ -49,7 +51,7 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 
 		// Buttons in the navbar with ui-state-persist class should regain their active state before page show
 		$navbar.closest( ".ui-page" ).bind( "pagebeforeshow", function() {
-			$navbtns.filter( ".ui-state-persist" ).addClass( $.mobile.activeBtnClass );
+			$navbtns.removeClass( $.mobile.activeBtnClass ).filter( ".ui-state-persist" ).addClass( $.mobile.activeBtnClass );
 		});
 	}
 });


### PR DESCRIPTION
Issue:

In the docs on the "Navbars" page is explained that you can add class ui-btn-active in the markup to give a navbar button the active state. Only at the "Persistent toolbars" page is mentioned that you need to add class ui-state-persist as well.
In fact you always need to add class ui-state-persist to make sure the button get the active state again on pageshow. Otherwise it only gets the active state again when the navbar is enhanced again, which does not happen if that page remains in the DOM.

Fix:

I added a function to the navbar widget that adds class ui-state-persist to anchor elements with class ui-btn-active during enhancement.
Additionally I changed the function that restores class ui-btn-active so it first removes this class from all navbar links. This is for the examples on the "Navbars" page which are not real links, so removing ui-btn-active upon succesful navigation does not happen.
In the docs I removed the info on the "Persistent toolbars" page about adding class ui-state-persist manually and I removed this class from the markup.

Fixes issue #2425
