### PR TITLE
CSS: Make the page title in headers more responsive

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -56,6 +56,8 @@ div.ui-mobile-viewport { overflow-x: hidden; }
 .ui-footer .ui-btn-icon-notext,
 .ui-header .ui-btn-icon-notext { top: 6px; }
 .ui-header .ui-title, .ui-footer .ui-title { min-height: 1.1em; text-align: center; font-size: 16px; display: block; margin: .6em 30% .8em; padding: 0; text-overflow: ellipsis; overflow: hidden; white-space: nowrap; outline: 0 !important; }
+.ui-header .ui-title:only-child { margin: .6em .8em .8em; }
+.ui-header .ui-btn-icon-notext + .ui-title:last-child, .ui-header .ui-btn-icon-notext ~ .ui-title:first-child {  margin: .6em 2.5em .8em; }
 .ui-footer .ui-title { margin: .6em 15px .8em; }
 
 /*content area*/


### PR DESCRIPTION
Titles in page headers always have a left/right margin of 30% for add slots for the header buttons.
This is a lot for headers without buttons or with icon only buttons.
This PR adds two rules to make the margins more responsive.

**Limitations:**
- No support for old IE and WP7
- The markup for links and the title has to be in the right order to support smaller margins for text only buttons (if not, standard margins will be used).

**Demo:**
http://jsfiddle.net/MauriceG/pxFga/show/light/ (edit: http://jsfiddle.net/MauriceG/pxFga/)
