### PR TITLE
inputs: Modify placeholder text color in Firefox to use standard

### DIFF
--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -17,6 +17,7 @@ textarea.ui-input-text { height: 50px; -webkit-transition: height 200ms linear; 
 input.ui-mini, .ui-mini input, textarea.ui-mini { font-size: 14px; }
 textarea.ui-mini { height: 45px; }
 
+/* Resolves issue #5166: Added to support issue introduced in Firefox 15. We can likely remove this in the future. */
 :-moz-placeholder { color: #aaa; }
 
 @media all and (min-width: 450px){

--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -17,6 +17,8 @@ textarea.ui-input-text { height: 50px; -webkit-transition: height 200ms linear; 
 input.ui-mini, .ui-mini input, textarea.ui-mini { font-size: 14px; }
 textarea.ui-mini { height: 45px; }
 
+:-moz-placeholder { color: #aaa; }
+
 @media all and (min-width: 450px){
 	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 2% 0 0 }
 	.ui-field-contain input.ui-input-text, 


### PR DESCRIPTION
inputs: Modify placeholder text color in Firefox to use standard in FF 15+. Fixes #5166 - Text input placeholder text not grayed out in Firefox

Demo without fix:

http://jsbin.com/inupud/6

Demo with fix:

http://jsbin.com/inupud/5
