### PR TITLE
Collapsible: Add support for same expanded/collapsed non default icon

### DIFF
--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -122,13 +122,14 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 					event.preventDefault();
 
 					collapsibleHeading
-						.toggleClass( "ui-collapsible-heading-collapsed", isCollapse)
+						.toggleClass( "ui-collapsible-heading-collapsed", isCollapse )
 						.find( ".ui-collapsible-heading-status" )
 							.text( isCollapse ? o.expandCueText : o.collapseCueText )
 						.end()
 						.find( ".ui-icon" )
 							.toggleClass( "ui-icon-" + expandedIcon, !isCollapse )
-							.toggleClass( "ui-icon-" + collapsedIcon, isCollapse )
+							// logic or cause same icon for expanded/collapsed state would remove the ui-icon-class
+							.toggleClass( "ui-icon-" + collapsedIcon, ( isCollapse || expandedIcon == collapsedIcon ) )
 						.end()
 						.find( "a" ).first().removeClass( $.mobile.activeBtnClass );
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -129,7 +129,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 						.find( ".ui-icon" )
 							.toggleClass( "ui-icon-" + expandedIcon, !isCollapse )
 							// logic or cause same icon for expanded/collapsed state would remove the ui-icon-class
-							.toggleClass( "ui-icon-" + collapsedIcon, ( isCollapse || expandedIcon == collapsedIcon ) )
+							.toggleClass( "ui-icon-" + collapsedIcon, ( isCollapse || expandedIcon === collapsedIcon ) )
 						.end()
 						.find( "a" ).first().removeClass( $.mobile.activeBtnClass );
 


### PR DESCRIPTION
Fixes #4801 Collapsible Content: Info Icon Issue.
Having the same non standard icon for expanded and collapsed state, toggleClass removes the ui-icon-x class for collapsed state.
Tests: Passed.
