### PR TITLE
Fixes #4001 - Page flash after transition

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -14,7 +14,7 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 .ui-mobile .ui-page-active { display: block; overflow: visible; }
 
 /* on ios4, setting focus on the page element causes flashing during transitions when there is an outline, so we turn off outlines */
-.ui-page { outline: none; }
+.ui-page { outline: none; -webkit-backface-visibility: hidden; }
 
 /*orientations from js are available */
 @media screen and (orientation: portrait){


### PR DESCRIPTION
Fixes #4001
Tested on: BlackBerry 9900 - 7.1, BlackBerry 10 devAlpha, iPad 5.1,
Chrome, Firefox 12
