### PR TITLE
change invaid US-ASCII apostrophe character in comment

### DIFF
--- a/js/jquery.mobile.forms.button.js
+++ b/js/jquery.mobile.forms.button.js
@@ -81,7 +81,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 		// Add hidden input during submit if input type="submit" has a name.
 		if ( type !== "button" && type !== "reset" && name ) {
 				$el.bind( "vclick", function() {
-					// Add hidden input if it doesn’t already exist.
+					// Add hidden input if it doesn't already exist.
 					if( $buttonPlaceholder === undefined ) {
 						$buttonPlaceholder = $( "<input>", {
 							type: "hidden",


### PR DESCRIPTION
While trying to use the compiled jquery.mobile-1.1.0.js in a sinatra project using sprockets I received an error indicating that the file contained an invalid US-ASCII character. I tracked it down to an apostrophe in a comment.

This change replaces that invalid character with a valid one so the javascript will work with ruby 1.9.3 and sprockets.
