### PR TITLE
FixedToolbar: change destroy to _destroy per ui 1.9 upgrade guide widget...

### DIFF
--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -264,7 +264,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 				});
 		},
 
-		destroy: function() {
+		_destroy: function() {
 			var $el = this.element,
 				header = $el.is( ".ui-header" );
 


### PR DESCRIPTION
... was not being destroyed previously. Fixes #3880 - fixedToolbar _destroy()
