### PR TITLE
Issue #4559: Fixing the blink forward/back effect that sometimes happens...

### DIFF
--- a/css/structure/jquery.mobile.transition.css
+++ b/css/structure/jquery.mobile.transition.css
@@ -10,15 +10,18 @@
 }
 
 .in {
+    -webkit-animation-fill-mode: both;
 	-webkit-animation-timing-function: ease-out;
 	-webkit-animation-duration: 350ms;
+    -moz-animation-fill-mode: both;
 	-moz-animation-timing-function: ease-out;
 	-moz-animation-duration: 350ms;
 }
-
 .out {
+    -webkit-animation-fill-mode: both;
 	-webkit-animation-timing-function: ease-in;
 	-webkit-animation-duration: 225ms;
+    -moz-animation-fill-mode: both;
 	-moz-animation-timing-function: ease-in;
 	-moz-animation-duration: 225ms;
 }


### PR DESCRIPTION
... before and after transitions.  This fix will only work in browsers that support animation-fill-mode.  Here's a description of the relevant values of the animation-fill-mode property and their functions:

forwards
The target will retain the computed values set by the last keyframe encountered during execution. This is usually the '100%' or 'to' keyframe, unless animation-direction is 'alternate' and animation-iteration-count is set to an even number, in which case it is the '0%' or 'from' keyframe.

backwards
The animation will apply the values defined in the '0%' or 'from' keyframe as soon as it is applied to the target, and retain this during the animation-delay period.

both
The animation will follow the rules for both forwards and backwards, thus extending the animation properties in both directions.
