### PR TITLE
Navigation: enable adding custom code to loadPage

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -866,22 +866,26 @@ define( [
 						page = settings.pageContainer.children( "[data-" + $.mobile.ns +"url='" + dataUrl + "']" );
 					}
 
-					//bind pageHide to removePage after it's hidden, if the page options specify to do so
+					// wait for completeLoad to report that the page is really loaded
+					settings.completeLoad( page, function() {
 
-					// Remove loading message.
-					if ( settings.showLoadMsg ) {
-						hideMsg();
-					}
+						//bind pageHide to removePage after it's hidden, if the page options specify to do so
 
-					// Add the page reference and xhr to our triggerData.
-					triggerData.xhr = xhr;
-					triggerData.textStatus = textStatus;
-					triggerData.page = page;
+						// Remove loading message.
+						if ( settings.showLoadMsg ) {
+							hideMsg();
+						}
 
-					// Let listeners know the page loaded successfully.
-					settings.pageContainer.trigger( "pageload", triggerData );
+						// Add the page reference and xhr to our triggerData.
+						triggerData.xhr = xhr;
+						triggerData.textStatus = textStatus;
+						triggerData.page = page;
 
-					deferred.resolve( absUrl, options, page, dupCachedPage );
+						// Let listeners know the page loaded successfully.
+						settings.pageContainer.trigger( "pageload", triggerData );
+
+						deferred.resolve( absUrl, options, page, dupCachedPage );
+					});
 				},
 				error: function( xhr, textStatus, errorThrown ) {
 					//set base back to current path
@@ -935,7 +939,10 @@ define( [
 		role: undefined, // By default we rely on the role defined by the @data-role attribute.
 		showLoadMsg: false,
 		pageContainer: undefined,
-		loadMsgDelay: 50 // This delay allows loads that pull from browser cache to occur without showing the loading message.
+		loadMsgDelay: 50, // This delay allows loads that pull from browser cache to occur without showing the loading message.
+		completeLoad: function( page, callback ) {
+			callback();
+		}
 	};
 
 	// Show a specific page in the page container.


### PR DESCRIPTION
Add a new option $.mobile.loadPage.defaults.completeLoad which allows the user to define when a page has been fully loaded.

By default the existing functionality is unchanged - a page is considered loaded when the html has been added to the dom. 

If pages include large images which are not preloaded or other asynchronous components, the page may be displayed before it is fully rendered.

Adding the below code (and the waitForImages plugin) to the app keeps the loading message visible for longer and does not start the transition until the page is actually ready to be displayed.

```
$.mobile.loadPage.defaults.completeLoad = function(page, callback ) {
    $(page).waitForImages(function() {
       callback();
    });
};
```
