### PR TITLE
Linting fix for table merge

### DIFF
--- a/js/widgets/jquery.mobile.table.reflow.js
+++ b/js/widgets/jquery.mobile.table.reflow.js
@@ -50,7 +50,6 @@ $( document ).delegate( ":jqmData(role='table')", "tablecreate", function() {
 
 					if( iteration ){
 						filter = "td:nth-child("+ iteration +"n + " + ( colstart ) +")";
-						console.log("td:nth-child("+ iteration +"n + " + ( colstart ) +")");
 					}
 					$cells.filter( filter ).prepend( "<b class='" + o.classes.cellLabels + hierarchyClass + "'>" + text + "</b>"  );
 				}


### PR DESCRIPTION
Removing console.log so this:

Running "lint:files" (lint) task
Linting js/widgets/jquery.mobile.table.reflow.js...ERROR
[L53:C25] 'console' is not defined.
            console.log("td:nth-child("+ iteration +"n + " + ( colstart ) +")");

<WARN> Task "lint:files" failed. Use --force to continue. </WARN>

doesn't happen.
