### PR TITLE
Collapsible: Changed $.testHelper.openPage to $.mobile.changepage. Fixed #4993 - Collapsible: Unit Tests failing on Windows Phone 7

### DIFF
--- a/tests/unit/collapsible/collapsible_core.js
+++ b/tests/unit/collapsible/collapsible_core.js
@@ -9,7 +9,7 @@
 	asyncTest( "The page should be enhanced correctly", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#basic-collapsible-test" );
+				$.mobile.changePage( $( "#basic-collapsible-test" ) );
 			},
 
 			function() {
@@ -28,7 +28,7 @@
 	asyncTest( "Expand/Collapse", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#basic-collapsible-test" );
+				$.mobile.changePage( $( "#basic-collapsible-test" ) );
 			},
 
 			function() {
@@ -47,7 +47,7 @@
 	asyncTest( "The page should be enhanced correctly", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#basic-collapsible-set-test" );
+				$.mobile.changePage( $( "#basic-collapsible-set-test" ) );
 			},
 
 			function() {
@@ -69,7 +69,7 @@
 	asyncTest( "Collapsible set with only one collapsible", function() {
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-set-with-lonely-collapsible-test" );
+				$.mobile.changePage( $( "#collapsible-set-with-lonely-collapsible-test" ) );
 			},
 
 			function() {
@@ -88,7 +88,7 @@
 	asyncTest( "Section expanded by default", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#basic-collapsible-set-test" );
+				$.mobile.changePage( $( "#basic-collapsible-set-test" ) );
 			},
 
 			function() {
@@ -102,7 +102,7 @@
 	asyncTest( "Expand/Collapse", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#basic-collapsible-set-test" );
+				$.mobile.changePage( $( "#basic-collapsible-set-test" ) );
 			},
 
 			function() {
@@ -119,7 +119,7 @@
 	asyncTest( "Collapsible Set with dynamic content", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-set-with-dynamic-content" );
+				$.mobile.changePage( $( "#collapsible-set-with-dynamic-content" ) );
 			},
 
 			function() {
@@ -143,7 +143,7 @@
 	asyncTest( "Collapsible Set with static and dynamic content", function(){
 		$.testHelper.pageSequence([
 			function(){
-  				$.testHelper.openPage( "#collapsible-set-with-static-and-dynamic-content" );
+  				$.mobile.changePage( $( "#collapsible-set-with-static-and-dynamic-content" ) );
   			},
 
   			function() {
@@ -167,7 +167,7 @@
 	asyncTest( "Collapsible set with last collapsible expanded", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-set-with-last-collapsible-expanded" );
+				$.mobile.changePage( $( "#collapsible-set-with-last-collapsible-expanded" ) );
 			},
 
 			function() {
@@ -181,7 +181,7 @@
 	asyncTest( "Collapsible Set", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-set-with-legends" );
+				$.mobile.changePage( $( "#collapsible-set-with-legends" ) );
 			},
 
 			function() {
@@ -199,7 +199,7 @@
 	asyncTest( "Collapsible with custom icons", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-with-custom-icons" );
+				$.mobile.changePage( $( "#collapsible-with-custom-icons" ) );
 			},
 
 			function() {
@@ -222,7 +222,7 @@
 	asyncTest( "Collapsible sets with custom icons", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-set-with-custom-icons" );
+				$.mobile.changePage( $( "#collapsible-set-with-custom-icons" ) );
 			},
 
 			function() {
@@ -243,7 +243,7 @@
 	asyncTest( "Collapsible", 6, function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-with-theming" );
+				$.mobile.changePage( $( "#collapsible-with-theming" ) );
 			},
 
 			function() {
@@ -263,7 +263,7 @@
 	asyncTest( "Collapsible Set", function(){
 		$.testHelper.pageSequence([
 			function(){
-				$.testHelper.openPage( "#collapsible-set-with-theming" );
+				$.mobile.changePage( $( "#collapsible-set-with-theming" ) );
 			},
 
 			function() {


### PR DESCRIPTION
Some of the Collapsible Unit tests (3-14) are failing on Windows Phone 7. This pull request addresses issue #4993.

The code that is being tested works fine on the actual device when I took the samples and ran them outside of the unit test environment. 

![Failing Unit Tests](http://f.cl.ly/items/3C0D2X1K47281y2e2V1G/collapsible-before-240x400.png)

By changing `$.testHelper.openPage()` to `$.mobile.changePage()` it resolved all of the failures. It appears the assertions were being made before jQuery Mobile had a chance to enhance the DOM. 

Here is an example of one of the changes I made...

``` diff
- $.testHelper.openPage( "#basic-collapsible-test" );
+ $.mobile.changePage( $( "#basic-collapsible-test" ) );
```

After making the above changes all of the unit tests run and pass successfully as seen below

![Passing Unit Tests](http://f.cl.ly/items/0w0h0328091y0E1W1g0Q/collapsible-after-240x400.png)
