### PR TITLE
Docs: Minor update for description of taphold event.

### DIFF
--- a/docs/api/events.html
+++ b/docs/api/events.html
@@ -46,7 +46,7 @@
 			</dd>
 
 			<dt><code>taphold</code></dt>
-			<dd><p>Triggers after a held complete touch event (close to one second).</p>
+			<dd><p>Triggers after a held complete touch event.</p>
 			<ul>
 				<li><code>$.event.special.tap.tapholdThreshold</code> (default: 750ms) – This value dictates how long the user must hold their tap before the taphold event is fired on the target element.</li>
 			</ul>


### PR DESCRIPTION
 Removed the redundant info "(close to one second)" as the line just below this says 750ms as the tapholdTreshold value.
