### PR TITLE
Fixed location of iPad touch icon in the iOS docs

### DIFF
--- a/docs/config/iOSFullscreen.html
+++ b/docs/config/iOSFullscreen.html
@@ -13,7 +13,7 @@
     <!-- iPhone (Retina) ICON-->
     <link href="../_assets/images/ios_icon_114.png" sizes="114x114" rel="apple-touch-icon">
     <!-- iPad (Retina) ICON-->
-    <link href="../_assets/images/ios_icon144.png" sizes="144x144" rel="apple-touch-icon">
+    <link href="../_assets/images/ios_icon_144.png" sizes="144x144" rel="apple-touch-icon">
 	
 	
 	<link rel="apple-touch-startup-image" href="../_assets/images/ios_startup.png" />


### PR DESCRIPTION
The iOS FullScreen docs had a reference to an invalid URL for the 144px touch icon. 
