### PR TITLE
Issue #4535: Modified click handler to remove the call to window.history...

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1114,6 +1114,9 @@ define( [
 			toPage.jqmData( "title", pageTitle );
 		}
 
+		// This sets the scrollTo value for the page we're transitioning to
+		toPage.toPageScrollTo = settings.toPageScrollPosition;
+
 		// Make sure we have a transition defined.
 		settings.transition = settings.transition ||
 			( ( historyDir && !activeIsInitialPage ) ? active.transition : undefined ) ||
@@ -1309,16 +1312,50 @@ define( [
 				window.setTimeout( function() { removeActiveLinkClass( true ); }, 200 );
 			};
 
-			//if there's a data-rel=back attr, go back in history
-			if( $link.is( ":jqmData(rel='back')" ) ) {
-				window.history.back();
-				return false;
-			}
+		    // set up defaults for the new data-rel='back' link handling
+		    var prev = null;
+		    var toPageScrollTo = 0;
+
+		    //if there's a data-rel=back attr, go back in history
+		    if( $link.is( ":jqmData(rel='back')" ) ) {
+
+		        // Instead of calling window.history.back() let's use the urlHistory object to get the
+		        // previous url.  This fixes a bounce down to the scrollTo of the previous page caused 
+		        // by the call to window.history.back()
+		        prev = $.mobile.urlHistory.getPrev();
+		    }
 
 			var baseUrl = getClosestBaseUrl( $link ),
 
 				//get href, if defined, otherwise default to empty hash
 				href = path.makeUrlAbsolute( $link.attr( "href" ) || "#", baseUrl );
+
+		    // if prev is not null, then we must be going back
+		    if ( prev != null ) {
+
+		        var lastChar = href.substring(href.length - 1, href.length);
+
+		        if ( lastChar === "#" ) {
+
+		        	href = path.makeUrlAbsolute( href + prev.url );
+
+		        } else {
+
+		        	href = path.makeUrlAbsolute( prev.url );
+		        }
+
+		        // We need this so we can pass it as a changePage setting
+		        toPageScrollTo = prev.lastScroll;
+
+		        // removing the currently active entry from urlHistory
+		        removed_active = $.mobile.urlHistory.stack.pop();
+		        
+		        // removing previous item from stack too since we already have the url and it will be added back on the stack when we get there
+		        removed_previous = $.mobile.urlHistory.stack.pop();
+
+		        // decrement urlHistory activeIndex 
+		        $.mobile.urlHistory.activeIndex = $.mobile.urlHistory.activeIndex - 1;
+		    }
 
 			//if ajax is disabled, exit early
 			if( !$.mobile.ajaxEnabled && !path.isEmbeddedPage( href ) ){
@@ -1386,7 +1423,7 @@ define( [
 				$.mobile.popup.handleLink( $link );
 			}
 			else {
-				$.mobile.changePage( href, { transition: transition, reverse: reverse, role: role } );
+				$.mobile.changePage( href, { transition: transition, reverse: reverse, role: role, toPageScrollPosition: toPageScrollTo } );
 			}
 			event.preventDefault();
 		});

--- a/js/jquery.mobile.transition.js
+++ b/js/jquery.mobile.transition.js
@@ -22,7 +22,7 @@ var createHandler = function( sequential ){
 		var deferred = new $.Deferred(),
 			reverseClass = reverse ? " reverse" : "",
 			active	= $.mobile.urlHistory.getActive(),
-			toScroll = active.lastScroll || $.mobile.defaultHomeScroll,
+			toScroll = ( $to.toPageScrollTo || active.lastScroll ) || $.mobile.defaultHomeScroll,
 			screenHeight = $.mobile.getScreenHeight(),
 			maxTransitionOverride = $.mobile.maxTransitionWidth !== false && $( window ).width() > $.mobile.maxTransitionWidth,
 			none = !$.support.cssTransitions || maxTransitionOverride || !name || name === "none",

--- a/tests/unit/popup/popup_core.js
+++ b/tests/unit/popup/popup_core.js
@@ -365,7 +365,7 @@
 				closed: { src: $( "#test-popup" ), event: "closed.openCloseQuickStep1" },
 				hashchange1: { src: $( window ), event: "hashchange.openCloseQuickStep1a" },
 				hashchange2: { src: $( window ), event: "hashchange.openCloseQuickStep1b" },
-				timeout: { src: null, length: 600 }
+				timeout: { src: null, length: 700 }
 			},
 
 			function( result ) {


### PR DESCRIPTION
....back() which was contributing to jumpiness of transitions (especially noticeable on Android) and used urlHistory instead (see issue #4535 for more info).  Also updated a line of code in jquery.mobile.transition.js to retrieve the toPageScrollTo that's passed along.  Also updated the test for popup_core.js since there was one test failing which was not related to my changes, and only seemed to be a timing issue since changing line 368 to have a timeout length of 700 instead of 600 allowed the test to pass.
