### PR TITLE
Issue #4535: Modified click handler to remove the call to window.history...

### DIFF
--- a/js/jquery.mobile.transition.js
+++ b/js/jquery.mobile.transition.js
@@ -22,7 +22,7 @@ var createHandler = function( sequential ){
 		var deferred = new $.Deferred(),
 			reverseClass = reverse ? " reverse" : "",
 			active	= $.mobile.urlHistory.getActive(),
-			toScroll = active.lastScroll || $.mobile.defaultHomeScroll,
+			toScroll = ( $to.toPageScrollTo || active.lastScroll ) || $.mobile.defaultHomeScroll,
 			screenHeight = $.mobile.getScreenHeight(),
 			maxTransitionOverride = $.mobile.maxTransitionWidth !== false && $( window ).width() > $.mobile.maxTransitionWidth,
 			none = !$.support.cssTransitions || maxTransitionOverride || !name || name === "none",

--- a/tests/unit/popup/popup_core.js
+++ b/tests/unit/popup/popup_core.js
@@ -365,7 +365,7 @@
 				closed: { src: $( "#test-popup" ), event: "closed.openCloseQuickStep1" },
 				hashchange1: { src: $( window ), event: "hashchange.openCloseQuickStep1a" },
 				hashchange2: { src: $( window ), event: "hashchange.openCloseQuickStep1b" },
-				timeout: { src: null, length: 600 }
+				timeout: { src: null, length: 700 }
 			},
 
 			function( result ) {


### PR DESCRIPTION
....back() which was contributing to jumpiness of transitions (especially noticeable on Android) and used urlHistory instead (see issue #4535 for more info). Also updated a line of code in jquery.mobile.transition.js to retrieve the toPageScrollTo that's passed along. Also updated the test for popup_core.js since there was one test failing which was not related to my changes, and only seemed to be a timing issue since changing line 368 to have a timeout length of 700 instead of 600 allowed the test to pass.
