### PR TITLE
Docs-Suggestion: Show version banner on all pages if not on final

### DIFF
--- a/docs/_assets/js/jqm-docs.js
+++ b/docs/_assets/js/jqm-docs.js
@@ -6,18 +6,21 @@ $(function(){
 });
 
 // display the version of jQM
-$(document).bind( 'pageinit', function() {
+$(document).bind( 'pageinit', function( event ) {
 	var version = $.mobile.version || "dev",
 		words = version.split( "-" ),
 		ver = words[0],
 		str = (words[1] || "Final"),
 		html = ver;
+		targetPage = $( event.target );
+		banner = targetPage.find( "p.jqm-version" );
 
 	str = str.charAt( 0 ).toUpperCase() + str.slice( 1 );
 	if ( $.mobile.version && str ) {
 		html += " <b>" + str + "</b>";
 	}
-	$( "p.jqm-version" ).html( html );
+ 	( str !== 'Final' && !banner.length ) ? targetPage.find( ':jqmData(role="content")' ).prepend( '<p class="jqm-version" style="z-index:1001; position:fixed;">' + html + '</p>' ) : null;
+	banner.length ? banner.html( html ) : null;
 })
 
 // Turn off AJAX for local file browsing


### PR DESCRIPTION
@agcolom, @toddparker, @ugomobi
This is just a suggestion to show the version banner on all pages in the docs, if the viewed version is a unstable one.
I suppose, the $.mobile.version "at home" is something like 1.2.0-pre for an pre-release. Therefore, if the version suffix is something else then "Final", the banner will be shown everywhere (except the page templates).
Demo at: http://test.jqmobile.de/  (`$.mobile.version` set to "1.2.0-pre" there). 
Addresses partly #3330
