### PR TITLE
Resolve input=number width issue for Android 4.1

### DIFF
--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -21,7 +21,7 @@ textarea.ui-mini { height: 45px; }
 input:-moz-placeholder { color: #aaa; }
 
 /* Resolves issue #5131: Width of textinput depends on its type, for Android 4.1 */
-input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
+input[type=number]::-webkit-outer-spin-button { margin: 0; }
 
 @media all and (min-width: 450px){
 	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 2% 0 0 }

--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -20,6 +20,9 @@ textarea.ui-mini { height: 45px; }
 /* Resolves issue #5166: Added to support issue introduced in Firefox 15. We can likely remove this in the future. */
 input:-moz-placeholder { color: #aaa; }
 
+/* Resolves issue #5131: Width of textinput depends on its type, for Android 4.1 */
+input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
+
 @media all and (min-width: 450px){
 	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 2% 0 0 }
 	.ui-field-contain input.ui-input-text, 


### PR DESCRIPTION
Added CSS to resolve the issue as suggested by Todd Parker and Jasper DeGroot:

input[type=number]::-webkit-outer-spin-button { margin: 0; }

JS Bin example of the fix:

http://jsbin.com/oguzef/1

Tested in iOS 5, iOS 6, Android 2.3, Android 4.1, Chrome 22.0.1229.94, Firefox 16.0.1
