### PR TITLE
Fix for issue: #5182

### DIFF
--- a/js/widgets/listview.js
+++ b/js/widgets/listview.js
@@ -231,7 +231,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 						linkIcon = last.jqmData( "icon" );
 
 						last.appendTo( item )
-							.attr( "title", last.getEncodedText() )
+							.attr( "title", $.trim(last.getEncodedText()) )
 							.addClass( "ui-li-link-alt" )
 							.empty()
 							.buttonMarkup({


### PR DESCRIPTION
Fix for issue: #5182 - "Title attribute of a split button pulls in extra spaces"
Cause:  entire text node is copied for the title attribute, including any leading or trailing spaces.
Solution:  Apply $.trim() to the text node value before assigning to the title attribute.
Files Impacted:
  listview.js
