### PR TITLE
auto repositioning of opened collapsibles #5394

### DIFF
--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -7,57 +7,64 @@
 
 
 
-// smart_scroll(el, offset) - scroll an element fully into view
+//
+// scroll an element fully into view
 //
 // if fully visible: do nothing
 // if partly visible: scroll as little as to make it fully visible
 // if larger than viewport: scroll to top of screen
 //
-// offset: manual correction, if other elem (eg. a header above) should also be visible
+// after expanding or loading an element it's often badly positioned and you 
+// start scrolling immediately. this scrolls it into the best possible position
 //
 //
-// https://github.com/jquery/jquery-mobile/issues/5394
+// demo: http://jsbin.com/udahoh/4/
 //
-// demo: http://jsbin.com/udahoh/3
-//
-// usage outside of jQM: 
-//
-// $('#boats,#cars').live('expand', function(e){ smart_scroll(e.target); });
-//
-// when using "on"  'expand' seems to fire before it's actually expanded. 
-// el_height will then be height of closed collaps. won't work.
-
 
 
 function smart_scroll(el, offset) 
 { 
   
-if(typeof offset === "undefined") offset = 0;  // manual override if other elem should be visible
+
+offset = offset || 0; // manual correction, if other elem (eg. a header above) should also be visible
   
-var air         = 15; // above+below space so it's not tucked to the screen edge
+var air         = 15; // above+below space so element is not tucked to the screen edge
     
-var el_height   = $(el).height()+ 2 * air;
+var el_height   = $(el).height()+ 2 * air + offset;
 var el_pos      = $(el).offset();
-var el_pos_top  = el_pos.top - air;
+var el_pos_top  = el_pos.top - air - offset;
   
 var vport_height = $(window).height();
 var win_top      = $(window).scrollTop();
  
 //  alert("el_pos_top:"+el_pos_top+"  el_height:"+el_height+"win_top:"+win_top+"  vport_height:"+vport_height);
   
-var hidden = (el_pos_top + el_height) - (win_top + vport_height);      // hidden part of element
+var hidden = (el_pos_top + el_height) - (win_top + vport_height);
   
 if ( hidden > 0 ) // element not fully visible
     {
     var scroll;
     
-    if(el_height > vport_height) scroll = el_pos_top;       // larger than viewport - scroll to top
-    else                         scroll = win_top + hidden; // smaller than vieport - scroll minimally but fully into view
+    if(el_height > vport_height) scroll = el_pos_top;        // larger than viewport - scroll to top
+    else                         scroll = win_top + hidden;   // smaller than vieport - scroll minimally but fully into view
  
-    $('html, body').animate({ scrollTop: (scroll+offset) }, 200); 
+ 
+    $('html, body').animate({ scrollTop: (scroll) }, 200); 
     }
 
 }
+
+
+
+
+// when using "on"  'expand' seems to fire before it's actually expanded. 
+// el_height will then be height of closed collaps. won't work.
+
+//$('#boats,#cars').live('expand', function(e){ smart_scroll(e.target); });
+
+//$('#offset').live('expand', function(e){ 
+//  smart_scroll( e.target, $('#header').height() + 20 ); 
+//});
 
 
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -45,7 +45,7 @@ var win_top      = $(window).scrollTop();
  
 //  alert("el_pos_top:"+el_pos_top+"  el_height:"+el_height+"win_top:"+win_top+"  vport_height:"+vport_height);
   
-var hidden = (el_pos_top + el_height) - (win_top + vport_height);
+var hidden = (el_pos_top + el_height) - (win_top + vport_height);      // hidden part of element
   
 if ( hidden > 0 ) // element not fully visible
     {

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -1,4 +1,3 @@
-
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 //>>description: Creates collapsible content blocks.
 //>>label: Collapsible
@@ -20,7 +19,7 @@
 //
 // usage outside of jQM: 
 //
-//$('#collapsible').live('expand',smart_scroll); 
+//   $('#collapsible').live('expand',smart_scroll); 
 //
 // strange: when using "on" instead of "live"  'expand' seems to fire before collaps. actually expanded. 
 // el_height will then be height of closed collaps. doesn't work with "on".

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -14,10 +14,10 @@
 //
 
 
-function smart_scroll() { 
+function smart_scroll(el) { 
 
-var el_height   = $(this).height();
-var el_pos      = $(this).offset();
+var el_height   = $(el).height();
+var el_pos      = $(el).offset();
 var el_pos_top  = el_pos.top;
 
 var vport_height = $(window).height();
@@ -183,7 +183,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 
 					collapsibleContent.trigger( "updatelayout" );
 					
-					if(o.autoscroll && !isCollapse) smart_scroll();
+					if(o.autoscroll && !isCollapse)  smart_scroll($this);
 				}
 			})
 			.trigger( o.collapsed ? "collapse" : "expand" );

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -6,7 +6,7 @@
 // if partly visible: scroll as little as to make it fully visible
 // if larger than viewport: scroll to top of screen
 //
-//
+// https://github.com/jquery/jquery-mobile/issues/5394
 
 function smart_scroll() { 
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -8,6 +8,8 @@
 //
 // https://github.com/jquery/jquery-mobile/issues/5394
 
+// demo: http://jsbin.com/amozef/30
+
 function smart_scroll() { 
 
 var el_height   = $(this).height();

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -10,6 +10,8 @@
 
 // demo: http://jsbin.com/amozef/30
 
+// usage: $('#collapsible').live('expand',smart_scroll);
+
 function smart_scroll() { 
 
 var el_height   = $(this).height();

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -1,6 +1,15 @@
-//
-//
-// scroll an element fully into view
+
+
+//>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
+//>>description: Creates collapsible content blocks.
+//>>label: Collapsible
+//>>group: Widgets
+//>>css.structure: ../css/structure/jquery.mobile.collapsible.css
+//>>css.theme: ../css/themes/default/jquery.mobile.theme.css
+
+
+
+// smart_scroll(el) - scroll an element fully into view
 //
 // if fully visible: do nothing
 // if partly visible: scroll as little as to make it fully visible
@@ -11,7 +20,6 @@
 // demo: http://jsbin.com/amozef/30
 //
 // usage: $('#collapsible').live('expand',smart_scroll);
-//
 
 
 function smart_scroll(el) { 
@@ -42,12 +50,8 @@ if (hidden>0) // element not fully visible
 
 
 
-//>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
-//>>description: Creates collapsible content blocks.
-//>>label: Collapsible
-//>>group: Widgets
-//>>css.structure: ../css/structure/jquery.mobile.collapsible.css
-//>>css.theme: ../css/themes/default/jquery.mobile.theme.css
+
+
 
 define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.buttonMarkup" ], function( $ ) {
 //>>excludeEnd("jqmBuildExclude");

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -1,3 +1,41 @@
+//
+//
+// scroll an element fully into view
+//
+// if fully visible: do nothing
+// if partly visible: scroll as little as to make it fully visible
+// if larger than viewport: scroll to top of screen
+//
+//
+
+function smart_scroll() { 
+
+var el_height   = $(this).height();
+var el_pos      = $(this).offset();
+var el_pos_top  = el_pos.top;
+
+var vport_height = $(window).height();
+var win_top      = $(window).scrollTop();
+
+//  alert("el_pos_top:"+el_pos_top+"  el_height:"+el_height+"win_top:"+win_top+"  vport_height:"+vport_height);
+
+var hidden = (el_pos_top + el_height) - (win_top + vport_height);   // hidden part of element
+
+if (hidden>0) // element not fully visible
+    {
+    var scroll;
+
+    if(el_height > vport_height) scroll = el_pos_top;  // larger than viewport - scroll to top
+    else scroll = win_top + hidden; // smaller than vieport - scroll minimally but fully into view
+
+    $('html, body').animate({scrollTop: scroll},200); 
+    // $.mobile.silentScroll( scroll); // jump scroll alternative, less cpu but maybe disturbing
+    }
+
+}
+
+
+
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 //>>description: Creates collapsible content blocks.
 //>>label: Collapsible
@@ -24,6 +62,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 		corners: true,
 		mini: false,
 		initSelector: ":jqmData(role='collapsible')"
+		autoscroll: true,
 	},
 	_create: function() {
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -7,10 +7,12 @@
 // if larger than viewport: scroll to top of screen
 //
 // https://github.com/jquery/jquery-mobile/issues/5394
-
+//
 // demo: http://jsbin.com/amozef/30
-
+//
 // usage: $('#collapsible').live('expand',smart_scroll);
+//
+
 
 function smart_scroll() { 
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -1,5 +1,4 @@
 
-
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 //>>description: Creates collapsible content blocks.
 //>>label: Collapsible
@@ -19,7 +18,12 @@
 //
 // demo: http://jsbin.com/amozef/30
 //
-// usage: $('#collapsible').live('expand',smart_scroll);
+// usage outside of jQM: 
+//
+//$('#collapsible').live('expand',smart_scroll); 
+//
+// strange: when using "on" instead of "live"  'expand' seems to fire before collaps. actually expanded. 
+// el_height will then be height of closed collaps. doesn't work with "on".
 
 
 function smart_scroll(el) { 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -7,49 +7,58 @@
 
 
 
-// smart_scroll(el) - scroll an element fully into view
+// smart_scroll(el, offset) - scroll an element fully into view
 //
 // if fully visible: do nothing
 // if partly visible: scroll as little as to make it fully visible
 // if larger than viewport: scroll to top of screen
 //
+// offset: manual correction, if other elem (eg. a header above) should also be visible
+//
+//
 // https://github.com/jquery/jquery-mobile/issues/5394
 //
-// demo: http://jsbin.com/amozef/30
+// demo: http://jsbin.com/udahoh/3
 //
 // usage outside of jQM: 
 //
-//   $('#collapsible').live('expand',smart_scroll); 
+// $('#boats,#cars').live('expand', function(e){ smart_scroll(e.target); });
 //
-// strange: when using "on" instead of "live"  'expand' seems to fire before collaps. actually expanded. 
-// el_height will then be height of closed collaps. doesn't work with "on".
+// when using "on"  'expand' seems to fire before it's actually expanded. 
+// el_height will then be height of closed collaps. won't work.
 
 
-function smart_scroll(el) { 
 
-var el_height   = $(el).height();
+function smart_scroll(el, offset) 
+{ 
+  
+if(typeof offset === "undefined") offset = 0;  // manual override if other elem should be visible
+  
+var air         = 15; // above+below space so it's not tucked to the screen edge
+    
+var el_height   = $(el).height()+ 2 * air;
 var el_pos      = $(el).offset();
-var el_pos_top  = el_pos.top;
-
+var el_pos_top  = el_pos.top - air;
+  
 var vport_height = $(window).height();
 var win_top      = $(window).scrollTop();
-
+ 
 //  alert("el_pos_top:"+el_pos_top+"  el_height:"+el_height+"win_top:"+win_top+"  vport_height:"+vport_height);
-
-var hidden = (el_pos_top + el_height) - (win_top + vport_height);   // hidden part of element
-
-if (hidden>0) // element not fully visible
+  
+var hidden = (el_pos_top + el_height) - (win_top + vport_height);
+  
+if ( hidden > 0 ) // element not fully visible
     {
     var scroll;
-
-    if(el_height > vport_height) scroll = el_pos_top;  // larger than viewport - scroll to top
-    else scroll = win_top + hidden; // smaller than vieport - scroll minimally but fully into view
-
-    $('html, body').animate({scrollTop: scroll},200); 
-    // $.mobile.silentScroll( scroll); // jump scroll alternative, less cpu but maybe disturbing
+    
+    if(el_height > vport_height) scroll = el_pos_top;       // larger than viewport - scroll to top
+    else                         scroll = win_top + hidden; // smaller than vieport - scroll minimally but fully into view
+ 
+    $('html, body').animate({ scrollTop: (scroll+offset) }, 200); 
     }
 
 }
+
 
 
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -182,6 +182,8 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 					collapsibleContent.toggleClass( "ui-collapsible-content-collapsed", isCollapse ).attr( "aria-hidden", isCollapse );
 
 					collapsibleContent.trigger( "updatelayout" );
+					
+					if(o.autoscroll && !isCollapse) smart_scroll();
 				}
 			})
 			.trigger( o.collapsed ? "collapse" : "expand" );


### PR DESCRIPTION
toddparker asked me to do a pull request.

https://github.com/jquery/jquery-mobile/issues/5394

it's a first. no idea what i'm doing. so bear with me if it 's looking stupid (eg. don't know where to put the scroll function). tested this locally, seems to work as intended.

after opening a collapsible it's often badly positioned and you start scrolling immediately.

feature request:
when you open a collapsible it should automatically scroll into the best possible position

if it's fully visible: do nothing
if it's partly visible: scroll as little as to make it fully visible
if larger than viewport: scroll to top of screen
could at least be done as an option if is problematic as default.

demo included - see code
