### PR TITLE
Text on buttons should not be selectable Rev 2

### DIFF
--- a/css/structure/jquery.mobile.button.css
+++ b/css/structure/jquery.mobile.button.css
@@ -23,7 +23,7 @@
 .ui-btn-icon-notext .ui-btn-inner { padding: 0; height: 100%; }
 .ui-btn-icon-notext .ui-btn-inner .ui-icon { margin: 2px 1px 2px 3px; }
 
-.ui-btn-text { position: relative; z-index: 1; width: 100%; }
+.ui-btn-text { position: relative; z-index: 1; width: 100%; -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none; }
 .ui-btn-icon-notext .ui-btn-text { position: absolute; left: -9999px; }
 
 .ui-btn-icon-left .ui-btn-inner { padding-left: 40px; }

--- a/css/structure/jquery.mobile.forms.checkboxradio.css
+++ b/css/structure/jquery.mobile.forms.checkboxradio.css
@@ -22,4 +22,3 @@
 
 /* input, label positioning */
 .ui-checkbox input,.ui-radio input { position:absolute; left:20px; top:50%; width: 10px; height: 10px;  margin:-5px 0 0 0; outline: 0 !important; z-index: 1; }
-.ui-checkbox label,.ui-radio label { -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none; }


### PR DESCRIPTION
Removes the `.ui-checkbox label` user-select rule for checkboxes and radios
adds `user-select: none` for `ui-btn-text` at all

Demo: http://jsfiddle.net/MauriceG/SbFSk/show/
(demo uses own hosted css with this changes applied)
