### PR TITLE
Slide panel refactor tests

### DIFF
--- a/css/structure/jquery.mobile.panel.css
+++ b/css/structure/jquery.mobile.panel.css
@@ -196,14 +196,6 @@
 	left: 0;
 }
 
-
-/* while open, page x overflow is disabled */
-.ui-page-active.ui-panel-page-block{
-	overflow-x:hidden;
-}
-
-
-
 /* wrap push on wide viewports once open */
 @media (min-width: 60em){
 	.ui-panel-content-wrap.ui-panel-content-wrap-open-complete.ui-panel-content-wrap-display-push,

--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -25,7 +25,8 @@ $.widget( "mobile.panel", $.mobile.widget, {
 			contentWrapOpenComplete: "ui-panel-content-wrap-open-complete",
 			pageBlock: "ui-panel-page-block",
 			pagePanel: "ui-page-panel",
-			pageChildAnimations: "ui-page-panel-animate"
+			pageChildAnimations: "ui-page-panel-animate",
+			cssTransform3d: "ui-panel-3dtransforms"
 		},
 		animate: true,
 		theme: null,
@@ -99,7 +100,7 @@ $.widget( "mobile.panel", $.mobile.widget, {
 		}
 
 		if( $.support.cssTransform3d ){
-			panelClasses += " ui-panel-3dtransforms";
+			panelClasses += " " + this.options.classes.cssTransform3d;
 		}
 		return panelClasses;
 	},

--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -202,7 +202,7 @@ $.widget( "mobile.panel", $.mobile.widget, {
 	_contentWrapOpenClasses: null,
 	_modalOpenClasses: null,
 
-	open: function( options ){
+	open: function( options, immediate ){
 		var self = this,
 			o = self.options,
 			complete = function(){
@@ -217,7 +217,7 @@ $.widget( "mobile.panel", $.mobile.widget, {
 
 		self._trigger( "beforeopen" );
 
-		if ( $.support.cssTransitions && o.animate ) {
+		if ( !immediate && $.support.cssTransitions && o.animate ) {
 			self.element.add( self._wrapper ).on( self._transitionEndEvents , complete );
 		} else{
 			setTimeout( complete , 0 );
@@ -251,9 +251,9 @@ $.widget( "mobile.panel", $.mobile.widget, {
 
 		self._trigger( "beforeclose" );
 
-		if ( $.support.cssTransform3d && o.animate ) {
-			self.element.add( self._wrapper ).on( self._transitionEndEvents , complete );
-		} else{
+		if ( !immediate && $.support.cssTransform3d && o.animate ) {
+			self.element.add( self._wrapper ).on( self._transitionEndEvents, complete );
+		} else {
 			setTimeout( complete , 0 );
 		}
 

--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -223,7 +223,7 @@ $.widget( "mobile.panel", $.mobile.widget, {
 		} else{
 			setTimeout( complete , 0 );
 		}
-		self._page.addClass( self.options.classes.pageBlock );
+		self._page.addClass( o.classes.pageBlock );
 		self.element.removeClass( o.classes.panelClosed );
 		self.element.addClass( o.classes.panelOpen );
 		self._contentWrapOpenClasses = self._getPosDisplayClasses( o.classes.contentWrap );
@@ -240,11 +240,11 @@ $.widget( "mobile.panel", $.mobile.widget, {
 		var o = this.options,
 			self = this,
 			complete = function(){
-				self.element.add( self._wrapper ).unbind( self._transitionEndEvents , complete );
+				self.element.add( self._wrapper ).unbind( self._transitionEndEvents, complete );
 				self.element.addClass( o.classes.panelClosed );
 				self._wrapper.removeClass( self._contentWrapOpenClasses );
 				self._wrapper.addClass( o.classes.contentWrapClosed );
-				self._page.removeClass( self.options.classes.pageBlock );
+				self._page.removeClass( o.classes.pageBlock );
 				self._fixPanel();
 				self._unbindFixListener();
 				self._trigger( "close" );

--- a/tests/unit/panel/index.html
+++ b/tests/unit/panel/index.html
@@ -39,126 +39,28 @@
 		<ol id="qunit-tests">
 		</ol>
 
-		<div id="qunit-fixture">
-
-			<!-- Basic Panel test -->
-			<div data-nstest-role="page">
-				<div data-nstest-role="panel" id="panel-test-1">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-1">Open Panel</a>
-				</div>
+		<div data-nstest-role="page">
+			<div data-nstest-role="panel" id="panel-test-stock">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-non-default-theme" data-nstest-theme="c">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-with-close">
+				<p>Contents of a panel.</p>
+				<a href="#demo-links" data-nstest-rel="close" data-nstest-role="button">Close panel</a>
 			</div>
 
-
-			<div data-nstest-role="page">
-				<div data-nstest-role="panel" id="panel-test-2" data-animate="false">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-2">Open Panel</a>
-				</div>
+			<div data-nstest-role="header">
+				<h1>Panel Test</h1>
 			</div>
-
-			<div data-nstest-role="page">
-				<div data-nstest-role="panel" id="panel-test-3" data-theme="c">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-3">Open Panel</a>
-				</div>
+			<div data-nstest-role="content">
+				<h1 id="demo-links">Panels</h1>
+				<a href="#panel-test-stock">Open Panel</a>
+				<a href="#panel-test-non-default-theme">Open Panel</a>
+				<a href="#panel-test-with-close">Open Panel</a>
 			</div>
-
-			<div data-nstest-role="page">
-				<div data-nstest-role="panel" id='panel-tes4' data-position="right">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-4">Open Panel</a>
-				</div>
-			</div>
-
-
-			<div data-nstest-role="page">
-				<div data-nstest-role="panel" id='panel-test-5' data-display="push">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-5">Open Panel</a>
-				</div>
-			</div>
-
-			<div data-nstest-role="page">
-				<div data-nstest-role="panel" id='panel-test-6' data-display="reveal">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-6">Open Panel</a>
-				</div>
-			</div>
-
-			<div data-nstest-role="page" >
-				<div data-nstest-role="panel" id='panel-test-7' data-display="push" data-position="right">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-7">Open Panel</a>
-				</div>
-			</div>
-
-			<div data-nstest-role="page" >
-				<div data-nstest-role="panel" id='panel-test-8' data-display="reveal" data-position="right">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-8">Open Panel</a>
-				</div>
-			</div>
-
-			<div data-nstest-role="page">
-				<div data-nstest-role="panel" id='panel-test-8' data-dismissible="false">
-					<p>Contents of a panel.</p>
-				</div>
-				<div data-nstest-role="header">
-					<h1>Panel Test</h1>
-				</div>
-				<div data-nstest-role="content">
-					<a href="#panel-test-9">Open Panel</a>
-				</div>
-			</div>
-
-
-
-
-
-
 		</div>
-
 
 	</body>
 </html>

--- a/tests/unit/panel/index.html
+++ b/tests/unit/panel/index.html
@@ -18,9 +18,7 @@
 		</script>
 		<script>
 			$.testHelper.asyncLoad([
-				[
-					"widgets/panel"
-				],
+				[ "widgets/panel" ],
 				[ "jquery.mobile.init" ],
 				[ "panel_core.js" ]
 			]);
@@ -40,7 +38,28 @@
 		</ol>
 
 		<div data-nstest-role="page">
-			<div data-nstest-role="panel" id="panel-test-stock">
+			<div data-nstest-role="panel" id="panel-test-create">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-events">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-open">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-close">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-toggle">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-wrapper">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-dismiss">
+				<p>Contents of a panel.</p>
+			</div>
+			<div data-nstest-role="panel" id="panel-test-destroy">
 				<p>Contents of a panel.</p>
 			</div>
 			<div data-nstest-role="panel" id="panel-test-non-default-theme" data-nstest-theme="c">
@@ -56,7 +75,14 @@
 			</div>
 			<div data-nstest-role="content">
 				<h1 id="demo-links">Panels</h1>
-				<a href="#panel-test-stock">Open Panel</a>
+				<a href="#panel-test-create">Open Panel</a>
+				<a href="#panel-test-events">Open Panel</a>
+				<a href="#panel-test-open">Open Panel</a>
+				<a href="#panel-test-close">Open Panel</a>
+				<a href="#panel-test-toggle">Open Panel</a>
+				<a href="#panel-test-wrapper">Open Panel</a>
+				<a href="#panel-test-dismiss">Open Panel</a>
+				<a href="#panel-test-destroy">Open Panel</a>
 				<a href="#panel-test-non-default-theme">Open Panel</a>
 				<a href="#panel-test-with-close">Open Panel</a>
 			</div>

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -3,33 +3,270 @@
  */
 
 (function($){
+	var defaults = $.mobile.panel.prototype.options,
+		classes = defaults.classes;
 
+	//QUnit.config.reorder = false;
 
-	$(document).on( "pageinit", function(){
+	function getPageFromPanel( $panel ) {
+		return $panel.closest( ":jqmData(role='page')" );
+	}
 
-		var panel1 = $( "#panel-test-1" ),
-			panel2 = $( "#panel-test-2" ),
-			panel3 = $( "#panel-test-3" ),
-			panel4 = $( "#panel-test-4" ),
-			panel5 = $( "#panel-test-5" ),
-			panel6 = $( "#panel-test-6" ),
-			panel7 = $( "#panel-test-7" ),
-			panel8 = $( "#panel-test-8" ),
-			panel9 = $( "#panel-test-9" ),
-			defaults = $.mobile.panel.prototype.options;
+	function getModalFromPanel( $panel ) {
+		var $page = getPageFromPanel( $panel );
 
-		/* test class additions */
-		test( "classes are added as expected on create", function(){
+		return $page.find( "." + defaults.classes.modal ).filter(function() {
+			return $( this ).data( "panelid" ) === $panel.attr( "id" );
+		});
+	}
 
-			ok( panel1.is( ".ui-panel" ), "default class is present" );
-			equal( panel1.is( ".ui-panel-animate" ), $.support.cssTransform3d, "animate class is present by default when supported" );
-			ok( panel1.is( ".ui-panel-display-" + defaults.display ), "display class is added per the default" );
-			ok( panel1.is( ".ui-panel-position-" + defaults.position ), "position class is added per the default" );
+	function getWrapperFromPage( $page ) {
+		return $page.find( "." + defaults.classes.contentWrap );
+	}
+
+	$(document).on( "pageinit", function() {
+
+		module( "stock panel");
+
+		test( "expected classes on create", function() {
+
+			var $panel = $( "#panel-test-stock" ),
+				$page = getPageFromPanel( $panel );
+
+			ok( $panel.hasClass( defaults.classes.panel ), "default class is present" );
+			ok( $panel.hasClass( "ui-panel-display-" + defaults.display ), "display class is added per the default" );
+			ok( $panel.hasClass( "ui-panel-position-" + defaults.position ), "position class is added per the default" );
+
+			equal( $panel.hasClass( "ui-panel-animate" ), $.support.cssTransform3d, "animate class is present by default when supported" );
+			equal( $page.hasClass( defaults.classes.pageChildAnimations ), $.support.cssTransform3d, "animation wrapper class added to page" );
+			ok( $panel.hasClass( defaults.classes.panelClosed ), "panel is closed by default" );
+			equal( $panel.hasClass( defaults.classes.cssTransform3d ), $.support.cssTransform3d, "transforms class added to page" );
+		});
+
+		asyncTest( "expected open, close events", function() {
+
+			expect( 4 );
+
+			var $panel = $( "#panel-test-stock" );
+
+			$panel.one( "panelbeforeopen panelopen panelbeforeclose panelclose", function( event ) {
+				ok( true, event.type + " event." );
+			}).one( "panelopen", function() {
+				$panel.panel( "close" );
+			}).one( "panelclose", function() {
+				start();
+			});
+
+			$panel.panel( "open" );
 
 		});
 
+		asyncTest( "classes modified by open", function() {
+			expect( 13 );
+
+			var $panel = $( "#panel-test-stock" ),
+				$page = getPageFromPanel( $panel ),
+				$wrapper = getWrapperFromPage( $page ),
+				$modal = getModalFromPanel( $panel ),
+				$openButton = $page.find( "a[href='\\#panel-test-stock']" );
+
+			$panel.one( "panelopen", function( event ) {
+				ok( !$openButton.hasClass( $.mobile.activeBtnClass ), "button doesn't have active class" );
+
+				ok( $page.hasClass( defaults.classes.pageBlock ), "page block class added to page" );
+				ok( !$panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
+				ok( $panel.hasClass( defaults.classes.panelOpen ), "open class added" );
+
+				ok( !$wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper not closed class" );
+				ok( $wrapper.hasClass( defaults.classes.contentWrapOpen ), "wrapper open class" );
+
+				var prefix = defaults.classes.contentWrap;
+				ok( $wrapper.hasClass( prefix + "-position-left" ), "wrapper position class" );
+				ok( $wrapper.hasClass( prefix + "-display-overlay" ), "wrapper display type class" );
+
+				ok( $modal.hasClass( defaults.classes.modalOpen ), "modal open class" );
+				prefix = defaults.classes.modal;
+				ok( $modal.hasClass( prefix + "-position-left" ), "modal position class" );
+				ok( $modal.hasClass( prefix + "-display-overlay" ), "modal display type class" );
+
+				// complete
+				ok( $panel.hasClass( defaults.classes.openComplete ), "open complete class" );
+				ok( $wrapper.hasClass( defaults.classes.contentWrapOpenComplete ), "wrapper open complete class" );
+
+				// TODO test positioning when panel height > screen height
+				// TODO test rebind resize after complete
+
+				$panel.panel( "close" );
+			}).one( "panelclose", function() {
+				start();
+			});
+
+			$panel.panel( "open" );
+
+		});
+
+		asyncTest( "classes modified by close", function() {
+			expect( 12 );
+
+			var $panel = $( "#panel-test-stock" ),
+				$page = getPageFromPanel( $panel ),
+				$wrapper = getWrapperFromPage( $page ),
+				$modal = getModalFromPanel( $panel ),
+				$openButton = $page.find( "a[href='\\#panel-test-stock']" );
+
+			$panel.one( "panelopen", function( event ) {
+				$panel.panel( "close" );
+			}).one( "panelclose", function( event ) {
+				ok( !$openButton.hasClass( $.mobile.activeBtnClass ), "button doesn't have active class" );
+				ok( !$panel.hasClass( defaults.classes.panelOpen ), "panel not open class" );
+
+				ok( !$modal.hasClass( defaults.classes.modalOpen ), "modal without open class" );
+				var prefix = defaults.classes.modal;
+				ok( !$modal.hasClass( prefix + "-position-left" ), "modal without position class" );
+				ok( !$modal.hasClass( prefix + "-display-overlay" ), "modal without display type class" );
+
+				ok( !$wrapper.hasClass( defaults.classes.contentWrapOpen ), "wrapper open class" );
+				ok( !$wrapper.hasClass( defaults.classes.contentWrapOpenComplete ), "wrapper open complete class" );
+
+				// complete
+				ok( $panel.hasClass( defaults.classes.panelClosed ), "panel closed class" );
+
+				prefix = defaults.classes.contentWrap;
+				ok( !$wrapper.hasClass( prefix + "-position-left" ), "wrapper position class" );
+				ok( !$wrapper.hasClass( prefix + "-display-overlay" ), "wrapper display type class" );
+
+				ok( $wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper closed class" );
+				ok( !$page.hasClass( defaults.classes.pageBlock ), "page block class not added to page" );
+
+				// TODO test positioning when panel height > screen height
+				// TODO test rebind resize after complete
+
+				start();
+			});
+
+			$panel.panel( "open" );
+
+		});
+
+		asyncTest( "toggle", function() {
+			expect( 2 );
+
+			var $panel = $( "#panel-test-stock" ),
+				$page = getPageFromPanel( $panel );
+
+			$panel.one( "panelopen", function( event ) {
+				ok( true, "toggle open" );
+				$panel.panel( "close" );
+			}).one( "panelclose", function( event ) {
+				ok( true, "toggle closed" );
+				start();
+			});
+
+			$panel.panel( "toggle" );
+
+		});
+
+		test( "wrapper exists after create", function() {
+
+			var $page = getPageFromPanel( $( "#panel-test-stock" ) ),
+				$wrapper = getWrapperFromPage( $page );
+
+			ok( $wrapper.length, "wrapper exists" );
+			ok( $wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper has closed class" );
+
+		});
+
+		// TODO _bindPageEvents
+
+		test( "dismissable", function() {
+
+			var $panel = $( "#panel-test-stock" );
+
+			equal( getModalFromPanel( $panel ).length, 1, "modal added to page" );
+		});
+
+		asyncTest( "click on dismissable modal closes panel", function() {
+
+			expect( 1 );
+
+			var $panel = $( "#panel-test-stock" ),
+				$modal = getModalFromPanel( $panel );
+
+			$panel.one( "panelopen", function() {
+
+				$modal.trigger( "mousedown" );
+
+			}).one( "panelclose", function() {
+
+				ok( true, "modal is closed" );
+				start();
+
+			});
+
+			$panel.panel( "open" );
+
+		});
+
+		test( "destroy method", function() {
+
+			var $panel = $( "#panel-test-stock" ),
+				$page = getPageFromPanel( $panel ),
+				$wrapper = getWrapperFromPage( $page );
+
+			$panel.panel( "destroy" );
+			// test page without sibling panels
+
+			ok( !$wrapper.hasClass( defaults.classes.contentWrapOpen ) );
+			ok( !$wrapper.hasClass( defaults.classes.contentWrapOpenComplete ) );
+
+			ok( !$panel.hasClass( defaults.classes.panel ) );
+			ok( !$wrapper.hasClass( "ui-panel-position-left" ) );
+			ok( !$wrapper.hasClass( "ui-panel-display-overlay" ) );
+			ok( !$panel.hasClass( defaults.classes.panelOpen ) );
+			ok( !$panel.hasClass( defaults.classes.panelClosed ) );
+			ok( !$panel.hasClass( "ui-body-c" ) );
+			ok( !$panel.hasClass( defaults.classes.cssTransform3d ) );
+			ok( getModalFromPanel( $panel ).length === 0, "modal was removed" );
+
+			ok( !$panel.hasClass( [ classes.openComplete, classes.panelUnfixed, classes.panelClosed, classes.panelOpen ].join( " " ) ) );
+			ok( !$page.hasClass( classes.pageBlock ) );
+
+			$panel.panel();
+		});
+
+		module( "panel with non-default theme" );
+
+		test( "expected classes on create", function() {
+
+			var $panel = $( "#panel-test-non-default-theme" );
+			ok( $panel.hasClass( "ui-body-" + $panel.jqmData('theme') ), "theme class was added" );
+
+		});
+
+		module( "panel with close button" );
+
+		asyncTest( "panel opens, close button hides panel", function() {
+			expect( 2 );
+
+			var $panel = $( "#panel-test-with-close" ),
+				$page = getPageFromPanel( $panel ),
+				$closeButton = $panel.find( ":jqmData(rel='close')" );
+
+			$panel.one( "panelopen", function() {
+
+				ok( !$panel.hasClass( defaults.classes.panelClosed ), "wrapper opens" );
+				$closeButton.trigger( "click" );
+
+			}).one( "panelclose", function() {
+
+				ok( $panel.hasClass( defaults.classes.panelClosed ), "wrapper has closed class" );
+				start();
+			});
+
+			$panel.panel( "open" );
+		});
+
 	});
-	
 
 
 }( jQuery ));

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -6,8 +6,6 @@
 	var defaults = $.mobile.panel.prototype.options,
 		classes = defaults.classes;
 
-	//QUnit.config.reorder = false;
-
 	function getPageFromPanel( $panel ) {
 		return $panel.closest( ":jqmData(role='page')" );
 	}

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -2,8 +2,6 @@
  * mobile panel unit tests
  */
 
-// stop qunit from running the tests until everything is in the page
-QUnit.config.autostart = false;
 
 (function( $ ){
 
@@ -26,15 +24,11 @@ QUnit.config.autostart = false;
 		return $page.find( "." + defaults.classes.contentWrap );
 	}
 
-	$( document ).on( "pageinit", function(){
-		QUnit.start();
-	});
-
-	module( "stock panel");
+	module( "stock panel" );
 
 	test( "expected classes on create", function() {
 
-		var $panel = $( "#panel-test-stock" ),
+		var $panel = $( "#panel-test-create" ),
 			$page = getPageFromPanel( $panel );
 
 		ok( $panel.hasClass( defaults.classes.panel ), "default class is present" );
@@ -51,7 +45,7 @@ QUnit.config.autostart = false;
 
 		expect( 4 );
 
-		var $panel = $( "#panel-test-stock" );
+		var $panel = $( "#panel-test-events" );
 
 		$panel.one( "panelbeforeopen panelopen panelbeforeclose panelclose", function( event ) {
 			ok( true, event.type + " event." );
@@ -66,13 +60,13 @@ QUnit.config.autostart = false;
 	});
 
 	asyncTest( "classes modified by open", function() {
-		expect( 13 );
+		expect( 14 );
 
-		var $panel = $( "#panel-test-stock" ),
+		var $panel = $( "#panel-test-open" ),
 			$page = getPageFromPanel( $panel ),
 			$wrapper = getWrapperFromPage( $page ),
 			$modal = getModalFromPanel( $panel ),
-			$openButton = $page.find( "a[href='\\#panel-test-stock']" );
+			$openButton = $page.find( "a[href='\\#panel-test-open']" );
 
 		$panel.one( "panelopen", function( event ) {
 			ok( !$openButton.hasClass( $.mobile.activeBtnClass ), "button doesn't have active class" );
@@ -81,7 +75,9 @@ QUnit.config.autostart = false;
 			ok( !$panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
 			ok( $panel.hasClass( defaults.classes.panelOpen ), "open class added" );
 
+			equal( $wrapper.length, 1, "wrapper exists." );
 			ok( !$wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper not closed class" );
+
 			ok( $wrapper.hasClass( defaults.classes.contentWrapOpen ), "wrapper open class" );
 
 			var prefix = defaults.classes.contentWrap;
@@ -112,11 +108,11 @@ QUnit.config.autostart = false;
 	asyncTest( "classes modified by close", function() {
 		expect( 12 );
 
-		var $panel = $( "#panel-test-stock" ),
+		var $panel = $( "#panel-test-close" ),
 			$page = getPageFromPanel( $panel ),
 			$wrapper = getWrapperFromPage( $page ),
 			$modal = getModalFromPanel( $panel ),
-			$openButton = $page.find( "a[href='\\#panel-test-stock']" );
+			$openButton = $page.find( "a[href='\\#panel-test-close']" );
 
 		$panel.one( "panelopen", function( event ) {
 			$panel.panel( "close" );
@@ -155,7 +151,7 @@ QUnit.config.autostart = false;
 	asyncTest( "toggle", function() {
 		expect( 2 );
 
-		var $panel = $( "#panel-test-stock" ),
+		var $panel = $( "#panel-test-toggle" ),
 			$page = getPageFromPanel( $panel );
 
 		$panel.one( "panelopen", function( event ) {
@@ -172,7 +168,7 @@ QUnit.config.autostart = false;
 
 	test( "wrapper exists after create", function() {
 
-		var $page = getPageFromPanel( $( "#panel-test-stock" ) ),
+		var $page = getPageFromPanel( $( "#panel-test-wrapper" ) ),
 			$wrapper = getWrapperFromPage( $page );
 
 		ok( $wrapper.length, "wrapper exists" );
@@ -182,38 +178,9 @@ QUnit.config.autostart = false;
 
 	// TODO _bindPageEvents
 
-	test( "dismissable", function() {
-
-		var $panel = $( "#panel-test-stock" );
-
-		equal( getModalFromPanel( $panel ).length, 1, "modal added to page" );
-	});
-
-	asyncTest( "click on dismissable modal closes panel", function() {
-
-		expect( 1 );
-
-		var $panel = $( "#panel-test-stock" ),
-			$modal = getModalFromPanel( $panel );
-
-		$panel.one( "panelopen", function() {
-
-			$modal.trigger( "mousedown" );
-
-		}).one( "panelclose", function() {
-
-			ok( true, "modal is closed" );
-			start();
-
-		});
-
-		$panel.panel( "open" );
-
-	});
-
 	test( "destroy method", function() {
 
-		var $panel = $( "#panel-test-stock" ),
+		var $panel = $( "#panel-test-destroy" ),
 			$page = getPageFromPanel( $panel ),
 			$wrapper = getWrapperFromPage( $page );
 
@@ -236,6 +203,35 @@ QUnit.config.autostart = false;
 		ok( !$page.hasClass( classes.pageBlock ) );
 
 		$panel.panel();
+	});
+
+	module( "dismissable panel" );
+
+	test( "dismissable", function() {
+		var $panel = $( "#panel-test-dismiss" );
+		equal( getModalFromPanel( $panel ).length, 1, "modal added to page" );
+	});
+
+	asyncTest( "click on dismissable modal closes panel", function() {
+
+		expect( 1 );
+
+		var $panel = $( "#panel-test-dismiss" ),
+			$modal = getModalFromPanel( $panel );
+
+		$panel.one( "panelopen", function() {
+
+			$modal.trigger( "mousedown" );
+
+		}).one( "panelclose", function() {
+
+			ok( true, "modal is closed" );
+			start();
+
+		});
+
+		$panel.panel( "open" );
+
 	});
 
 	module( "panel with non-default theme" );

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -2,7 +2,11 @@
  * mobile panel unit tests
  */
 
-(function($){
+// stop qunit from running the tests until everything is in the page
+QUnit.config.autostart = false;
+
+(function( $ ){
+
 	var defaults = $.mobile.panel.prototype.options,
 		classes = defaults.classes;
 
@@ -22,249 +26,248 @@
 		return $page.find( "." + defaults.classes.contentWrap );
 	}
 
-	$(document).on( "pageinit", function() {
+	$( document ).on( "pageinit", function(){
+		QUnit.start();
+	});
 
-		module( "stock panel");
+	module( "stock panel");
 
-		test( "expected classes on create", function() {
+	test( "expected classes on create", function() {
 
-			var $panel = $( "#panel-test-stock" ),
-				$page = getPageFromPanel( $panel );
+		var $panel = $( "#panel-test-stock" ),
+			$page = getPageFromPanel( $panel );
 
-			ok( $panel.hasClass( defaults.classes.panel ), "default class is present" );
-			ok( $panel.hasClass( "ui-panel-display-" + defaults.display ), "display class is added per the default" );
-			ok( $panel.hasClass( "ui-panel-position-" + defaults.position ), "position class is added per the default" );
+		ok( $panel.hasClass( defaults.classes.panel ), "default class is present" );
+		ok( $panel.hasClass( "ui-panel-display-" + defaults.display ), "display class is added per the default" );
+		ok( $panel.hasClass( "ui-panel-position-" + defaults.position ), "position class is added per the default" );
 
-			equal( $panel.hasClass( "ui-panel-animate" ), $.support.cssTransform3d, "animate class is present by default when supported" );
-			equal( $page.hasClass( defaults.classes.pageChildAnimations ), $.support.cssTransform3d, "animation wrapper class added to page" );
-			ok( $panel.hasClass( defaults.classes.panelClosed ), "panel is closed by default" );
-			equal( $panel.hasClass( defaults.classes.cssTransform3d ), $.support.cssTransform3d, "transforms class added to page" );
+		equal( $panel.hasClass( "ui-panel-animate" ), $.support.cssTransform3d, "animate class is present by default when supported" );
+		equal( $page.hasClass( defaults.classes.pageChildAnimations ), $.support.cssTransform3d, "animation wrapper class added to page" );
+		ok( $panel.hasClass( defaults.classes.panelClosed ), "panel is closed by default" );
+		equal( $panel.hasClass( defaults.classes.cssTransform3d ), $.support.cssTransform3d, "transforms class added to page" );
+	});
+
+	asyncTest( "expected open, close events", function() {
+
+		expect( 4 );
+
+		var $panel = $( "#panel-test-stock" );
+
+		$panel.one( "panelbeforeopen panelopen panelbeforeclose panelclose", function( event ) {
+			ok( true, event.type + " event." );
+		}).one( "panelopen", function() {
+			$panel.panel( "close" );
+		}).one( "panelclose", function() {
+			start();
 		});
 
-		asyncTest( "expected open, close events", function() {
-
-			expect( 4 );
-
-			var $panel = $( "#panel-test-stock" );
-
-			$panel.one( "panelbeforeopen panelopen panelbeforeclose panelclose", function( event ) {
-				ok( true, event.type + " event." );
-			}).one( "panelopen", function() {
-				$panel.panel( "close" );
-			}).one( "panelclose", function() {
-				start();
-			});
-
-			$panel.panel( "open" );
-
-		});
-
-		asyncTest( "classes modified by open", function() {
-			expect( 13 );
-
-			var $panel = $( "#panel-test-stock" ),
-				$page = getPageFromPanel( $panel ),
-				$wrapper = getWrapperFromPage( $page ),
-				$modal = getModalFromPanel( $panel ),
-				$openButton = $page.find( "a[href='\\#panel-test-stock']" );
-
-			$panel.one( "panelopen", function( event ) {
-				ok( !$openButton.hasClass( $.mobile.activeBtnClass ), "button doesn't have active class" );
-
-				ok( $page.hasClass( defaults.classes.pageBlock ), "page block class added to page" );
-				ok( !$panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
-				ok( $panel.hasClass( defaults.classes.panelOpen ), "open class added" );
-
-				ok( !$wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper not closed class" );
-				ok( $wrapper.hasClass( defaults.classes.contentWrapOpen ), "wrapper open class" );
-
-				var prefix = defaults.classes.contentWrap;
-				ok( $wrapper.hasClass( prefix + "-position-left" ), "wrapper position class" );
-				ok( $wrapper.hasClass( prefix + "-display-overlay" ), "wrapper display type class" );
-
-				ok( $modal.hasClass( defaults.classes.modalOpen ), "modal open class" );
-				prefix = defaults.classes.modal;
-				ok( $modal.hasClass( prefix + "-position-left" ), "modal position class" );
-				ok( $modal.hasClass( prefix + "-display-overlay" ), "modal display type class" );
-
-				// complete
-				ok( $panel.hasClass( defaults.classes.openComplete ), "open complete class" );
-				ok( $wrapper.hasClass( defaults.classes.contentWrapOpenComplete ), "wrapper open complete class" );
-
-				// TODO test positioning when panel height > screen height
-				// TODO test rebind resize after complete
-
-				$panel.panel( "close" );
-			}).one( "panelclose", function() {
-				start();
-			});
-
-			$panel.panel( "open" );
-
-		});
-
-		asyncTest( "classes modified by close", function() {
-			expect( 12 );
-
-			var $panel = $( "#panel-test-stock" ),
-				$page = getPageFromPanel( $panel ),
-				$wrapper = getWrapperFromPage( $page ),
-				$modal = getModalFromPanel( $panel ),
-				$openButton = $page.find( "a[href='\\#panel-test-stock']" );
-
-			$panel.one( "panelopen", function( event ) {
-				$panel.panel( "close" );
-			}).one( "panelclose", function( event ) {
-				ok( !$openButton.hasClass( $.mobile.activeBtnClass ), "button doesn't have active class" );
-				ok( !$panel.hasClass( defaults.classes.panelOpen ), "panel not open class" );
-
-				ok( !$modal.hasClass( defaults.classes.modalOpen ), "modal without open class" );
-				var prefix = defaults.classes.modal;
-				ok( !$modal.hasClass( prefix + "-position-left" ), "modal without position class" );
-				ok( !$modal.hasClass( prefix + "-display-overlay" ), "modal without display type class" );
-
-				ok( !$wrapper.hasClass( defaults.classes.contentWrapOpen ), "wrapper open class" );
-				ok( !$wrapper.hasClass( defaults.classes.contentWrapOpenComplete ), "wrapper open complete class" );
-
-				// complete
-				ok( $panel.hasClass( defaults.classes.panelClosed ), "panel closed class" );
-
-				prefix = defaults.classes.contentWrap;
-				ok( !$wrapper.hasClass( prefix + "-position-left" ), "wrapper position class" );
-				ok( !$wrapper.hasClass( prefix + "-display-overlay" ), "wrapper display type class" );
-
-				ok( $wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper closed class" );
-				ok( !$page.hasClass( defaults.classes.pageBlock ), "page block class not added to page" );
-
-				// TODO test positioning when panel height > screen height
-				// TODO test rebind resize after complete
-
-				start();
-			});
-
-			$panel.panel( "open" );
-
-		});
-
-		asyncTest( "toggle", function() {
-			expect( 2 );
-
-			var $panel = $( "#panel-test-stock" ),
-				$page = getPageFromPanel( $panel );
-
-			$panel.one( "panelopen", function( event ) {
-				ok( true, "toggle open" );
-				$panel.panel( "close" );
-			}).one( "panelclose", function( event ) {
-				ok( true, "toggle closed" );
-				start();
-			});
-
-			$panel.panel( "toggle" );
-
-		});
-
-		test( "wrapper exists after create", function() {
-
-			var $page = getPageFromPanel( $( "#panel-test-stock" ) ),
-				$wrapper = getWrapperFromPage( $page );
-
-			ok( $wrapper.length, "wrapper exists" );
-			ok( $wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper has closed class" );
-
-		});
-
-		// TODO _bindPageEvents
-
-		test( "dismissable", function() {
-
-			var $panel = $( "#panel-test-stock" );
-
-			equal( getModalFromPanel( $panel ).length, 1, "modal added to page" );
-		});
-
-		asyncTest( "click on dismissable modal closes panel", function() {
-
-			expect( 1 );
-
-			var $panel = $( "#panel-test-stock" ),
-				$modal = getModalFromPanel( $panel );
-
-			$panel.one( "panelopen", function() {
-
-				$modal.trigger( "mousedown" );
-
-			}).one( "panelclose", function() {
-
-				ok( true, "modal is closed" );
-				start();
-
-			});
-
-			$panel.panel( "open" );
-
-		});
-
-		test( "destroy method", function() {
-
-			var $panel = $( "#panel-test-stock" ),
-				$page = getPageFromPanel( $panel ),
-				$wrapper = getWrapperFromPage( $page );
-
-			$panel.panel( "destroy" );
-			// test page without sibling panels
-
-			ok( !$wrapper.hasClass( defaults.classes.contentWrapOpen ) );
-			ok( !$wrapper.hasClass( defaults.classes.contentWrapOpenComplete ) );
-
-			ok( !$panel.hasClass( defaults.classes.panel ) );
-			ok( !$wrapper.hasClass( "ui-panel-position-left" ) );
-			ok( !$wrapper.hasClass( "ui-panel-display-overlay" ) );
-			ok( !$panel.hasClass( defaults.classes.panelOpen ) );
-			ok( !$panel.hasClass( defaults.classes.panelClosed ) );
-			ok( !$panel.hasClass( "ui-body-c" ) );
-			ok( !$panel.hasClass( defaults.classes.cssTransform3d ) );
-			ok( getModalFromPanel( $panel ).length === 0, "modal was removed" );
-
-			ok( !$panel.hasClass( [ classes.openComplete, classes.panelUnfixed, classes.panelClosed, classes.panelOpen ].join( " " ) ) );
-			ok( !$page.hasClass( classes.pageBlock ) );
-
-			$panel.panel();
-		});
-
-		module( "panel with non-default theme" );
-
-		test( "expected classes on create", function() {
-
-			var $panel = $( "#panel-test-non-default-theme" );
-			ok( $panel.hasClass( "ui-body-" + $panel.jqmData('theme') ), "theme class was added" );
-
-		});
-
-		module( "panel with close button" );
-
-		asyncTest( "panel opens, close button hides panel", function() {
-			expect( 2 );
-
-			var $panel = $( "#panel-test-with-close" ),
-				$page = getPageFromPanel( $panel ),
-				$closeButton = $panel.find( ":jqmData(rel='close')" );
-
-			$panel.one( "panelopen", function() {
-
-				ok( !$panel.hasClass( defaults.classes.panelClosed ), "wrapper opens" );
-				$closeButton.trigger( "click" );
-
-			}).one( "panelclose", function() {
-
-				ok( $panel.hasClass( defaults.classes.panelClosed ), "wrapper has closed class" );
-				start();
-			});
-
-			$panel.panel( "open" );
-		});
+		$panel.panel( "open" );
 
 	});
 
+	asyncTest( "classes modified by open", function() {
+		expect( 13 );
+
+		var $panel = $( "#panel-test-stock" ),
+			$page = getPageFromPanel( $panel ),
+			$wrapper = getWrapperFromPage( $page ),
+			$modal = getModalFromPanel( $panel ),
+			$openButton = $page.find( "a[href='\\#panel-test-stock']" );
+
+		$panel.one( "panelopen", function( event ) {
+			ok( !$openButton.hasClass( $.mobile.activeBtnClass ), "button doesn't have active class" );
+
+			ok( $page.hasClass( defaults.classes.pageBlock ), "page block class added to page" );
+			ok( !$panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
+			ok( $panel.hasClass( defaults.classes.panelOpen ), "open class added" );
+
+			ok( !$wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper not closed class" );
+			ok( $wrapper.hasClass( defaults.classes.contentWrapOpen ), "wrapper open class" );
+
+			var prefix = defaults.classes.contentWrap;
+			ok( $wrapper.hasClass( prefix + "-position-left" ), "wrapper position class" );
+			ok( $wrapper.hasClass( prefix + "-display-overlay" ), "wrapper display type class" );
+
+			ok( $modal.hasClass( defaults.classes.modalOpen ), "modal open class" );
+			prefix = defaults.classes.modal;
+			ok( $modal.hasClass( prefix + "-position-left" ), "modal position class" );
+			ok( $modal.hasClass( prefix + "-display-overlay" ), "modal display type class" );
+
+			// complete
+			ok( $panel.hasClass( defaults.classes.openComplete ), "open complete class" );
+			ok( $wrapper.hasClass( defaults.classes.contentWrapOpenComplete ), "wrapper open complete class" );
+
+			// TODO test positioning when panel height > screen height
+			// TODO test rebind resize after complete
+
+			$panel.panel( "close" );
+		}).one( "panelclose", function() {
+			start();
+		});
+
+		$panel.panel( "open" );
+
+	});
+
+	asyncTest( "classes modified by close", function() {
+		expect( 12 );
+
+		var $panel = $( "#panel-test-stock" ),
+			$page = getPageFromPanel( $panel ),
+			$wrapper = getWrapperFromPage( $page ),
+			$modal = getModalFromPanel( $panel ),
+			$openButton = $page.find( "a[href='\\#panel-test-stock']" );
+
+		$panel.one( "panelopen", function( event ) {
+			$panel.panel( "close" );
+		}).one( "panelclose", function( event ) {
+			ok( !$openButton.hasClass( $.mobile.activeBtnClass ), "button doesn't have active class" );
+			ok( !$panel.hasClass( defaults.classes.panelOpen ), "panel not open class" );
+
+			ok( !$modal.hasClass( defaults.classes.modalOpen ), "modal without open class" );
+			var prefix = defaults.classes.modal;
+			ok( !$modal.hasClass( prefix + "-position-left" ), "modal without position class" );
+			ok( !$modal.hasClass( prefix + "-display-overlay" ), "modal without display type class" );
+
+			ok( !$wrapper.hasClass( defaults.classes.contentWrapOpen ), "wrapper open class" );
+			ok( !$wrapper.hasClass( defaults.classes.contentWrapOpenComplete ), "wrapper open complete class" );
+
+			// complete
+			ok( $panel.hasClass( defaults.classes.panelClosed ), "panel closed class" );
+
+			prefix = defaults.classes.contentWrap;
+			ok( !$wrapper.hasClass( prefix + "-position-left" ), "wrapper position class" );
+			ok( !$wrapper.hasClass( prefix + "-display-overlay" ), "wrapper display type class" );
+
+			ok( $wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper closed class" );
+			ok( !$page.hasClass( defaults.classes.pageBlock ), "page block class not added to page" );
+
+			// TODO test positioning when panel height > screen height
+			// TODO test rebind resize after complete
+
+			start();
+		});
+
+		$panel.panel( "open" );
+
+	});
+
+	asyncTest( "toggle", function() {
+		expect( 2 );
+
+		var $panel = $( "#panel-test-stock" ),
+			$page = getPageFromPanel( $panel );
+
+		$panel.one( "panelopen", function( event ) {
+			ok( true, "toggle open" );
+			$panel.panel( "close" );
+		}).one( "panelclose", function( event ) {
+			ok( true, "toggle closed" );
+			start();
+		});
+
+		$panel.panel( "toggle" );
+
+	});
+
+	test( "wrapper exists after create", function() {
+
+		var $page = getPageFromPanel( $( "#panel-test-stock" ) ),
+			$wrapper = getWrapperFromPage( $page );
+
+		ok( $wrapper.length, "wrapper exists" );
+		ok( $wrapper.hasClass( defaults.classes.contentWrapClosed ), "wrapper has closed class" );
+
+	});
+
+	// TODO _bindPageEvents
+
+	test( "dismissable", function() {
+
+		var $panel = $( "#panel-test-stock" );
+
+		equal( getModalFromPanel( $panel ).length, 1, "modal added to page" );
+	});
+
+	asyncTest( "click on dismissable modal closes panel", function() {
+
+		expect( 1 );
+
+		var $panel = $( "#panel-test-stock" ),
+			$modal = getModalFromPanel( $panel );
+
+		$panel.one( "panelopen", function() {
+
+			$modal.trigger( "mousedown" );
+
+		}).one( "panelclose", function() {
+
+			ok( true, "modal is closed" );
+			start();
+
+		});
+
+		$panel.panel( "open" );
+
+	});
+
+	test( "destroy method", function() {
+
+		var $panel = $( "#panel-test-stock" ),
+			$page = getPageFromPanel( $panel ),
+			$wrapper = getWrapperFromPage( $page );
+
+		$panel.panel( "destroy" );
+		// test page without sibling panels
+
+		ok( !$wrapper.hasClass( defaults.classes.contentWrapOpen ) );
+		ok( !$wrapper.hasClass( defaults.classes.contentWrapOpenComplete ) );
+
+		ok( !$panel.hasClass( defaults.classes.panel ) );
+		ok( !$wrapper.hasClass( "ui-panel-position-left" ) );
+		ok( !$wrapper.hasClass( "ui-panel-display-overlay" ) );
+		ok( !$panel.hasClass( defaults.classes.panelOpen ) );
+		ok( !$panel.hasClass( defaults.classes.panelClosed ) );
+		ok( !$panel.hasClass( "ui-body-c" ) );
+		ok( !$panel.hasClass( defaults.classes.cssTransform3d ) );
+		ok( getModalFromPanel( $panel ).length === 0, "modal was removed" );
+
+		ok( !$panel.hasClass( [ classes.openComplete, classes.panelUnfixed, classes.panelClosed, classes.panelOpen ].join( " " ) ) );
+		ok( !$page.hasClass( classes.pageBlock ) );
+
+		$panel.panel();
+	});
+
+	module( "panel with non-default theme" );
+
+	test( "expected classes on create", function() {
+
+		var $panel = $( "#panel-test-non-default-theme" );
+		ok( $panel.hasClass( "ui-body-" + $panel.jqmData('theme') ), "theme class was added" );
+
+	});
+
+	module( "panel with close button" );
+
+	asyncTest( "panel opens, close button hides panel", function() {
+		expect( 2 );
+
+		var $panel = $( "#panel-test-with-close" ),
+			$page = getPageFromPanel( $panel ),
+			$closeButton = $panel.find( ":jqmData(rel='close')" );
+
+		$panel.one( "panelopen", function() {
+
+			ok( !$panel.hasClass( defaults.classes.panelClosed ), "wrapper opens" );
+			$closeButton.trigger( "click" );
+
+		}).one( "panelclose", function() {
+
+			ok( $panel.hasClass( defaults.classes.panelClosed ), "wrapper has closed class" );
+			start();
+		});
+
+		$panel.panel( "open" );
+	});
 
 }( jQuery ));


### PR DESCRIPTION
- Q-unit Tests for panel.
- Adds immediate on panel open/close methods.
- Fix for Firefox issue where the transitionend event wasn't firing on open (no animation).
