### PR TITLE
Add a setTimeout() round updatePagePadding() for fixedToolbar

### DIFF
--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -131,7 +131,9 @@ define( [ "../jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../j
 				})
 				.bind( "pageshow", function(){
 					var thisPage = this;
+
 					self.updatePagePadding( thisPage );
+
 					if( o.updatePagePadding ){
 						$( window ).bind( "throttledresize." + self.widgetName, function(){
 						 	self.updatePagePadding( thisPage );
@@ -177,7 +179,10 @@ define( [ "../jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../j
 			if( this.options.fullscreen ){ return; }
 
 			tbPage = tbPage || $el.closest( ".ui-page" );
-			$( tbPage ).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() );
+
+			setTimeout( function() {
+				$( tbPage ).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() );
+			}, 0);
 		},
 
 		_useTransition: function( notransition ){


### PR DESCRIPTION
In certain cases, the updatePagePadding() function (used
to reposition elements when a page has a fixed toolbar) doesn't
reposition other page elements at the correct stage of the
page render. This can result in elements further down the `<body>`
being partially covered by the fixed toolbar. (This usually resolves
itself if another page is navigated to, followed by a return to the
page with the obscured content.)

To remedy this, put a setTimeout() around updatePagePadding()
so that it is applied after rendering completes successfully.

NB The environment where I spotted this was Chrome (20.0.1132.3 dev)
on Linux.
