### PR TITLE
Clear input button for text inputs

### DIFF
--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -5,15 +5,19 @@ input.ui-input-text.ui-mini, textarea.ui-input-text.ui-mini { margin: .25em 0; }
 input.ui-input-text, textarea.ui-input-text, .ui-input-search { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; -ms-box-sizing: border-box; box-sizing: border-box; }
 input.ui-input-text { -webkit-appearance: none; }
 textarea.ui-input-text { height: 50px; -webkit-transition: height 200ms linear; -moz-transition: height 200ms linear; -o-transition: height 200ms linear; transition: height 200ms linear; }
-.ui-input-search { padding: 0 30px; margin: .5em 0; background-image: none; position: relative; }
+.ui-input-search, .ui-input-text { padding: 0 30px; margin: .5em 0; background-image: none; position: relative; }
 .ui-input-search.ui-mini { margin: .25em 0; }
-.ui-field-contain .ui-input-search { margin: 0; }
+.ui-field-contain .ui-input-search, .ui-field-contain .ui-input-text { margin: 0; }
 .ui-icon-searchfield:after { position: absolute; left: 7px; top: 50%; margin-top: -9px; content: ""; width: 18px; height: 18px; opacity: .5; }
-.ui-input-search input.ui-input-text { border: none; width: 98%; padding: .4em 0; margin: 0; display: block; background: transparent none; outline: 0 !important; }
-.ui-input-search .ui-input-clear { position: absolute; right: 0; top: 50%; margin-top: -13px; }
+.ui-input-search input.ui-input-text, .ui-input-text input.ui-input-text, .ui-input-text textarea.ui-input-text { border: none; width: 98%; padding: .4em 0; margin: 0; display: block; background: transparent none; outline: 0 !important; }
+.ui-input-search .ui-input-clear, .ui-input-text .ui-input-clear { position: absolute; right: 0; top: 50%; margin-top: -13px; }
 .ui-mini .ui-input-clear { right: -3px; }
 
-.ui-input-search .ui-input-clear-hidden { display: none; }
+.ui-input-text { padding: 0; }
+.ui-input-text input.ui-input-text, .ui-input-text textarea.ui-input-text { width: 100%; padding: .4em; }
+
+
+.ui-input-search .ui-input-clear-hidden, .ui-input-text .ui-input-clear-hidden { display: none; }
 input.ui-mini, .ui-mini input, textarea.ui-mini { font-size: 14px; }
 textarea.ui-mini { height: 45px; }
 
@@ -25,11 +29,12 @@ input[type=number]::-webkit-outer-spin-button { margin: 0; }
 
 @media all and (min-width: 450px){
 	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 2% 0 0 }
-	.ui-field-contain input.ui-input-text, 
-	.ui-field-contain textarea.ui-input-text, 
-	.ui-field-contain .ui-input-search { width: 78%; display: inline-block; } 
-	.ui-hide-label input.ui-input-text, 
-	.ui-hide-label textarea.ui-input-text, 
-	.ui-hide-label .ui-input-search { width: 100%; }
+	.ui-field-contain input.ui-input-text,
+	.ui-field-contain textarea.ui-input-text,
+	.ui-field-contain .ui-input-search { width: 78%; display: inline-block; }
+  .ui-field-contain div.ui-input-text { width: 77%; display: inline-block; }
+	.ui-hide-label input.ui-input-text,
+	.ui-hide-label textarea.ui-input-text,
+	.ui-hide-label .ui-input-search, .ui-hide-label .ui-input-text { width: 100%; }
 	.ui-input-search input.ui-input-text { width: 98%; /*echos rule from above*/ }
 }

--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -28,11 +28,11 @@ input:-moz-placeholder { color: #aaa; }
 input[type=number]::-webkit-outer-spin-button { margin: 0; }
 
 @media all and (min-width: 450px){
-	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 2% 0 0 }
+	.ui-field-contain label.ui-input-text  { vertical-align: top; display: inline-block; width: 20%; margin: 0 1% 0 0 }
 	.ui-field-contain input.ui-input-text,
 	.ui-field-contain textarea.ui-input-text,
-	.ui-field-contain .ui-input-search { width: 78%; display: inline-block; }
-  .ui-field-contain div.ui-input-text { width: 77%; display: inline-block; }
+	.ui-field-contain .ui-input-search,
+  .ui-field-contain .ui-input-text { width: 78%; display: inline-block; }
 	.ui-hide-label input.ui-input-text,
 	.ui-hide-label textarea.ui-input-text,
 	.ui-hide-label .ui-input-search, .ui-hide-label .ui-input-text { width: 100%; }

--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -81,6 +81,29 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 
 			input.bind( 'paste cut keyup focus change blur', toggleClear );
 
+		} else if ( input.not( ":jqmData(clear-btn='false')" ).is( "[type='text'],:jqmData(clear-btn='true')" ) ) {
+			focusedEl = input.wrap( "<div class='ui-input-text ui-shadow-inset ui-btn-corner-all ui-btn-shadow" + themeclass + miniclass + "'></div>" ).parent();
+			clearbtn = $( "<a href='#' class='ui-input-clear' title='" + o.clearSearchButtonText + "'>" + o.clearSearchButtonText + "</a>" )
+				.bind('click', function( event ) {
+					input
+						.val( "" )
+						.focus()
+						.trigger( "change" );
+					clearbtn.addClass( "ui-input-clear-hidden" );
+					event.preventDefault();
+				})
+				.appendTo( focusedEl )
+				.buttonMarkup({
+					icon: "delete",
+					iconpos: "notext",
+					corners: true,
+					shadow: true,
+					mini: o.mini
+				});
+
+			toggleClear();
+
+			input.bind( 'paste cut keyup focus change blur', toggleClear );
 		} else {
 			input.addClass( "ui-corner-all ui-shadow-inset" + themeclass + miniclass );
 		}

--- a/tests/unit/textinput/index.html
+++ b/tests/unit/textinput/index.html
@@ -57,6 +57,10 @@
   <textarea id="destroycorrectly">Test Value</textarea>
 
   <input type="search" id="search-input">
+
+  <input type="text" id="text-input">
+
+  <textarea data-clear-btn="true" id="textarea-clear-button"></textarea>
 </div>
 </body>
 </html>

--- a/tests/unit/textinput/textinput_core.js
+++ b/tests/unit/textinput/textinput_core.js
@@ -81,4 +81,12 @@
 	test( "'clear text' button for search inputs should use configured text", function(){
 		strictEqual( $( "#search-input" ).closest( ".ui-input-search" ).find( ".ui-input-clear" ).attr( "title" ), "custom value" );
 	});
+
+	test( "inputs [type='text'] have clear text button by default", function() {
+		ok( $( '#text-input' ).next( 'a.ui-input-clear' ), "input of type=text have clear button by default" );
+	});
+
+	test( "data-clear-btn adds clear text button to inputs", function() {
+		ok( $( "#textarea-clear-button" ).next( "a.ui-input-clear" ), "textarea with data-clear-btn=true has clear button" );
+	});
 })(jQuery);


### PR DESCRIPTION
This is a change to four files (2 test files and then the js/css for the text input widget) to add feature request #1834 (https://github.com/jquery/jquery-mobile/issues/1834) to automatically add a text clear button to text inputs with data-clear-button=true.

May need to decide if its right to allow the clear button on textarea elements or if only on input type text (right now it does both).
