### PR TITLE
Unset light shadow for input clear button and slider handle.

### DIFF
--- a/css/themes/default/jquery.mobile.theme.css
+++ b/css/themes/default/jquery.mobile.theme.css
@@ -1131,17 +1131,19 @@ a.ui-link-inherit {
 	-webkit-box-shadow: 0px 0px 12px 		rgba(0,0,0,.6);
 	box-shadow: 0px 0px 12px 				rgba(0,0,0,.6);
 }
-.ui-shadow {
-	-moz-box-shadow: 0px 1px 4px /*{global-box-shadow-size}*/ 			rgba(0,0,0,.3) /*{global-box-shadow-color}*/;
-	-webkit-box-shadow: 0px 1px 4px /*{global-box-shadow-size}*/ 		rgba(0,0,0,.3) /*{global-box-shadow-color}*/;
-	box-shadow: 0px 1px 4px /*{global-box-shadow-size}*/ 				rgba(0,0,0,.3) /*{global-box-shadow-color}*/;
-}
 .ui-bar-a .ui-shadow,
 .ui-bar-b .ui-shadow ,
 .ui-bar-c .ui-shadow  {
 	-moz-box-shadow: 0px 1px 0 				rgba(255,255,255,.3);
 	-webkit-box-shadow: 0px 1px 0 			rgba(255,255,255,.3);
 	box-shadow: 0px 1px 0 					rgba(255,255,255,.3);
+}
+.ui-shadow,
+.ui-slider-handle.ui-shadow,
+.ui-input-clear.ui-shadow {
+	-moz-box-shadow: 0px 1px 4px /*{global-box-shadow-size}*/ 			rgba(0,0,0,.3) /*{global-box-shadow-color}*/;
+	-webkit-box-shadow: 0px 1px 4px /*{global-box-shadow-size}*/ 		rgba(0,0,0,.3) /*{global-box-shadow-color}*/;
+	box-shadow: 0px 1px 4px /*{global-box-shadow-size}*/ 				rgba(0,0,0,.3) /*{global-box-shadow-color}*/;
 }
 .ui-shadow-inset {
 	-moz-box-shadow: inset 0px 1px 4px 		rgba(0,0,0,.2);


### PR DESCRIPTION
Issue: The light shadow for buttons in a theme A, B or C toolbar is also applied to the clear button of the search input and the slider handle (see: http://jsbin.com/atahip/65)

@toddparker

I have been looking for a solution without adding specific element classes to theme CSS, but didn't see any.
Applying the light shadow style only to buttons that are immediate children of the toolbar (`.ui-bar-a > .ui-shadow`) would fix the problem, but also create new ones.

Can I merge this PR?
