### PR TITLE
Docs: remove data-role="header" from buttons-in-bars-demo (api/themes.html)

### DIFF
--- a/docs/api/themes.html
+++ b/docs/api/themes.html
@@ -167,49 +167,54 @@
 		<p>If you want to add visual emphasis to a button, an alternate swatch color can be set by adding a <code> data-theme="a"</code> to the anchor. Once an alternate swatch color is set on a button in the markup, the framework won't override that color if the parent theme is changed, because you made a conscious decision to set it.</p>
 		
 		<div class="swatch-bars">
-			<div data-role="header" data-theme="a" class="ui-bar" >
+			<div class="ui-bar ui-bar-a">
+				Bar A
 				<div><!-- wrapper div to have control over butttons -->
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">A</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">B</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">C</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">D</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">E</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">Button A</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">Button B</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">Button C</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">Button D</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">Button E</a>
 				</div>
 			</div>
-			<div data-role="header" data-theme="b" class="ui-bar" >
+			<div class="ui-bar ui-bar-b">
+				Bar B
 				<div><!-- wrapper div to have control over butttons -->
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">A</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">B</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">C</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">D</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">E</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">Button A</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">Button B</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">Button C</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">Button D</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">Button E</a>
 				</div>
 			</div>
-			<div data-role="header" data-theme="c" class="ui-bar" >
+			<div class="ui-bar ui-bar-c">
+				Bar C
 				<div><!-- wrapper div to have control over butttons -->
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">A</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">B</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">C</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">D</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">E</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">Button A</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">Button B</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">Button C</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">Button D</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">Button E</a>
 				</div>
 			</div>
-			<div data-role="header" data-theme="d" class="ui-bar" >
+			<div class="ui-bar ui-bar-d">
+				Bar D
 				<div><!-- wrapper div to have control over butttons -->
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">A</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">B</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">C</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">D</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">E</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">Button A</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">Button B</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">Button C</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">Button D</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">Button E</a>
 				</div>
 			</div>
-			<div data-role="header" data-theme="e" class="ui-bar" >
+			<div class="ui-bar ui-bar-e">
+				Bar E
 				<div><!-- wrapper div to have control over butttons -->
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">A</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">B</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">C</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">D</a>
-					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">E</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="a">Button A</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="b">Button B</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="c">Button C</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="d">Button D</a>
+					<a href="index.html" data-role="button" data-icon="arrow-l" data-theme="e">Button E</a>
 				</div>
 			</div>
 			


### PR DESCRIPTION
Buttons in headers gets mini-styled by default.
Also changes the buttons single-letter-label (as discussed) and adds a swatch-label to the bars
