### PR TITLE
Event: Fixed loading and reloading of touch support. Fixed #4879 - Swipe...

### DIFF
--- a/tests/unit/event/event_core.js
+++ b/tests/unit/event/event_core.js
@@ -132,6 +132,7 @@
 
 	var forceTouchSupport = function(){
 		document.ontouchend = function() {};
+		$.testHelper.reloadLib( "jquery.mobile.support.touch.js" );
 		$.each( components, function( index, value ) { $.testHelper.reloadLib( value ); });
 
 		//mock originalEvent information

--- a/tests/unit/event/index.html
+++ b/tests/unit/event/index.html
@@ -13,6 +13,7 @@
 	</script>
 
 	<script src="../../../js/jquery.mobile.define.js"></script>
+	<script src="../../../js/jquery.mobile.support.touch.js"></script>
 	<script src="../../../js/jquery.mobile.events.js"></script>
     <script src="../../../js/events/touch.js"></script>
     <script src="../../../js/events/throttledresize.js"></script>


### PR DESCRIPTION
... Event Unit tests not executing correctly.

Included jquery.mobile.touch.support.js on test page and forced the lib to reload in the forceTouchSupport() method. An undefined error was being thrown and causing tests 17-19 to pass with false positives as well as test 16 to fail.
