### PR TITLE
Docs: Added themed read-only list examples

### DIFF
--- a/docs/lists/lists-themes.html
+++ b/docs/lists/lists-themes.html
@@ -269,6 +269,45 @@
 		</ul>
 		
 		
+		<h2>Read-only list items</h2>
+
+		<p>Read-only list items have a flatter appearance and do not have an icon.</p>
+
+		<p>Swatch <strong>"a"</strong> on read-only listview</p>
+		<ul data-role="listview" data-inset="true" data-theme="a">
+			<li>Gold<span class="ui-li-count">1</span></li>
+			<li>Silver<span class="ui-li-count">2</span></li>
+			<li>Bronze<span class="ui-li-count">3</span></li>
+		</ul>
+
+		<p>Swatch <strong>"b"</strong> on read-only listview</p>
+		<ul data-role="listview" data-inset="true" data-theme="b">
+			<li>Gold<span class="ui-li-count">1</span></li>
+			<li>Silver<span class="ui-li-count">2</span></li>
+			<li>Bronze<span class="ui-li-count">3</span></li>
+		</ul>
+
+		<p>Swatch <strong>"c"</strong> on read-only listview</p>
+		<ul data-role="listview" data-inset="true" data-theme="c">
+			<li>Gold<span class="ui-li-count">1</span></li>
+			<li>Silver<span class="ui-li-count">2</span></li>
+			<li>Bronze<span class="ui-li-count">3</span></li>
+		</ul>
+
+		<p>Swatch <strong>"d"</strong> on read-only listview</p>
+		<ul data-role="listview" data-inset="true" data-theme="d">
+			<li>Gold<span class="ui-li-count">1</span></li>
+			<li>Silver<span class="ui-li-count">2</span></li>
+			<li>Bronze<span class="ui-li-count">3</span></li>
+		</ul>
+
+		<p>Swatch <strong>"e"</strong> on read-only listview</p>
+		<ul data-role="listview" data-inset="true" data-theme="e">
+			<li>Gold<span class="ui-li-count">1</span></li>
+			<li>Silver<span class="ui-li-count">2</span></li>
+			<li>Bronze<span class="ui-li-count">3</span></li>
+		</ul>
+
 		</div><!--/content-primary -->		
 
 		<div class="content-secondary">


### PR DESCRIPTION
Provides an example for each default swatch of the new flat style for read-only list items in 1.2 (see #4347 and 571c08e).
