### PR TITLE
Fixes #4493: remove query string from hash before trying to find page with that hash in initializePage

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -83,7 +83,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.support", "./jquery
 			// Remember, however, that the hash can also be a path!
 			if ( ! ( $.mobile.hashListeningEnabled &&
 			         $.mobile.path.isHashValid( location.hash ) &&
-			         ( $( location.hash + ':jqmData(role="page")' ).length ||
+			         ( $( '#' + $.mobile.path.cleanHash( location.hash ) + ':jqmData(role="page")' ).length ||
 			           $.mobile.path.isPath( location.hash ) ) ) ) {
 				$.mobile.changePage( $.mobile.firstPage, { transition: "none", reverse: true, changeHash: false, fromHashChange: true } );
 			}


### PR DESCRIPTION
Not removing the query string causes the page lookup to fail when there is a period somewhere in the query string and initializePage will load $.mobile.firstPage rather than the page given in the hash.
