### PR TITLE
Fixes: #1181 - navbar link stays active when using changePage()

### DIFF
--- a/js/widgets/navbar.js
+++ b/js/widgets/navbar.js
@@ -41,6 +41,10 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 			if( !$(event.target).hasClass("ui-disabled") ) {
 				$navbtns.removeClass( $.mobile.activeBtnClass );
 				$( this ).addClass( $.mobile.activeBtnClass );
+				var activeNavbtn = $( this );
+				$( document ).one( "pagechange", function( event ) {
+					activeNavbtn.removeClass( $.mobile.activeBtnClass );
+				});
 			}
 		});
 


### PR DESCRIPTION
Clears the active button class on the pressed navbar button after a
pagechange.
