### PR TITLE
Fixed bug that throws an error in $.mobile.changePage

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -179,7 +179,7 @@ define( [
 
 			convertUrlToDataUrl: function( absUrl ) {
 				var u = path.parseUrl( absUrl );
-				if ( path.isEmbeddedPage( u ) ) {
+				if ( path.isEmbeddedPage( u ) && !path.isFirstPageUrl( absUrl ) ) {
 					// For embedded pages, remove the dialog hash key as in getFilePath(),
 					// otherwise the Data Url won't match the id of the embedded Page.
 					return u.hash.split( dialogHashKey )[0].replace( /^#/, "" );


### PR DESCRIPTION
The error is thrown at: https://github.com/jquery/jquery-mobile/blob/master/js/jquery.mobile.navigation.js#L1098

**To replicate the bug you need a specific set of conditions:**
https://github.com/jquery/jquery-mobile/blob/master/js/jquery.mobile.navigation.js#L1017 will incorrectly return an empty string because the call to `path.convertUrlToDataUrl( settings.dataUrl )` incorrectly returns an empty string when `settings.dataUrl` looks like `http://example.com/myapp/#` - note the `#` on the end

**To fix the bug**
`path.convertUrlToDataUrl( ... )` at https://github.com/jquery/jquery-mobile/blob/master/js/jquery.mobile.navigation.js#L180 needs to add an additional check at https://github.com/jquery/jquery-mobile/blob/master/js/jquery.mobile.navigation.js#L182 to ensure `!path.isFirstPage( absUrl )`

**NB:** This bug has only arisen because I am bypassing jquery mobile navigation and using backbone's router.
