### PR TITLE
Support: Modified$.mobile.browser.ie to support IE10+ detection. Fixes #...

### DIFF
--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -117,7 +117,16 @@ $.mobile.browser.ie = (function() {
 		div.innerHTML = "<!--[if gt IE " + ( ++v ) + "]><br><![endif]-->";
 	} while( a[0] );
 
-	return v > 4 ? v : !v;
+	v = v > 4 ? v : !v;
+
+	// Fallback to UA detection because IE10+ does not support conditional comments
+	if ( !v && navigator.appName === 'Microsoft Internet Explorer' ) {
+		var regex  = new RegExp("MSIE ([0-9]{1,}[\.0-9]{0,})");
+		if (regex.exec( navigator.userAgent ) !== null)
+			v = parseFloat( RegExp.$1 );
+	}
+
+	return v;
 })();
 
 


### PR DESCRIPTION
...4868 - IE Browser Check Unit Test Failing.

Added a fallback for User Agent sniffing because IE10 no longer supports conditional comments and therefore the current version check fails.
