### PR TITLE
33.333% leads to a small space left on the right of the three buttons

### DIFF
--- a/css/structure/jquery.mobile.grid.css
+++ b/css/structure/jquery.mobile.grid.css
@@ -10,7 +10,7 @@
 .ui-grid-a .ui-block-a { clear: left; }
 
 /* grid b: 33/33/33 */
-.ui-grid-b .ui-block-a, .ui-grid-b .ui-block-b, .ui-grid-b .ui-block-c { width: 33.333%; }
+.ui-grid-b .ui-block-a, .ui-grid-b .ui-block-b, .ui-grid-b .ui-block-c { width: 33.334%; }
 .ui-grid-b .ui-block-a { clear: left; }
 
 /* grid c: 25/25/25/25 */


### PR DESCRIPTION
33.333% leads to a small space left on the right of the three buttons which is very visible when the rightmost button is selected. 

Adding 0.001% seems to get rid of that space without overflowing the rightmost button on a new line.
