### PR TITLE
fixedToolbar.js: adding spaces pre/post brackets

### DIFF
--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -177,7 +177,7 @@ define( [ "../jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../j
 			if( this.options.fullscreen ){ return; }
 
 			tbPage = tbPage || $el.closest( ".ui-page" );
-			$(tbPage).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() );
+			$( tbPage ).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() );
 		},
 
 		_useTransition: function( notransition ){


### PR DESCRIPTION
according the liberal spacing syntax rule: http://docs.jquery.com/JQuery_Core_Style_Guidelines#Spacing
