### PR TITLE
Docs: Change fixed footer to page-end causing a gap if content is themed

### DIFF
--- a/docs/content/content-themes.html
+++ b/docs/content/content-themes.html
@@ -25,7 +25,7 @@
 	<div data-role="content">
 			<div class="content-primary">
 		<h2>Theming the content area</h2>
-		<p>The main content area of a page (container with the <code> data-role="content"</code> attribute) should be themed by adding the <code> data-theme</code> attribute to the <code> data-role="page"</code> container to ensure that the background colors are applied to the full page, regardless of the content length. (If you add the <code> data-theme</code> attribute to the content container, the background color will stop after the content. So there may be a gap in color between the content and fixed footer.)</p>
+		<p>The main content area of a page (container with the <code> data-role="content"</code> attribute) should be themed by adding the <code> data-theme</code> attribute to the <code> data-role="page"</code> container to ensure that the background colors are applied to the full page, regardless of the content length. (If you add the <code> data-theme</code> attribute to the content container, the background color will stop after the content. So there may be a gap in color between the content and the end of the page.)</p>
 		<p>Additionally, the content area of a collapsible can be themed to match the theme of the collapsible header using the <code>data-content-theme</code> attribute.</p>
 
 <code>


### PR DESCRIPTION
at content-themes.html
No fixed footer is required to create a gap between the content end and the page end, if the content is themed other than the page:  http://jsfiddle.net/MauriceG/JrXWT/show/
