### PR TITLE
Fix for swipe to close on panel

### DIFF
--- a/css/structure/jquery.mobile.panel.css
+++ b/css/structure/jquery.mobile.panel.css
@@ -196,6 +196,11 @@
 	left: 0;
 }
 
+/* while open, page x overflow is disabled */
+.ui-page-active.ui-panel-page-block {
+	overflow-x:hidden;
+}
+
 /* wrap push on wide viewports once open */
 @media (min-width: 60em){
 	.ui-panel-content-wrap.ui-panel-content-wrap-open-complete.ui-panel-content-wrap-display-push,

--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -210,6 +210,7 @@ $.widget( "mobile.panel", $.mobile.widget, {
 				self.element.add( self._wrapper ).unbind( self._transitionEndEvents , complete );
 				self.element.addClass( o.classes.openComplete );
 				self._wrapper.addClass( o.classes.contentWrapOpenComplete );
+				self._page.addClass( o.classes.pageBlock );
 				self._positionPanel();
 				self._bindFixListener();
 				self._trigger( "open" );
@@ -223,7 +224,6 @@ $.widget( "mobile.panel", $.mobile.widget, {
 		} else{
 			setTimeout( complete , 0 );
 		}
-		self._page.addClass( o.classes.pageBlock );
 		self.element.removeClass( o.classes.panelClosed );
 		self.element.addClass( o.classes.panelOpen );
 		self._contentWrapOpenClasses = self._getPosDisplayClasses( o.classes.contentWrap );


### PR DESCRIPTION
Reinstated CSS previously removed to fix transition issue in FF, but instead broke swipe to close when page had horizontal overflow. Both FF issue and swipe to close fixed by adding page-block class after transition is complete.
