### PR TITLE
Broken listview layout with fieldcontainers

### DIFF
--- a/css/structure/jquery.mobile.forms.fieldcontain.css
+++ b/css/structure/jquery.mobile.forms.fieldcontain.css
@@ -13,7 +13,7 @@
 	right: 1em;
 }
 
-.ui-field-contain, .ui-mobile fieldset.ui-field-contain { width: 100%; } /* This prevents horizontal scrollbar in IE7 */
+.ui-field-contain:not(.ui-li), .ui-mobile fieldset.ui-field-contain { width: 100%; } /* This prevents horizontal scrollbar in IE7 */
 
 @media all and (min-width: 450px){
 	.ui-field-contain, .ui-mobile fieldset.ui-field-contain { border-width: 0; padding: 0; margin: 1em 0; }


### PR DESCRIPTION
Cause of commit https://github.com/jquery/jquery-mobile/commit/4270ee054f1a2a9f2337ccab331fbe5bd1d0933f the layout of listviews with fieldcontainers get broken due to a container-width of 100%: http://jsfiddle.net/MauriceG/9MUht/ and http://jquerymobile.com/test/docs/lists/lists-forms-inset.html 
