### PR TITLE
Change Options page example for expandedIcon to match Basics page

### DIFF
--- a/docs/content/content-collapsible-set-options.html
+++ b/docs/content/content-collapsible-set-options.html
@@ -52,10 +52,10 @@
 				<p class="default">default: "minus"</p>
 				<p>Sets the icon for the headers of the collapsible containers when in an expanded state. To set the value for all instances of this widget, bind this option to the <a href="../../api/globalconfig.html">mobileinit event</a>:</p>
 <pre><code>$( document ).bind( "mobileinit", function(){
-    <strong>$.mobile.collapsibleset.prototype.options.expandedIcon = "arrow-r";</strong>
+    <strong>$.mobile.collapsibleset.prototype.options.expandedIcon = "arrow-d";</strong>
 });
 </code></pre>
-				<p>This option is also exposed as a data attribute: <code>data-expanded-icon=&quot;arrow-r&quot;</code>.</p>
+				<p>This option is also exposed as a data attribute: <code>data-expanded-icon=&quot;arrow-d&quot;</code>.</p>
 			</dd>
 
 			<dt><code>iconpos</code> <em>string</em></dt>


### PR DESCRIPTION
This commit brings the Options page in line with the example from the Basics page: `data-collapsed-icon="arrow-r"` and `data-expanded-icon="arrow-d"`.  I think this is probably going to be the most common icon set when these data-\* attributes are used.
