### PR TITLE
Be able to use 'reverse' direction, even if you disable back-button handlers (for example when using jqm with backbone.js)

### DIFF
--- a/docs/pages/page-transitions.html
+++ b/docs/pages/page-transitions.html
@@ -111,6 +111,19 @@
 
 	<h2>Setting a transition on a link or form submit</h2>
 	<p>By default, the framework applies a <strong>fade</strong> transition. To set a custom transition effect, add the <code>data-transition</code> attribute to the link. </p>
+	<p>
+		Note that reverse direction won't be applied if you disable the link binding with <code>$.mobile.linkBindingEnabled = false;</code>.
+		If you want to force a reverse direction, please define: <code>$.mobile.forceReverse = true;</code>. For example:
+
+<code>
+$.mobile.forceReverse = true;
+
+($('a[data-rel="back"]')).live('click', function() {
+  $.mobile.forceReverse = true;
+  window.history.back();
+});
+</code>
+	</p>
 
 <code><code>
 &lt;a href=&quot;index.html&quot; <strong>data-transition=&quot;pop&quot;</strong>&gt;I'll pop&lt;/a&gt;

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -64,8 +64,18 @@ define( [ "jquery", "text!../version.txt" ], function( $, __version__ ) {
 		// For error messages, which theme does the box uses?
 		pageLoadErrorMessageTheme: "e",
 
-		//automatically initialize the DOM when it's ready
+		// Automatically initialize the DOM when it's ready
 		autoInitializePage: true,
+
+		// Force reverse direction, for example when:
+		// $.mobile.linkBindingEnabled = false;
+
+		// So, you can:
+		// ($('a[data-rel="back"]')).live('click', function() {
+		//   $.mobile.forceReverse = true;
+		//   window.history.back();
+		// });
+		forceReverse: false,
 
 		pushStateEnabled: true,
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1150,7 +1150,8 @@ define( [
 		$.mobile.activePage = toPage;
 
 		// If we're navigating back in the URL history, set reverse accordingly.
-		settings.reverse = settings.reverse || historyDir < 0;
+		settings.reverse = settings.reverse || $.mobile.forceReverse || historyDir < 0;
+		$.mobile.forceReverse = false;
 
 		transitionPages( toPage, fromPage, settings.transition, settings.reverse )
 			.done(function( name, reverse, $to, $from, alreadyFocused ) {


### PR DESCRIPTION
## Context:
- jQuery Mobile + backbone.js App.
- jQuery Mobile bindings/history/routing were disabled to use Backbone's.
- Back buttons are being used manually (that means using window.history.back directly)
## Problem:
- 1.1.1 won't apply the reverse direction even if you set the link with data-direction="reverse" to the links.
## Example:

For example having:
(based on http://coenraets.org/blog/2012/03/using-backbone-js-with-jquery-mobile/ )

```
  # Disable jQuery Mobile routing and history to use Backbone.
  $.mobile.ajaxEnabled = false
  $.mobile.linkBindingEnabled = false
  $.mobile.hashListeningEnabled = false
  $.mobile.pushStateEnabled = false

  # Enable back buttons by default
  $.mobile.page.prototype.options.addBackBtn = true
```

This will add the back button, but since all the handlers are disabled, you need to redirect to the last page manually:

```
($('a[data-rel="back"]')).live('click', function() {
  window.history.back();
});
```

That will work. But sadly you won't see the default reverse direction for any back button. But it will be fixed by setting the `$.mobile.forceReverse = true`. So letting the application to use forward direction by default, and reverse for all the back buttons.

```
($('a[data-rel="back"]')).live('click', function() {
  $.mobile.forceReverse = true;
  window.history.back();
});
```

That change won't affect any other place than the Back buttons. And the variable is `false` by default.
I've included the Documentation changes too.
