### PR TITLE
Reducing $(document) and $(window) functions call to improve performance.

### DIFF
--- a/js/events/navigate.js
+++ b/js/events/navigate.js
@@ -8,7 +8,7 @@ define([ "jquery", "./../jquery.mobile.support" ], function( $ ) {
 //>>excludeEnd("jqmBuildExclude");
 
 (function( $, undefined ) {
-	var $win = $( window ), self, history;
+	var $win = $.mobile.$window, self, history;
 
 	$.event.special.navigate = self = {
 		bound: false,

--- a/js/events/orientationchange.js
+++ b/js/events/orientationchange.js
@@ -7,7 +7,7 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 //>>excludeEnd("jqmBuildExclude");
 
 (function( $, window ) {
-	var win = $( window ),
+	var win = $.mobile.$window,
 		event_name = "orientationchange",
 		special_event,
 		get_orientation,
@@ -44,8 +44,8 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 		// developer console. The actual threshold value is somewhat arbitrary, we just
 		// need to make sure it is large enough to exclude the developer console case.
 
-		var ww = window.innerWidth || $( window ).width(),
-			wh = window.innerHeight || $( window ).height(),
+		var ww = window.innerWidth || $.mobile.$window.width(),
+			wh = window.innerHeight || $.mobile.$window.height(),
 			landscape_threshold = 50;
 
 		initial_orientation_is_landscape = ww > wh && ( ww - wh ) > landscape_threshold;

--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -99,7 +99,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 
 					$this.unbind( "vclick", clickHandler )
 						.unbind( "vmouseup", clearTapTimer );
-					$( document ).unbind( "vmousecancel", clearTapHandlers );
+					$.mobile.$document.unbind( "vmousecancel", clearTapHandlers );
 				}
 
 				function clickHandler( event ) {
@@ -114,7 +114,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 
 				$this.bind( "vmouseup", clearTapTimer )
 					.bind( "vclick", clickHandler );
-				$( document ).bind( "vmousecancel", clearTapHandlers );
+				$.mobile.$document.bind( "vmousecancel", clearTapHandlers );
 
 				timer = setTimeout( function() {
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold", { target: origTarget } ) );

--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -212,7 +212,7 @@ function updateButtonClass( $btn, classToRemove, classToAdd, hover, state ) {
 var attachEvents = function() {
 	var hoverDelay = $.mobile.buttonMarkup.hoverDelay, hov, foc;
 
-	$( document ).bind( {
+	$.mobile.$document.bind( {
 		"vmousedown vmousecancel vmouseup vmouseover vmouseout focus blur scrollstart": function( event ) {
 			var theme,
 				$btn = $( closestEnabledButton( event.target ) ),
@@ -266,7 +266,7 @@ var attachEvents = function() {
 
 //links in bars, or those with  data-role become buttons
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 
 	$( ":jqmData(role='button'), .ui-bar > a, .ui-header > a, .ui-footer > a, .ui-bar > :jqmData(role='controlgroup') > a", e.target )
 		.jqmEnhanceable()

--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -84,6 +84,10 @@ define( [ "jquery", "text!../version.txt" ], function( $, __version__ ) {
 			hoverDelay: 200
 		},
 
+		// define the window and the document objects
+		$window: $( window ),
+		$document: $( document ),		
+
 		// TODO might be useful upstream in jquery itself ?
 		keyCode: {
 			ALT: 18,
@@ -134,7 +138,7 @@ define( [ "jquery", "text!../version.txt" ], function( $, __version__ ) {
 
 			setTimeout( function() {
 				window.scrollTo( 0, ypos );
-				$( document ).trigger( "silentscroll", { x: 0, y: ypos });
+				$.mobile.$document.trigger( "silentscroll", { x: 0, y: ypos });
 			}, 20 );
 
 			setTimeout( function() {
@@ -240,7 +244,7 @@ define( [ "jquery", "text!../version.txt" ], function( $, __version__ ) {
 		getScreenHeight: function() {
 			// Native innerHeight returns more accurate value for this across platforms,
 			// jQuery version is here as a normalized fallback for platforms like Symbian
-			return window.innerHeight || $( window ).height();
+			return window.innerHeight || $.mobile.$window.height();
 		}
 	}, $.mobile );
 

--- a/js/jquery.mobile.degradeInputs.js
+++ b/js/jquery.mobile.degradeInputs.js
@@ -26,7 +26,7 @@ $.mobile.page.prototype.options.degradeInputs = {
 
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 
 	var page = $.mobile.closestPageData( $( e.target ) ), options;
 

--- a/js/jquery.mobile.fieldContain.js
+++ b/js/jquery.mobile.fieldContain.js
@@ -19,7 +19,7 @@ $.fn.fieldcontain = function( options ) {
 };
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$( ":jqmData(role='fieldcontain')", e.target ).jqmEnhanceable().fieldcontain();
 });
 

--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -19,7 +19,7 @@ define([
 (function( $, window, undefined ) {
 	var	$html = $( "html" ),
 			$head = $( "head" ),
-			$window = $( window );
+			$window = $.mobile.$window;
 
 	//remove initial build class (only present on first pageshow)
 	function hideRenderingClass() {
@@ -143,7 +143,7 @@ define([
 		// if defaultHomeScroll hasn't been set yet, see if scrollTop is 1
 		// it should be 1 in most browsers, but android treats 1 as 0 (for hiding addr bar)
 		// so if it's 1, use 0 from now on
-		$.mobile.defaultHomeScroll = ( !$.support.scrollTop || $( window ).scrollTop() === 1 ) ? 0 : 1;
+		$.mobile.defaultHomeScroll = ( !$.support.scrollTop || $.mobile.$window.scrollTop() === 1 ) ? 0 : 1;
 
 		//dom-ready inits
 		if ( $.mobile.autoInitializePage ) {
@@ -159,7 +159,7 @@ define([
 			// by adding the 'ui-disabled' class to them. Using a JavaScript workaround for those browser.
 			// https://github.com/jquery/jquery-mobile/issues/3558
 
-			$( document ).delegate( ".ui-disabled", "vclick",
+			$.mobile.$document.delegate( ".ui-disabled", "vclick",
 				function( e ) {
 					e.preventDefault();
 					e.stopImmediatePropagation();

--- a/js/jquery.mobile.links.js
+++ b/js/jquery.mobile.links.js
@@ -8,7 +8,7 @@ define( [ "jquery" ], function( $ ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
 
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 
 	//links within content areas, tests included with page
 	$( e.target )

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -20,7 +20,7 @@ define( [
 (function( $, undefined ) {
 
 	//define vars for interal use
-	var $window = $( window ),
+	var $window = $.mobile.$window,
 		$html = $( 'html' ),
 		$head = $( 'head' ),
 
@@ -998,7 +998,7 @@ define( [
 		};
 
 		//bind to form submit events, handle with Ajax
-		$( document ).delegate( "form", "submit", function( event ) {
+		$.mobile.$document.delegate( "form", "submit", function( event ) {
 			var formData = getAjaxFormData( $( this ) );
 
 			if ( formData ) {
@@ -1008,7 +1008,7 @@ define( [
 		});
 
 		//add active state on vclick
-		$( document ).bind( "vclick", function( event ) {
+		$.mobile.$document.bind( "vclick", function( event ) {
 			var $btn, btnEls, target = event.target, needClosest = false;
 			// if this isn't a left click we don't care. Its important to note
 			// that when the virtual event is generated it will create the which attr
@@ -1071,7 +1071,7 @@ define( [
 		});
 
 		// click routing - direct to HTTP or Ajax, accordingly
-		$( document ).bind( "click", function( event ) {
+		$.mobile.$document.bind( "click", function( event ) {
 			if ( !$.mobile.linkBindingEnabled ) {
 				return;
 			}
@@ -1169,7 +1169,7 @@ define( [
 		});
 
 		//prefetch pages when anchors with data-prefetch are encountered
-		$( document ).delegate( ".ui-page", "pageshow.prefetch", function() {
+		$.mobile.$document.delegate( ".ui-page", "pageshow.prefetch", function() {
 			var urls = [];
 			$( this ).find( "a:jqmData(prefetch)" ).each(function() {
 				var $link = $( this ),
@@ -1276,8 +1276,8 @@ define( [
 		});
 
 		//set page min-heights to be device specific
-		$( document ).bind( "pageshow", resetActivePageHeight );
-		$( window ).bind( "throttledresize", resetActivePageHeight );
+		$.mobile.$document.bind( "pageshow", resetActivePageHeight );
+		$.mobile.$window.bind( "throttledresize", resetActivePageHeight );
 
 	};//navreadyDeferred done callback
 

--- a/js/jquery.mobile.nojs.js
+++ b/js/jquery.mobile.nojs.js
@@ -7,7 +7,7 @@ define( [ "jquery" ], function( $ ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
 
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$( ":jqmData(role='nojs')", e.target ).addClass( "ui-nojs" );
 	
 });

--- a/js/jquery.mobile.transition.js
+++ b/js/jquery.mobile.transition.js
@@ -24,8 +24,8 @@ var createHandler = function( sequential ) {
 			active	= $.mobile.urlHistory.getActive(),
 			toScroll = active.lastScroll || $.mobile.defaultHomeScroll,
 			screenHeight = $.mobile.getScreenHeight(),
-			maxTransitionOverride = $.mobile.maxTransitionWidth !== false && $( window ).width() > $.mobile.maxTransitionWidth,
-			none = !$.support.cssTransitions || maxTransitionOverride || !name || name === "none" || Math.max( $( window ).scrollTop(), toScroll ) > $.mobile.getMaxScrollForTransition(),
+			maxTransitionOverride = $.mobile.maxTransitionWidth !== false && $.mobile.$window.width() > $.mobile.maxTransitionWidth,
+			none = !$.support.cssTransitions || maxTransitionOverride || !name || name === "none" || Math.max( $.mobile.$window.scrollTop(), toScroll ) > $.mobile.getMaxScrollForTransition(),
 			toPreClass = " ui-page-pre-in",
 			toggleViewportClass = function() {
 				$.mobile.pageContainer.toggleClass( "ui-mobile-viewport-transitioning viewport-" + name );
@@ -59,7 +59,7 @@ var createHandler = function( sequential ) {
 				// Set the from page's height and start it transitioning out
 				// Note: setting an explicit height helps eliminate tiling in the transitions
 				$from
-					.height( screenHeight + $( window ).scrollTop() )
+					.height( screenHeight + $.mobile.$window.scrollTop() )
 					.addClass( name + " out" + reverseClass );
 			},
 
@@ -121,7 +121,7 @@ var createHandler = function( sequential ) {
 
 				// In some browsers (iOS5), 3D transitions block the ability to scroll to the desired location during transition
 				// This ensures we jump to that spot after the fact, if we aren't there already.
-				if ( $( window ).scrollTop() !== toScroll ) {
+				if ( $.mobile.$window.scrollTop() !== toScroll ) {
 					scrollPage();
 				}
 

--- a/js/jquery.mobile.vmouse.js
+++ b/js/jquery.mobile.vmouse.js
@@ -38,7 +38,7 @@ var dataPropertyName = "virtualMouseBindings",
 	blockMouseTriggers = false,
 	blockTouchTriggers = false,
 	eventCaptureSupported = "addEventListener" in document,
-	$document = $( document ),
+	$document = $.mobile.$document,
 	nextTouchID = 1,
 	lastTouchID = 0, threshold;
 

--- a/js/jquery.mobile.zoom.iosorientationfix.js
+++ b/js/jquery.mobile.zoom.iosorientationfix.js
@@ -37,9 +37,9 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.zoom" ], function( 
 		}
 	}
 
-	$( document ).on( "mobileinit", function(){
+	$.mobile.$document.on( "mobileinit", function(){
 		if( $.mobile.iosorientationfixEnabled ){
-			$( window )
+			$.mobile.$window
 				.bind( "orientationchange.iosorientationfix", zoom.enable )
 				.bind( "devicemotion.iosorientationfix", checkTilt );
 		}

--- a/js/navigation/navigator.js
+++ b/js/navigation/navigator.js
@@ -10,7 +10,7 @@ define([ "jquery", "../events/navigate", "./path", "./history" ], function( $ ) 
 	$.Navigator = function( history ) {
 		this.history = history;
 
-		$( window ).bind({
+		$.mobile.$window.bind({
 			"popstate.history": $.proxy( this.popstate, this ),
 			"hashchange.history": $.proxy( this.hashchange, this )
 		});
@@ -121,7 +121,7 @@ define([ "jquery", "../events/navigate", "./path", "./history" ], function( $ ) 
 				// caught that was triggered by the hash setting above.
 				if( !noEvents ) {
 					this.ignoreNextPopState = true;
-					$( window ).trigger( popstateEvent );
+					$.mobile.$window.trigger( popstateEvent );
 				}
 			}
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -158,7 +158,7 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 });
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.collapsible.prototype.enhanceWithin( e.target );
 });
 

--- a/js/widgets/collapsibleSet.js
+++ b/js/widgets/collapsibleSet.js
@@ -83,7 +83,7 @@ $.widget( "mobile.collapsibleset", $.mobile.widget, {
 $.widget( "mobile.collapsibleset", $.mobile.collapsibleset, $.mobile.behaviors.addFirstLastClasses );
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.collapsibleset.prototype.enhanceWithin( e.target );
 });
 

--- a/js/widgets/controlgroup.js
+++ b/js/widgets/controlgroup.js
@@ -110,7 +110,7 @@ define( [ "jquery",
 	// already be in place, ensuring that all widgets that need to be grouped will
 	// already have been enhanced by the time the controlgroup is created.
 	$( function() {
-		$( document ).bind( "pagecreate create", function( e )  {
+		$.mobile.$document.bind( "pagecreate create", function( e )  {
 			$.mobile.controlgroup.prototype.enhanceWithin( e.target, true );
 		});
 	});

--- a/js/widgets/dialog.js
+++ b/js/widgets/dialog.js
@@ -138,7 +138,7 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 });
 
 //auto self-init widgets
-$( document ).delegate( $.mobile.dialog.prototype.options.initSelector, "pagecreate", function() {
+$.mobile.$document.delegate( $.mobile.dialog.prototype.options.initSelector, "pagecreate", function() {
 	$.mobile.dialog.prototype.enhance( this );
 });
 

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -142,7 +142,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 		_handlePageShow: function() {
 			this.updatePagePadding( this._thisPage );
 			if ( this.options.updatePagePadding ) {
-				this._on( $( window ), { "throttledresize": "updatePagePadding" } );
+				this._on( $.mobile.$window, { "throttledresize": "updatePagePadding" } );
 			}
 		},
 
@@ -153,7 +153,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 				$.mobile.zoom.enable( true );
 			}
 			if ( o.updatePagePadding ) {
-				this._off( $( window ), "throttledresize" );
+				this._off( $.mobile.$window, "throttledresize" );
 			}
 
 			if ( o.trackPersistentToolbars ) {
@@ -190,7 +190,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 		},
 
 		_useTransition: function( notransition ) {
-			var $win = $( window ),
+			var $win = $.mobile.$window,
 				$el = this.element,
 				scroll = $win.scrollTop(),
 				elHeight = $el.height(),
@@ -296,7 +296,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 	});
 
 	//auto self-init widgets
-	$( document )
+	$.mobile.$document
 		.bind( "pagecreate create", function( e ) {
 
 			// DEPRECATED in 1.1: support for data-fullscreen=true|false on the page element.

--- a/js/widgets/fixedToolbar.workarounds.js
+++ b/js/widgets/fixedToolbar.workarounds.js
@@ -47,9 +47,9 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 			_viewportOffset: function() {
 				var $el = this.element,
 					header = $el.is( ".ui-header" ),
-					offset = Math.abs($el.offset().top - $( window ).scrollTop());
+					offset = Math.abs($el.offset().top - $.mobile.$window.scrollTop());
 				if( !header ) {
-					offset = Math.round(offset - $( window ).height() + $el.outerHeight())-60;
+					offset = Math.round(offset - $.mobile.$window.height() + $el.outerHeight())-60;
 				}
 				return offset;
 			},
@@ -58,7 +58,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 			_bindScrollWorkaround: function() {
 				var self = this;
 				//bind to scrollstop and check if the toolbars are correctly positioned
-				this._on( $( window ), { scrollstop: function() {
+				this._on( $.mobile.$window, { scrollstop: function() {
 					var viewportOffset = self._viewportOffset();
 					//check if the header is visible and if its in the right place
 					if( viewportOffset > 2 && self._visible) {

--- a/js/widgets/forms/button.js
+++ b/js/widgets/forms/button.js
@@ -95,7 +95,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 						}).insertBefore( $el );
 
 						// Bind to doc to remove after submit handling
-						$( document ).one( "submit", function() {
+						$.mobile.$document.one( "submit", function() {
 							$buttonPlaceholder.remove();
 
 							// reset the local var so that the hidden input
@@ -158,7 +158,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 });
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.button.prototype.enhanceWithin( e.target, true );
 });
 

--- a/js/widgets/forms/checkboxradio.js
+++ b/js/widgets/forms/checkboxradio.js
@@ -206,7 +206,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, {
 $.widget( "mobile.checkboxradio", $.mobile.checkboxradio, $.mobile.behaviors.formReset );
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.checkboxradio.prototype.enhanceWithin( e.target, true );
 });
 

--- a/js/widgets/forms/select.custom.js
+++ b/js/widgets/forms/select.custom.js
@@ -357,7 +357,7 @@ define( [
 
 			_decideFormat: function() {
 				var self = this,
-					$window = $( window ),
+					$window = $.mobile.$window,
 					selfListParent = self.list.parent(),
 					menuHeight = selfListParent.outerHeight(),
 					menuWidth = selfListParent.outerWidth(),
@@ -548,7 +548,7 @@ define( [
 	};
 
 	// issue #3894 - core doesn't trigger events on disabled delegates
-	$( document ).bind( "selectmenubeforecreate", function( event ) {
+	$.mobile.$document.bind( "selectmenubeforecreate", function( event ) {
 		var selectmenuWidget = $( event.target ).data( "mobile-selectmenu" );
 
 		if ( !selectmenuWidget.options.nativeMenu &&

--- a/js/widgets/forms/select.js
+++ b/js/widgets/forms/select.js
@@ -287,7 +287,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, {
 $.widget( "mobile.selectmenu", $.mobile.selectmenu, $.mobile.behaviors.formReset );
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.selectmenu.prototype.enhanceWithin( e.target, true );
 });
 })( jQuery );

--- a/js/widgets/forms/slider.js
+++ b/js/widgets/forms/slider.js
@@ -480,7 +480,7 @@ $.widget( "mobile.slider", $.mobile.widget, {
 $.widget( "mobile.slider", $.mobile.slider, $.mobile.behaviors.formReset );
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.slider.prototype.enhanceWithin( e.target, true );
 });
 

--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -132,13 +132,13 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 
 			// binding to pagechange here ensures that for pages loaded via
 			// ajax the height is recalculated without user input
-			this._on( $( document ), { "pagechange": "_keyup" });
+			this._on( $.mobile.$document, { "pagechange": "_keyup" });
 
 			// Issue 509: the browser is not providing scrollHeight properly until the styles load
 			if ( $.trim( input.val() ) ) {
 				// bind to the window load to make sure the height is calculated based on BOTH
 				// the DOM and CSS
-				this._on( $( window ), {"load": "_keyup"});
+				this._on( $.mobile.$window, {"load": "_keyup"});
 			}
 		}
 		if ( input.attr( "disabled" ) ) {
@@ -178,7 +178,7 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 });
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.textinput.prototype.enhanceWithin( e.target, true );
 });
 

--- a/js/widgets/listview.autodividers.js
+++ b/js/widgets/listview.autodividers.js
@@ -21,7 +21,7 @@ $.mobile.listview.prototype.options.autodividersSelector = function( elt ) {
 	return text;
 };
 
-$( document ).delegate( "ul,ol", "listviewcreate", function() {
+$.mobile.$document.delegate( "ul,ol", "listviewcreate", function() {
 
 	var list = $( this ),
 			listview = list.data( "mobile-listview" );

--- a/js/widgets/listview.filter.js
+++ b/js/widgets/listview.filter.js
@@ -19,7 +19,7 @@ var defaultFilterCallback = function( text, searchValue, item ) {
 
 $.mobile.listview.prototype.options.filterCallback = defaultFilterCallback;
 
-$( document ).delegate( "ul, ol", "listviewcreate", function() {
+$.mobile.$document.delegate( "ul, ol", "listviewcreate", function() {
 
 	var list = $( this ),
 		listview = list.data( "mobile-listview" );

--- a/js/widgets/listview.js
+++ b/js/widgets/listview.js
@@ -383,7 +383,7 @@ $.widget( "mobile.listview", $.mobile.widget, {
 $.widget( "mobile.listview", $.mobile.listview, $.mobile.behaviors.addFirstLastClasses );
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.listview.prototype.enhanceWithin( e.target );
 });
 

--- a/js/widgets/loader.js
+++ b/js/widgets/loader.js
@@ -38,7 +38,7 @@ define( [ "jquery",	"../jquery.mobile.core", "../jquery.mobile.widget" ], functi
 	});
 
 	// TODO move loader class down into the widget settings
-	var loaderClass = "ui-loader", $html = $( "html" ), $window = $( window );
+	var loaderClass = "ui-loader", $html = $( "html" ), $window = $.mobile.$window;
 
 	$.widget( "mobile.loader", {
 		// NOTE if the global config settings are defined they will override these
@@ -170,8 +170,8 @@ define( [ "jquery",	"../jquery.mobile.core", "../jquery.mobile.widget" ], functi
 				this.element.removeClass( "ui-loader-fakefix" );
 			}
 
-			$( window ).unbind( "scroll", this.fakeFixLoader );
-			$( window ).unbind( "scroll", this.checkLoaderPosition );
+			$.mobile.$window.unbind( "scroll", this.fakeFixLoader );
+			$.mobile.$window.unbind( "scroll", this.checkLoaderPosition );
 		}
 	});
 

--- a/js/widgets/navbar.js
+++ b/js/widgets/navbar.js
@@ -52,7 +52,7 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 });
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.navbar.prototype.enhanceWithin( e.target );
 });
 

--- a/js/widgets/page.sections.js
+++ b/js/widgets/page.sections.js
@@ -18,7 +18,7 @@ $.mobile.page.prototype.options.contentTheme = null;
 //      which expects .ui-footer top be applied in its gigantic selector
 // TODO remove the buttonMarkup giant selector and move it to the various modules
 //      on which it depends
-$( document ).bind( "pagecreate", function( e ) {
+$.mobile.$document.bind( "pagecreate", function( e ) {
 	var $page = $( e.target ),
 		o = $page.data( "mobile-page" ).options,
 		pageRole = $page.jqmData( "role" ),

--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -40,7 +40,7 @@ define( [
 	}
 
 	function windowCoords() {
-		var $win = $( window );
+		var $win = $.mobile.$window;
 
 		return {
 			x: $win.scrollLeft(),
@@ -235,12 +235,12 @@ define( [
 
 			ui.screen.bind( "vclick", $.proxy( this, "_eatEventAndClose" ) );
 
-			this._on( $( window ), {
+			this._on( $.mobile.$window, {
 				orientationchange: $.proxy( this, "_handleWindowOrientationchange" ),
 				resize: $.proxy( this, "_handleWindowResize" ),
 				keyup: $.proxy( this, "_handleWindowKeyUp" )
 			});
-			this._on( $( document ), {
+			this._on( $.mobile.$document, {
 				focusin: $.proxy( this, "_handleDocumentFocusIn" )
 			});
 		},
@@ -416,7 +416,7 @@ define( [
 			// If the height of the menu is smaller than the height of the document
 			// align the bottom with the bottom of the document
 
-			// fix for $( document ).height() bug in core 1.7.2.
+			// fix for $.mobile.$document.height() bug in core 1.7.2.
 			var docEl = document.documentElement, docBody = document.body,
 				docHeight = Math.max( docEl.clientHeight, docBody.scrollHeight, docBody.offsetHeight, docEl.scrollHeight, docEl.offsetHeight );
 
@@ -757,7 +757,7 @@ define( [
 
 			// set the global popup mutex
 			$.mobile.popup.active = this;
-			this._scrollTop = $( window ).scrollTop();
+			this._scrollTop = $.mobile.$window.scrollTop();
 
 			// if history alteration is disabled close on navigate events
 			// and leave the url as is
@@ -825,7 +825,7 @@ define( [
 				return;
 			}
 
-			this._scrollTop = $( window ).scrollTop();
+			this._scrollTop = $.mobile.$window.scrollTop();
 
 			if( this.options.history && this.urlAltered ) {
 				$.mobile.back();
@@ -869,14 +869,14 @@ define( [
 	};
 
 	// TODO move inside _create
-	$( document ).bind( "pagebeforechange", function( e, data ) {
+	$.mobile.$document.bind( "pagebeforechange", function( e, data ) {
 		if ( data.options.role === "popup" ) {
 			$.mobile.popup.handleLink( data.options.link );
 			e.preventDefault();
 		}
 	});
 
-	$( document ).bind( "pagecreate create", function( e )  {
+	$.mobile.$document.bind( "pagecreate create", function( e )  {
 		$.mobile.popup.prototype.enhanceWithin( e.target, true );
 	});
 

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -27,7 +27,7 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$( document ).delegate( ":jqmData(role='table')", "tablecreate", function() {
+$.mobile.$document.delegate( ":jqmData(role='table')", "tablecreate", function() {
 
 	var $table = $( this ),
 		self = $table.data( "mobile-table" ),
@@ -94,7 +94,7 @@ $( document ).delegate( ":jqmData(role='table')", "tablecreate", function() {
 		});
 	};
 
-	$( window ).on( "throttledresize", self.refresh );
+	$.mobile.$window.on( "throttledresize", self.refresh );
 
 	self.refresh();
 

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -66,7 +66,7 @@ $.widget( "mobile.table", $.mobile.widget, {
 });
 
 //auto self-init widgets
-$( document ).bind( "pagecreate create", function( e ) {
+$.mobile.$document.bind( "pagecreate create", function( e ) {
 	$.mobile.table.prototype.enhanceWithin( e.target );
 });
 

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -19,7 +19,7 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$( document ).delegate( ":jqmData(role='table')", "tablecreate", function() {
+$.mobile.$document.delegate( ":jqmData(role='table')", "tablecreate", function() {
 
 	var $table = $( this ),
 		self = $table.data( "mobile-table" ),


### PR DESCRIPTION
This case is similar with #5402. My team is developing Tizen web UIFW using jQuery Mobile and got a few performance issues and this PR is the first case to improve performance. "$( document )" and "$( window )" functions are repeatly called 73 times on many *.js files and the size of $() function is not small too. So I thought that it would be better to cut down and fix the function call count in performance view.

To resolve the issue my team created two variables to store the return values of the functions and changed the function calls to the variables - $.mobile.$window and $.mobile.$document. Therefore the functions are just called 2 times. After my team tested it on PC and Mobile devices, we got a performance improvement.

To be used in the other funtions the variables are defined in jQuery.mobile on my code. If the variables should be moved to another function, please let me know it.
- Tests : The code has been tested on several jQM widgets using qunit.js.
- Modified code is followed the jQuery Core Style guide.
- Scope : Performance improvement.

It is a simple case and similar with #5402. But my team modified many files to cover the issue but the method is very simple. We just change the function calls to using the new variables. If there are any problems or mistakes on my PR, please let me know. Thanks in advance. Happy New Year~!! :)
