### PR TITLE
Listview autodividers: Fix for text links in list items

### DIFF
--- a/js/widgets/listview.autodividers.js
+++ b/js/widgets/listview.autodividers.js
@@ -7,8 +7,8 @@ define( [ "jquery", "./listview" ], function( $ ) {
 
 $.mobile.listview.prototype.options.autodividers = false;
 $.mobile.listview.prototype.options.autodividersSelector = function( elt ) {
-	// look for the first anchor in the item
-	var text = elt.find( 'a' ).text() || elt.text() || null;
+	// look for the text in the given element
+	var text = elt.text() || null;
 
 	if ( !text ) {
 		return null;


### PR DESCRIPTION
All tests succeeded.

Issue: http://jsfiddle.net/MauriceG/4ud6M/  -- creates autodividers for the links instead of the list item text
Patched: http://jsfiddle.net/MauriceG/4ud6M/2/  -- do not take links into account for autodividers
