### PR TITLE
Make changePage working properly on PhoneGap with WP7

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -53,8 +53,8 @@ define( [
 			// browsers that auto	decode it. All references to location.href should be
 			// replaced with a call to this method so that it can be dealt with properly here
 			getLocation: function( url ) {
-				var uri = url ? this.parseUrl( url ) : location,
-					hash = this.parseUrl( url || location.href ).hash;
+				var url = this.parseUrl( url || location.href ),
+					hash = uri.hash;
 
 				// mimic the browser with an empty string when the hash is empty
 				hash = hash === "#" ? "" : hash;
@@ -62,7 +62,7 @@ define( [
 				// Make sure to parse the url or the location object for the hash because using location.hash
 				// is autodecoded in firefox, the rest of the url should be from the object (location unless
 				// we're testing) to avoid the inclusion of the authority
-				return uri.protocol + "//" + uri.host + uri.pathname + uri.search + hash;
+				return uri.protocol + uri.doubleSlash + uri.host + uri.pathname + uri.search + hash;
 			},
 
 			parseLocation: function() {

--- a/tests/unit/navigation/navigation_helpers.js
+++ b/tests/unit/navigation/navigation_helpers.js
@@ -250,6 +250,10 @@
 		equal( $.mobile.path.getLocation( allUriParts ), allUriParts.replace( "jblas:password@", "") );
 	});
 
+	test( "path.getLocation works properly on WP7 with PhoneGap", function() {
+	  equal( $.mobile.path.getLocation("x-wmapp1:/app/www/index.html"), "x-wmapp1:/app/www/index.html" );
+	});
+
 	test( "calling mobile back uses phonegap's navigator object when present", function() {
 		var previous = $.mobile.phonegapNavigationEnabled;
 


### PR DESCRIPTION
WP7 with PhoneGap uses different local file name which has form like:
x-wmapp1:/app/www/index.html
Currently navigation helper assumes that every URL has double slash in url which is not the case in this situation. I added fix which always checks if there is double slash necessary for given url. That makes this working for all tradtional urls, as well as for WP7.
