### PR TITLE
Fix for issue #4724  - Moving through form in Mobile Safari with "Next" and "Previous" system controls causes fixed position, tap-toggle false Header to reveal itself

### DIFF
--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -241,7 +241,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 		},
 
 		_bindToggleHandlers: function() {
-			var self = this,
+			var self = this, delay,
 				o = self.options,
 				$el = self.element;
 
@@ -259,7 +259,18 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 					//and issue #4113 Header and footer change their position after keyboard popup - iOS
 					//and issue #4410 Footer navbar moves up when clicking on a textbox in an Android environment
 					if ( screen.width < 1025 && $( e.target ).is( o.hideDuringFocus ) && !$( e.target ).closest( ".ui-header-fixed, .ui-footer-fixed" ).length ) {
-						self[ ( e.type === "focusin" && self._visible ) ? "hide" : "show" ]();
+						//Fix for issue #4724 Moving through form in Mobile Safari with "Next" and "Previous" system 
+						//controls causes fixed position, tap-toggle false Header to reveal itself 
+						if(e.type === "focusout" && self._visible ){
+							//wait for the stack to unwind and see if we have jumped to another input
+							delay = setTimeout(function(){
+								self.show();
+							},0); 
+						} else if( e.type === "focusin" && self._visible ) {
+							//if we have jumped to another input clear the time out to cancle the show.
+							clearTimeout( delay );
+							self.hide();
+						}
 					}
 				});
 		},

--- a/tests/unit/fixed-toolbar/fixedToolbar.js
+++ b/tests/unit/fixed-toolbar/fixedToolbar.js
@@ -195,11 +195,17 @@
 
 			function() {
 				ok( !$( '#classes-test-g' ).hasClass('ui-fixed-hidden'), 'The toolbar does not have the ui-fixed-hidden class');
+			},
+
+			function() {
 				$( '#classes-test-g' ).fixedtoolbar( "toggle" );
 			},
 
 			function() {
 				ok( $( '#classes-test-g' ).hasClass('ui-fixed-hidden'), 'The toolbar does have the ui-fixed-hidden class');
+			},
+
+			function() {
 				$( '#classes-test-g' ).fixedtoolbar( "toggle" );
 			},
 


### PR DESCRIPTION
...out to make sure we have not jumped to another input. Fixed #4724 - Moving through form in Mobile Safari with "Next" and "Previous" system controls causes fixed position, tap-toggle false Header to reveal itself
