### PR TITLE
Fix list-dividers use data-theme attribute first

### DIFF
--- a/js/widgets/listview.js
+++ b/js/widgets/listview.js
@@ -255,7 +255,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 					}
 				} else if ( isDivider ) {
 
-					itemClass += " ui-li-divider ui-bar-" + dividertheme;
+					itemClass += " ui-li-divider ui-bar-" + (item.jqmData("theme") || dividertheme);
 					item.attr( "role", "heading" );
 
 					if ( ol ) {	


### PR DESCRIPTION
Allow the list-divider to customize its own theme if desired

``` html
<ul data-role="listview" data-divider-theme="e">
<li data-role="list-divider">Theme e</li>
<li>some value</li>
<li data-role="list-divider" data-theme="b">Theme b</li>
<li>some other value</li>
</ul>
```
