### PR TITLE
Navigation: Fix the navigation_helpers.js module from hanging the test suite. Fixes #5010 - Navigation: Unit test suite does not complete in Windows Mobile 7.5

### DIFF
--- a/tests/unit/navigation/navigation_helpers.js
+++ b/tests/unit/navigation/navigation_helpers.js
@@ -6,7 +6,7 @@
 
 	module('jquery.mobile.navigation.js', {
 		setup: function(){
-			if ( location.hash ) {
+			if ( location.hash && location.hash !== "#" ) {
 				stop();
 				$(document).one("pagechange", function() {
 					start();


### PR DESCRIPTION
Made a minor change in the setup of the module in the `navigation_helpers.js` test file. Windows Mobile 7.5 does not do well when you try to clear out the location.hash and it leaves the `#` in there, so I am checking that in the if condition.

The test suite now continues past test 2. There are many error that show up in the test suite now. Some of those unit tests can be easily fixed and can be addressed in another pull request.

This pull request address issue #5010 
