### PR TITLE
Mark dialog as not open when it is closed even if put on its own page

### DIFF
--- a/js/widgets/forms/select.custom.js
+++ b/js/widgets/forms/select.custom.js
@@ -383,6 +383,9 @@ define( [
 						focusMenuItem();
 						self.isOpen = true;
 					});
+					self.menuPage.one( "pagebeforehide", function() {
+						self.isOpen = false;
+					});
 
 					self.menuType = "page";
 					self.menuPageContent.append( self.list );


### PR DESCRIPTION
If this is not done it can cause strange behaviour on the next page transition.

No test case is provided because i hade a real hard time reproducing the bad behaviour, it seemed to depend on the timing of the events on the page transition after the dialog is closed.
