### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 0.8

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "dependencies for the grunt based build",
   "version": "0.0.1",
   "scripts": {
-    "lint" : "grunt"
+    "lint" : "grunt",
+    "test" : "make; grunt"
   },
   "main": "grunt.js",
   "repository": {


### PR DESCRIPTION
Added Travis integration by including the needed travis configuration.

Be sure to create the hook from the Travis website, or manually as described in: http://about.travis-ci.org/docs/user/how-to-setup-and-trigger-the-hook-manually/

[![Build Status](https://secure.travis-ci.org/gbraad/jquery-mobile.png)](http://travis-ci.org/gbraad/jquery-mobile)
