### PR TITLE
Fixes issue #4114 - mini listview not supported

### DIFF
--- a/js/jquery.mobile.listview.js
+++ b/js/jquery.mobile.listview.js
@@ -23,7 +23,6 @@ $.widget( "mobile.listview", $.mobile.widget, {
 		dividerTheme: "b",
 		splitIcon: "arrow-r",
 		splitTheme: "b",
-		mini: false,
 		inset: false,
 		initSelector: ":jqmData(role='listview')"
 	},
@@ -33,7 +32,6 @@ $.widget( "mobile.listview", $.mobile.widget, {
 			listviewClasses = "";
 
 		listviewClasses += t.options.inset ? " ui-listview-inset ui-corner-all ui-shadow " : "";
-		listviewClasses += t.element.jqmData( "mini" ) || t.options.mini === true ? " ui-mini" : "";
 
 		// create listview markup
 		t.element.addClass(function( i, orig ) {


### PR DESCRIPTION
As discussed at #4114 we are not supporting data-mini="true" on listviews.
This commit removes the option from the JS. No changes in CSS needed.
