### PR TITLE
Docs: Fixed typo in swipe description vertical should be 75px

### DIFF
--- a/docs/api/events.html
+++ b/docs/api/events.html
@@ -53,7 +53,7 @@
 			</dd>
 
 			<dt><code>swipe</code></dt>
-			<dd><p>Triggers when a horizontal drag of 30px or more (and less than 20px vertically) occurs within 1 second duration but these can be configured:</p>
+			<dd><p>Triggers when a horizontal drag of 30px or more (and less than 75px vertically) occurs within 1 second duration but these can be configured:</p>
 			  <ul>
 			  	<li><code>$.event.special.swipe.scrollSupressionThreshold</code> (default: 10px) – More than this horizontal displacement, and we will suppress scrolling.</li>
 			  	<li><code>$.event.special.swipe.durationThreshold</code> (default: 1000ms) – More time than this, and it isn’t a swipe.</li>


### PR DESCRIPTION
...(see verticalDistanceThreshold property)
