### PR TITLE
Removing references to attrFn to support jQuery 1.8 core

### DIFF
--- a/js/events/orientationchange.js
+++ b/js/events/orientationchange.js
@@ -141,9 +141,6 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 	$.fn[ event_name ] = function( fn ) {
 		return fn ? this.bind( event_name, fn ) : this.trigger( event_name );
 	};
-
-	$.attrFn[ event_name ] = true;
-
 }( jQuery, this ));
 
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);

--- a/js/events/orientationchange.js
+++ b/js/events/orientationchange.js
@@ -141,6 +141,12 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 	$.fn[ event_name ] = function( fn ) {
 		return fn ? this.bind( event_name, fn ) : this.trigger( event_name );
 	};
+
+	// jQuery < 1.8
+	if ( $.attrFn ) {
+		$.attrFn[ event_name ] = true;
+	}
+
 }( jQuery, this ));
 
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);

--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -16,8 +16,6 @@ define( [ "jquery", "../jquery.mobile.vmouse" ], function( $ ) {
 		$.fn[ name ] = function( fn ) {
 			return fn ? this.bind( name, fn ) : this.trigger( name );
 		};
-
-		$.attrFn[ name ] = true;
 	});
 
 	var supportTouch = "ontouchend" in document,

--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -16,6 +16,11 @@ define( [ "jquery", "../jquery.mobile.vmouse" ], function( $ ) {
 		$.fn[ name ] = function( fn ) {
 			return fn ? this.bind( name, fn ) : this.trigger( name );
 		};
+
+		// jQuery < 1.8
+		if ( $.attrFn ) {
+			$.attrFn[ name ] = true;
+		}
 	});
 
 	var supportTouch = "ontouchend" in document,

--- a/tests/unit/event/event_core.js
+++ b/tests/unit/event/event_core.js
@@ -69,12 +69,6 @@
 		$('#qunit-fixture').touchstart();
 	});
 
-	test( "defining event functions sets the attrFn to true", function(){
-		$.each(events, function(i, name){
-			ok($.attrFn[name], "attribute function is true");
-		});
-	});
-
 	test( "scrollstart enabled defaults to true", function(){
 		$.event.special.scrollstart.enabled = false;
 		$.each( components, function( index, value ) { $.testHelper.reloadLib( value ); });

--- a/tests/unit/event/event_core.js
+++ b/tests/unit/event/event_core.js
@@ -69,6 +69,16 @@
 		$('#qunit-fixture').touchstart();
 	});
 
+	// jQuery < 1.8
+	if ( $.attrFn ) {
+		test( "defining event functions sets the attrFn to true", function(){
+			$.each( events, function( index, name ) {
+				ok( $.attrFn[ name ], "attribute function is true" );
+			});
+		});
+	}
+
+
 	test( "scrollstart enabled defaults to true", function(){
 		$.event.special.scrollstart.enabled = false;
 		$.each( components, function( index, value ) { $.testHelper.reloadLib( value ); });


### PR DESCRIPTION
This was an undocumented "internal" variable in jQuery core, and has been removed in 1.8.

It makes it so that if you call `attr( property, value )` with a property, it passes it to `$.fn[ property ]( value )` - You probably don't want this for events anyway.

If you do want to support this behavior which I feel we should discourage ( although it is default as of 1.8 - if there is a `$.fn` method `attr` automatically passes to it on setting) - Just put an `if ( jQuery.attrFn )` around these assignments.
