### PR TITLE
pull request for issue #4984

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1243,7 +1243,7 @@ define( [
 	//The following event bindings should be bound after mobileinit has been triggered
 	//the following deferred is resolved in the init file
 	$.mobile.navreadyDeferred = $.Deferred();
-	$.mobile.navreadyDeferred.done(function() {
+	$.mobile._registerInternalEvents = function() {
 		//bind to form submit events, handle with Ajax
 		$( document ).delegate( "form", "submit", function( event ) {
 			var $this = $( this );
@@ -1545,7 +1545,10 @@ define( [
 		$( document ).bind( "pageshow", resetActivePageHeight );
 		$( window ).bind( "throttledresize", resetActivePageHeight );
 
-	});//navreadyDeferred done callback
+	};//navreadyDeferred done callback
+	$( window.document ).bind('mobileinit', function() {
+  	$.mobile.navreadyDeferred.done($.mobile._registerInternalEvents())
+  });
 
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);


### PR DESCRIPTION
this is a pull request for a small code change to bring back _registerInternalEvents to allow overriding of JQM's event handlers in plugins as per this issue: https://github.com/jquery/jquery-mobile/issues/4984

I had to defer the registering of the callback to navreadyDeferred by binding it to mobileinit, because once registered to a deferred, it doesn't matter if _registerInternalEvents value is changed - deferred still points to the original callback. 

so am not sure this is a good solution, but provided here for your review anyways. 
