### PR TITLE
Docs: Remove double "the", adding code examples (buttons-types.html)

### DIFF
--- a/docs/buttons/buttons-types.html
+++ b/docs/buttons/buttons-types.html
@@ -74,22 +74,34 @@
 		<p>For ease of styling, the framework automatically converts any <code>button</code> or <code>input</code> element with a <code>type</code> of <code>submit</code>, <code>reset</code>, or <code>button</code> into a custom styled button &mdash; there is no need to add the <code> data-role="button"</code> attribute. However, if needed, you can directly call the button plugin on any selector, just like any jQuery plugin:</p>
 
 <code>
-$('[type='submit']').button();
+$('[type="submit"]').button();
 </code>
 
-		<p>To preserve events bound to the original <code>button</code> or <code>input</code>, the framework hides the original element by making it transparent and positioning it over the new button markup.  When a user clicks on the the custom-styled button, they're actually clicking on the original element. To prevent a form button from being converted into an enhanced button, add the <code>data-role="none"</code> attribute and the native control will be rendered.</p>
+		<p>To preserve events bound to the original <code>button</code> or <code>input</code>, the framework hides the original element by making it transparent and positioning it over the new button markup. When a user clicks on the custom-styled button, they're actually clicking on the original element. To prevent a form button from being converted into an enhanced button, add the <code>data-role="none"</code> attribute and the native control will be rendered.</p>
 
 		<p><strong>Button</strong> based button:</p>
+<pre><code>	
+&lt;button&gt;Button element&lt;/button&gt;
+</code></pre>
 		<button>Button element</button>
-		
+	
 		<p><strong>Input type="button"</strong> based button:</p>
-		<input type="button" value="buttonBtn" />
+<pre><code>	
+&lt;input type=&quot;button&quot; value=&quot;Button&quot; /&gt;
+</code></pre>
+		<input type="button" value="Button" />
 		
 		<p><strong>Input type="submit"</strong> based button:</p>
-		<input type="submit" value="submitBtn" />
+<pre><code>
+&lt;input type=&quot;submit&quot; value=&quot;Submit Button&quot; /&gt;
+</code></pre>
+		<input type="submit" value="Submit Button" />
 		
 		<p><strong>Input type="reset"</strong> based button:</p>
-		<input type="reset" value="resetBtn" />
+<pre><code>
+&lt;input type=&quot;reset&quot; value=&quot;Reset Button&quot; /&gt;
+</code></pre>
+		<input type="reset" value="Reset Button" />
 		
 	</div><!--/content-primary -->		
 	


### PR DESCRIPTION
- correct quote in quote in example code
- change labels from example form buttons
