### PR TITLE
fixedToolbar: added logic to set page padding back to 0 on destroy. Fixe...

### DIFF
--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -263,7 +263,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 			var $el = this.element,
 				header = $el.is( ".ui-header" );
 
-			$el.closest( '.ui-page' ).css( "padding-" + ( header ? "top" : "bottom" ), 0 );
+			$el.closest( '.ui-page' ).css( "padding-" + ( header ? "top" : "bottom" ), "" );
 			$el.removeClass( "ui-header-fixed ui-footer-fixed ui-header-fullscreen ui-footer-fullscreen in out fade slidedown slideup ui-fixed-hidden" );
 			$el.closest( ".ui-page" ).removeClass( "ui-page-header-fixed ui-page-footer-fixed ui-page-header-fullscreen ui-page-footer-fullscreen" );
 		}

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -260,8 +260,12 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 		},
 
 		destroy: function() {
-			this.element.removeClass( "ui-header-fixed ui-footer-fixed ui-header-fullscreen ui-footer-fullscreen in out fade slidedown slideup ui-fixed-hidden" );
-			this.element.closest( ".ui-page" ).removeClass( "ui-page-header-fixed ui-page-footer-fixed ui-page-header-fullscreen ui-page-footer-fullscreen" );
+			var $el = this.element,
+				header = $el.is( ".ui-header" );
+
+			$el.closest( '.ui-page' ).css( "padding-" + ( header ? "top" : "bottom" ), 0 );
+			$el.removeClass( "ui-header-fixed ui-footer-fixed ui-header-fullscreen ui-footer-fullscreen in out fade slidedown slideup ui-fixed-hidden" );
+			$el.closest( ".ui-page" ).removeClass( "ui-page-header-fixed ui-page-footer-fixed ui-page-header-fullscreen ui-page-footer-fullscreen" );
 		}
 
 	});

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -263,7 +263,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 			var $el = this.element,
 				header = $el.is( ".ui-header" );
 
-			$el.closest( '.ui-page' ).css( "padding-" + ( header ? "top" : "bottom" ), "" );
+			$el.closest( ".ui-page" ).css( "padding-" + ( header ? "top" : "bottom" ), "" );
 			$el.removeClass( "ui-header-fixed ui-footer-fixed ui-header-fullscreen ui-footer-fullscreen in out fade slidedown slideup ui-fixed-hidden" );
 			$el.closest( ".ui-page" ).removeClass( "ui-page-header-fixed ui-page-footer-fixed ui-page-header-fullscreen ui-page-footer-fullscreen" );
 		}


### PR DESCRIPTION
...d #5261 - When you call destroy on the fixedToolbar widget it does not restore page padding
