### PR TITLE
Docs: Change "or" to "and" at popup (data-attributes.html)

### DIFF
--- a/docs/api/data-attributes.html
+++ b/docs/api/data-attributes.html
@@ -469,7 +469,7 @@
 			</table>
 
 			<h2><a href="../pages/popup/">Popup</a></h2>
-			<p>Container with <code>data-role="popup"</code> or linked to with <code>data-rel="popup"</code> on the anchor.</p>
+			<p>Container with <code>data-role="popup"</code> and linked to with <code>data-rel="popup"</code> on the anchor.</p>
 			<table>
 				<tr>
 					<th>data-corners</th>


### PR DESCRIPTION
Because both attributes, `data-role`at the popup div and `data-rel`at the calling anchor, are necessary to open a popup.
It's not possible to open a popup with an anchor like `<a href="#popup1" data-rel="popup">Popup</a>`, if the called div has no `data-role="popup"` set.
And it is also not possible to open a div without `data-role="popup"` just with a `data-rel="popup"` at the calling anchor.
This is a difference between popups and dialogs that may need some more explanation in the docs.
