### PR TITLE
Unusual character in CSS comment causing compilation problems

### DIFF
--- a/css/structure/jquery.mobile.popup.css
+++ b/css/structure/jquery.mobile.popup.css
@@ -4,7 +4,7 @@
 
 }
 .ui-popup-screen {
-	background-image: url(data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==); /* Necessary to set some form of background to ensure element is clickable in IE6/7. While legacy IE won’t understand the data-URI’d image, it ensures no additional requests occur in all other browsers with little overhead. */
+	background-image: url(data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==); /* Necessary to set some form of background to ensure element is clickable in IE6/7. While legacy IE won't understand the data-URI'd image, it ensures no additional requests occur in all other browsers with little overhead. */
 	top: 0px;
 	left: 0px;
 	right: 0px;


### PR DESCRIPTION
The comment regarding legacy IE in css/structure/jquery.mobile.popup.css has an unusual apostrophe (recognized by Ruby as \xC3) - and this character causes an issue for CSS compilers (such as SASS, which should be able to natively pass-thru a standard CSS file.) Switching this character to its less fancy sibling, ', makes everything run as expected.

The usual character - â€™ when viewing the CSS in Firefox, ’ if GitHub recognizes it properly - is not used in an other CSS files and is otherwise only included in a couple docs and tests/unit/button/button_core.js.
