### PR TITLE
Reusing "$.mobile.firstPage" variable to improve performance slightly.

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -77,7 +77,7 @@ define([
 			$.mobile.firstPage = $pages.first();
 
 			// define page container
-			$.mobile.pageContainer = $pages.first().parent().addClass( "ui-mobile-viewport" );
+			$.mobile.pageContainer = $.mobile.firstPage.parent().addClass( "ui-mobile-viewport" );
 
 			// alert listeners that the pagecontainer has been determined for binding
 			// to events triggered on it


### PR DESCRIPTION
"$page.first()" function call is repeated on jquey.mobile.init.js file. "$page.first()" function is already called and assigned to "$.mobile.firstPage" variable.  So the variable should be used without duplicated function call.  You can know that Javascript Core(JSC) or another Javascript runtime engine will execute $page.first() function once more at that line. So It would be better to use not "$page.first()." but "$.mobile.firstPage."
And there are verified PR steps.
1. Tests : The code has been tested on several jQM widgets using qunit.js.
2. Modified code is followed the jQuery Core Style guide.
3. Scope : Performance improvement.

My team is developing Tizen web UIFW and got a few performance issues. I told Mr, Todd and he ask me to upload it. So I choose a very simple case because this is my first PR. It's the first for me to submit a PR. If there are any problems or mistakes to review it, please let me know. Thanks in advance. Merry Christmas~!! :)
