### PR TITLE
Events: modified touch.js to prevent scroll event listeners failing on re-binding.

### DIFF
--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -38,11 +38,26 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 
 	// also handles scrollstop
 	$.event.special.scrollstart = {
-
+		
 		enabled: true,
 
-		setup: function() {
+		mobileScrollHandler: function( event ) {
 
+			if ( !$.event.special.scrollstart.enabled ) {
+				return;
+			}
+
+			if ( !scrolling ) {
+				trigger( event, true );
+			}
+
+			clearTimeout( timer );
+			timer = setTimeout( function() {
+				trigger( event, false );
+			}, 50 );
+		},
+
+		setup: function() {
 			var thisObject = this,
 				$this = $( thisObject ),
 				scrolling,
@@ -54,21 +69,12 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 			}
 
 			// iPhone triggers scroll after a small delay; use touchmove instead
-			$this.bind( scrollEvent, function( event ) {
+			$this.bind( scrollEvent, $.event.special.scrollstart.mobileScrollHandler );
+		},
 
-				if ( !$.event.special.scrollstart.enabled ) {
-					return;
-				}
-
-				if ( !scrolling ) {
-					trigger( event, true );
-				}
-
-				clearTimeout( timer );
-				timer = setTimeout( function() {
-					trigger( event, false );
-				}, 50 );
-			});
+		teardown: function() {
+			$(this).unbind( scrollEvent , $.event.special.scrollstart.mobileScrollHandler );
+			return false;
 		}
 	};
 

--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -51,8 +51,8 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 				trigger( event, true );
 			}
 
-			clearTimeout( timer );
-			timer = setTimeout( function() {
+			clearTimeout( $.event.special.scrollstart.timer );
+			$.event.special.scrollstart.timer = setTimeout( function() {
 				trigger( event, false );
 			}, 50 );
 		},
@@ -60,8 +60,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 		setup: function() {
 			var thisObject = this,
 				$this = $( thisObject ),
-				scrolling,
-				timer;
+				scrolling;			
 
 			function trigger( event, state ) {
 				scrolling = state;
@@ -93,11 +92,10 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 				}
 
 				var origTarget = event.target,
-					origEvent = event.originalEvent,
-					timer;
+					origEvent = event.originalEvent;
 
 				function clearTapTimer() {
-					clearTimeout( timer );
+					clearTimeout( $.event.special.tap.timer );
 				}
 
 				function clearTapHandlers() {
@@ -122,7 +120,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 					.bind( "vclick", clickHandler );
 				$( document ).bind( "vmousecancel", clearTapHandlers );
 
-				timer = setTimeout( function() {
+				$.event.special.tap.timer = setTimeout( function() {
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold", { target: origTarget } ) );
 				}, $.event.special.tap.tapholdThreshold );
 			});


### PR DESCRIPTION
Events: modified touch.js to prevent scroll event listeners failing on re-binding.

===The Bug===
The handler binded to the scroll event in the "scrollStart" event's "start" function isn't being unbinded when ".unbind('scroll',someHandler)" is called. This causes the handler to be added multiple times to an element each time the element is binded to the scroll event, even if ".unbind" was called, thus preventing the programmers' supplied handler from listening to the event once a second "bind" was performed.
===The Fix===
I've added a "teardown" function to the event that performs the needed unbinding. (In order to unbind the specific handler I've changed it from an anonymous function to a function property inside the event's namespace).

Cheers :)
