### PR TITLE
jQuery Tag Inserter: added check for jQuery existence in conditional tha...

### DIFF
--- a/js/jquery.tag.inserter.js
+++ b/js/jquery.tag.inserter.js
@@ -18,7 +18,7 @@
 
 	document.write(
 		'<script>' +
-			'if ( parseInt( jQuery.fn.jquery.replace( /\\./g, "" ), 10 ) < 170 && window.define && window.define.amd ) {' +
+			'if ( window.jQuery && parseInt( jQuery.fn.jquery.replace( /\\./g, "" ), 10 ) < 170 && window.define && window.define.amd ) {' +
 			    'define( "jquery", [], function () { return jQuery; } );'+
 			'}'+
 		'</script>'


### PR DESCRIPTION
...t creates jQuery AMD definition. Fixes #4996. Win Phone 7/8: Slider onChange test failing.

WP 7 & 8 seem to have problems with jquery.tag.inserter.js. It seems that jQuery is not loaded in time for the conditional that creates the AMD definition. In WP, this conditional was always evaluating to true and causing the definition to run which, in turn, caused some strange event-related issue in the slider test. It may have been causing issues elsewhere, also. Will do more testing to see.

The drawback here is that AMD definition will probably never be loaded in WP. Based on the current logic, that seems like it will only be a problem when testing against jQuery versions < 1.7.0. I believe that leaves jQ 1.6.4 as the only supported version that will not run correctly.

Perhaps there is a better way to solve this problem to guarantee that all loading happens correctly, but it doesn't seem to happen in desktop browsers.
