### PR TITLE
Fix PHP Warning in server logs for js/index.php.

### DIFF
--- a/js/index.php
+++ b/js/index.php
@@ -62,7 +62,8 @@ $files = array(
 );
 
 function getCommitId() {
-	$logs = file_get_contents( "../.git/logs/HEAD" );
+	$gitHeadPath = "../.git/logs/HEAD";
+	$logs = ( is_readable( $gitHeadPath ) ? file_get_contents( $gitHeadPath ) : false );
 	if ( $logs ) {
 		$logs = explode( "\n", $logs );
 		$n_logs = count( $logs );


### PR DESCRIPTION
Backport 982d7fa2640f7425d9d8306b0917d97f11bdc095 from master to unprefixed-transitions.

```
PHP Warning:  file_get_contents(../.git/logs/HEAD): failed to open stream:
No such file or directory
in /var/lib/jenkins/jobs/jQuery Mobile Branch Preview/workspace/branches/unprefixed-transitions/
js/index.php on line 65
```
