### PR TITLE
inputs: add !important to resolve issue in build process

### DIFF
--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -18,7 +18,7 @@ input.ui-mini, .ui-mini input, textarea.ui-mini { font-size: 14px; }
 textarea.ui-mini { height: 45px; }
 
 /* Resolves issue #5166: Added to support issue introduced in Firefox 15. We can likely remove this in the future. */
-:-moz-placeholder { color: #aaa !important; }
+input:-moz-placeholder { color: #aaa; }
 
 @media all and (min-width: 450px){
 	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 2% 0 0 }

--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -18,7 +18,7 @@ input.ui-mini, .ui-mini input, textarea.ui-mini { font-size: 14px; }
 textarea.ui-mini { height: 45px; }
 
 /* Resolves issue #5166: Added to support issue introduced in Firefox 15. We can likely remove this in the future. */
-:-moz-placeholder { color: #aaa; }
+:-moz-placeholder { color: #aaa !important; }
 
 @media all and (min-width: 450px){
 	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 2% 0 0 }


### PR DESCRIPTION
inputs: add !important to resolve issue in build process where other CSS overrides :-moz-placeholder setting later on. Fixes #5166 - Text input placeholder text not grayed out in Firefox

Prior commit did not work properly after running through grunt build of CSS. Discussed with Jasper de Groot and we decided adding !important in this case is the best solution.
