### PR TITLE
Listview: add extra check to fix issue #4901

### DIFF
--- a/js/widgets/listview.autodividers.js
+++ b/js/widgets/listview.autodividers.js
@@ -26,7 +26,7 @@ $( document ).delegate( "ul,ol", "listviewcreate", function() {
 	var list = $( this ),
 			listview = list.data( "listview" );
 
-	if ( !listview.options.autodividers ) {
+	if ( !listview || !listview.options.autodividers ) {
 		return;
 	}
 


### PR DESCRIPTION
If a listview was nested inside a normal list then the listviewcreate
event for autodividers would also fire for the parent list causing an error
as this list did not contain listview data. An extra check is added to ensure
the list is actually a listview.

Fixes issue #4901
