### PR TITLE
Opening popup from within a listview does not restore button state

### DIFF
--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -786,6 +786,11 @@ define( [ "jquery",
 
 		//remove after delay
 		setTimeout( function() {
+			// Check if we are in a listview
+			var $parent = $link.parent().parent();
+			if ($parent.hasClass("ui-li")) {
+				$link = $parent.parent();
+			}
 			$link.removeClass( $.mobile.activeBtnClass );
 		}, 300 );
 	};


### PR DESCRIPTION
When I open a popup from within a listview, the button is always marked as active.
The code to restore this does not check if the button is inside a listview.
