### PR TITLE
Issue 1383 - fixes to handle single & double quotes in data-url

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -532,8 +532,8 @@ define( [
 							// The data-url attribute exists, properly extract data-url attribute value
 							// regardless of which attribute delimiters (' or ") are used;
 							// whether the attributes contain embedded ' or " characters or what order they occur in:
-							var baseTagAttributes = $(pageElement)[0].attributes;
-							url = fileUrl = path.getFilePath(baseTagAttributes.getNamedItem("data-" + $.mobile.ns + "url").nodeValue);
+							url = fileUrl = path.getFilePath(
+                                    $(pageElement)[0].attributes.getNamedItem("data-" + $.mobile.ns + "url").nodeValue);
 						}
 					}
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -414,7 +414,13 @@ define( [
 		// Check to see if the page already exists in the DOM.
 		// NOTE do _not_ use the :jqmData psuedo selector because parenthesis
 		//      are a valid url char and it breaks on the first occurence
-		page = settings.pageContainer.children( "[data-" + $.mobile.ns +"url='" + dataUrl + "']" );
+		if (dataUrl.indexOf("'") === -1) {
+			// No single quote detected in URL, use single quote delimiter to handle double quotes in search:
+			page = settings.pageContainer.children( "[data-" + $.mobile.ns +"url='" + dataUrl + "']" );
+		} else {
+			// Single quote was detected in URL, use double quote delimiter to handle single quotes in search:
+			page = settings.pageContainer.children( "[data-" + $.mobile.ns +"url=\"" + dataUrl + "\"]" )
+		}
 
 		// If we failed to find the page, check to see if the url is a
 		// reference to an embedded page. If so, it may have been dynamically
@@ -520,11 +526,16 @@ define( [
 
 					// data-url must be provided for the base tag so resource requests can be directed to the
 					// correct url. loading into a temprorary element makes these requests immediately
-					if ( pageElemRegex.test( html ) &&
-							RegExp.$1 &&
-							dataUrlRegex.test( RegExp.$1 ) &&
-							RegExp.$1 ) {
-						url = fileUrl = path.getFilePath( $( "<div>" + RegExp.$1 + "</div>" ).text() );
+                    if (pageElemRegex.test(html) &&	RegExp.$1) {
+						var pageElement = RegExp.$1;
+						if (dataUrlRegex.test(pageElement) && RegExp.$1) {
+							// The data-url attribute exists, properly extract data-url attribute value
+							// regardless of which attribute delimiters (' or ") are used;
+							// whether the attributes contain embedded ' or " characters or what order they occur in:
+							var baseTagAttributes = $(pageElement)[0].attributes;
+							var dataUrl = baseTagAttributes.getNamedItem("data-" + $.mobile.ns + "url").nodeValue;
+							url = fileUrl = path.getFilePath(dataUrl);
+						}
 					}
 
 					if ( base ) {

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -533,8 +533,7 @@ define( [
 							// regardless of which attribute delimiters (' or ") are used;
 							// whether the attributes contain embedded ' or " characters or what order they occur in:
 							var baseTagAttributes = $(pageElement)[0].attributes;
-							var dataUrl = baseTagAttributes.getNamedItem("data-" + $.mobile.ns + "url").nodeValue;
-							url = fileUrl = path.getFilePath(dataUrl);
+							url = fileUrl = path.getFilePath(baseTagAttributes.getNamedItem("data-" + $.mobile.ns + "url").nodeValue);
 						}
 					}
 

--- a/tests/unit/navigation/data-url-tests/double-quotes-in-search.html
+++ b/tests/unit/navigation/data-url-tests/double-quotes-in-search.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+	<head>
+	</head>
+<body>
+	<div  data-nstest-role='page' data-nstest-url='foo/bar/double.html?foo=o"bar&bar=foobar'></div>
+</body>
+</html>

--- a/tests/unit/navigation/data-url-tests/single-quotes-in-search.html
+++ b/tests/unit/navigation/data-url-tests/single-quotes-in-search.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+	<head>
+	</head>
+<body>
+	<div  data-nstest-role="page" data-nstest-url="foo/bar/single.html?foo=o'bar&bar=foobar"></div>
+</body>
+</html>

--- a/tests/unit/navigation/index.html
+++ b/tests/unit/navigation/index.html
@@ -1,311 +1,361 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>jQuery Mobile Navigation Test Suite</title>
+  <meta name="generator" content=
+  "HTML Tidy for Windows (vers 14 February 2006), see www.w3.org">
+  <meta charset="utf-8">
+  <meta name="viewport" content=
+  "width=device-width, initial-scale=1">
 
-	<script src="../../../js/jquery.tag.inserter.js"></script>
-	<script src="../jquery.setNameSpace.js"></script>
-	<script src="../../../tests/jquery.testHelper.js"></script>
-	<script type="text/javascript">
-    $( document ).bind( "mobileinit", function(){
-		  $.testHelper.setPushState();
+  <title>jQuery Mobile Navigation Test Suite</title>
+  <script src="../../../js/jquery.tag.inserter.js" type=
+  "text/javascript">
+</script>
+  <script src="../jquery.setNameSpace.js" type="text/javascript">
+</script>
+  <script src="../../../tests/jquery.testHelper.js" type=
+  "text/javascript">
+</script>
+  <script type="text/javascript">
+  $( document ).bind( "mobileinit", function(){
+                  $.testHelper.setPushState();
     });
-	</script>
-	<script src="../../../js/"></script>
-	<link rel="stylesheet"	href="../../../css/themes/default/jquery.mobile.css"/>
-	<link rel="stylesheet" href="../../../external/qunit.css"/>
-	<script src="../../../external/qunit.js"></script>
-	<script type="text/javascript" src="navigation_core.js"></script>
-	<script type="text/javascript" src="navigation_paths.js"></script>
-	<script src="../swarminject.js"></script>
+  </script>
+  <script src="../../../js/" type="text/javascript">
+</script>
+  <link rel="stylesheet" href=
+  "../../../css/themes/default/jquery.mobile.css" type="text/css">
+  <link rel="stylesheet" href="../../../external/qunit.css" type=
+  "text/css">
+  <script src="../../../external/qunit.js" type="text/javascript">
+</script>
+  <script type="text/javascript" src="navigation_core.js">
+</script>
+  <script type="text/javascript" src="navigation_paths.js">
+</script>
+  <script src="../swarminject.js" type="text/javascript">
+</script>
 </head>
+
 <body>
-<div id="qunit"></div>
+  <div id="qunit"></div>
 
-<div id="harmless-default-page"	 data-nstest-role="page" class="first-page">
-</div>
+  <div id="harmless-default-page" data-nstest-role="page" class=
+  "first-page"></div>
 
-<div id="foo" data-nstest-role="page" class="foo-class">
-	<a href="#bar" data-nstest-transition="flip"></a>
-	<a id="bad-internal-page-link" href="#non-existent-page"></a>
-</div>
+  <div id="foo" data-nstest-role="page" class="foo-class">
+    <a href="#bar" data-nstest-transition="flip"></a> <a id=
+    "bad-internal-page-link" href="#non-existent-page"></a>
+  </div>
 
-<div id="prefetch" data-nstest-role="page">
-	<a href="prefetched.html" data-nstest-prefetch>Prefetch test</a>
-</div>
+  <div id="prefetch" data-nstest-role="page">
+    <a href="prefetched.html" data-nstest-prefetch="">Prefetch
+    test</a>
+  </div>
 
-<div id="foozball" data-nstest-role="page">
-</div>
+  <div id="foozball" data-nstest-role="page"></div>
 
-<div id="bar"	 data-nstest-role="page">
-	<a href="#baz"></a>
-</div>
+  <div id="bar" data-nstest-role="page">
+    <a href="#baz"></a>
+  </div>
 
-<div id="baz"	 data-nstest-role="page">
-	<a href="#foo"></a>
-</div>
+  <div id="baz" data-nstest-role="page">
+    <a href="#foo"></a>
+  </div>
 
-<div id="fade-trans" data-nstest-role="page">
-	<a href="#flip-trans" data-nstest-transition="fade"></a>
-</div>
+  <div id="fade-trans" data-nstest-role="page">
+    <a href="#flip-trans" data-nstest-transition="fade"></a>
+  </div>
 
-<div id="flip-trans" data-nstest-role="page">
-	<a href="#fade-trans" data-nstest-transition="flip"></a>
-</div>
+  <div id="flip-trans" data-nstest-role="page">
+    <a href="#fade-trans" data-nstest-transition="flip"></a>
+  </div>
 
-<div id="no-trans" data-nstest-role="page">
-	<a href="#pop-trans"></a>
-</div>
+  <div id="no-trans" data-nstest-role="page">
+    <a href="#pop-trans"></a>
+  </div>
 
-<div id="pop-trans"	 data-nstest-role="page">
-	<a href="#no-trans" data-nstest-transition="pop"></a>
-</div>
+  <div id="pop-trans" data-nstest-role="page">
+    <a href="#no-trans" data-nstest-transition="pop"></a>
+  </div>
 
-<div id="default-trans"	 data-nstest-role="page">
-	<a href="#no-trans"></a>
-</div>
+  <div id="default-trans" data-nstest-role="page">
+    <a href="#no-trans"></a>
+  </div>
 
-<div id="data-url" data-nstest-role="page">
-	<a href="data-url-tests/data-url.html"></a>
-</div>
+  <div id="data-url" data-nstest-role="page">
+    <a href="data-url-tests/data-url.html"></a>
+  </div>
 
-<div id="non-data-url" data-nstest-role="page">
-	<a href="data-url-tests/non-data-url.html"></a>
-</div>
+  <div id="non-data-url" data-nstest-role="page">
+    <a href="data-url-tests/non-data-url.html"></a>
+  </div>
 
-<div id="nested-data-url"	 data-nstest-role="page">
-	<a href="data-url-tests/nested.html"></a>
-</div>
+  <div id="nested-data-url" data-nstest-role="page">
+    <a href="data-url-tests/nested.html"></a>
+  </div>
 
-<div id="single-quotes-data-url" data-nstest-role="page">
-	<a href="data-url-tests/single-quotes.html"></a>
-</div>
+  <div id="single-quotes-data-url" data-nstest-role="page">
+    <a href="data-url-tests/single-quotes.html"></a>
+  </div>
+  <div id="single-quote-in-data-url" data-nstest-role="page">
+    <a href="data-url-tests/single-quotes-in-search.html"></a>
+  </div>
 
-<div id="reverse-attr-data-url"	 data-nstest-role="page">
-	<a href="data-url-tests/reverse-attr.html"></a>
-</div>
+  <div id="double-quote-in-data-url" data-nstest-role="page">
+    <a href="data-url-tests/double-quotes-in-search.html"></a>
+  </div>
 
-<div id="ajax-disabled-form" data-nstest-role="page">
-	<form method="POST" id="non-ajax-form" action="/ajax-disabled-form" data-nstest-ajax="false">
-	</form>
+  <div id="reverse-attr-data-url" data-nstest-role="page">
+    <a href="data-url-tests/reverse-attr.html"></a>
+  </div>
 
-	<form method="POST" id="ajax-form" action="/ajax-disabled-form">
-	</form>
+  <div id="ajax-disabled-form" data-nstest-role="page">
+    <form method="post" id="non-ajax-form" action=
+    "/ajax-disabled-form" data-nstest-ajax="false"></form>
 
-	<form method="POST" id="rand-ajax-form" action="/ajax-disabled-form" data-nstest-ajax="foo">
-	</form>
-</div>
+    <form method="post" id="ajax-form" action=
+    "/ajax-disabled-form"></form>
 
-<div id="default-trans-dialog" data-nstest-role="page">
-	<a href="#no-trans-dialog" data-nstest-rel="dialog"></a>
-</div>
+    <form method="post" id="rand-ajax-form" action=
+    "/ajax-disabled-form" data-nstest-ajax="foo"></form>
+  </div>
 
-<div id="no-trans-dialog" data-nstest-role="page">
-</div>
+  <div id="default-trans-dialog" data-nstest-role="page">
+    <a href="#no-trans-dialog" data-nstest-rel="dialog"></a>
+  </div>
 
-<div id="dup-history-first" data-nstest-role="page">
-	<a href="#dup-history-second" data-nstest-transition="slideup" data-nstest-role="button" >
-		Page 2
-	</a>
-</div>
+  <div id="no-trans-dialog" data-nstest-role="page"></div>
 
-<div id="dup-history-second" data-nstest-role="page">
-	<a href="#dup-history-first" data-nstest-transition="slideup" data-nstest-role="button">
-		Page 1
-	</a>
-	<a href="#dup-history-dialog" data-nstest-role="button" data-nstest-transition="pop" data-nstest-rel="dialog">Dialog</a>
-</div>
+  <div id="dup-history-first" data-nstest-role="page">
+    <a href="#dup-history-second" data-nstest-transition="slideup"
+    data-nstest-role="button">Page 2</a>
+  </div>
 
-<div id="dup-history-dialog" data-nstest-role="dialog">
-	 <div data-nstest-role="header" data-nstest-position="inline">
-		 <h1>Dialog</h1>
-	 </div>
-</div>
+  <div id="dup-history-second" data-nstest-role="page">
+    <a href="#dup-history-first" data-nstest-transition="slideup"
+    data-nstest-role="button">Page 1</a> <a href=
+    "#dup-history-dialog" data-nstest-role="button"
+    data-nstest-transition="pop" data-nstest-rel=
+    "dialog">Dialog</a>
+  </div>
 
-<div id="skip-dialog-first" data-nstest-role="page">
-	<div data-nstest-role="content">
-		<a href="#skip-dialog" data-nstest-role="button" data-nstest-transition="pop" data-nstest-rel="dialog">Dialog</a>
-	</div>
-</div>
+  <div id="dup-history-dialog" data-nstest-role="dialog">
+    <div data-nstest-role="header" data-nstest-position="inline">
+      <h1>Dialog</h1>
+    </div>
+  </div>
 
-<div id="skip-dialog" data-nstest-role="dialog">
-	<div data-nstest-role="content">
-		<a href="#skip-dialog-second">Page 2</a>
-	</div>
-</div>
+  <div id="skip-dialog-first" data-nstest-role="page">
+    <div data-nstest-role="content">
+      <a href="#skip-dialog" data-nstest-role="button"
+      data-nstest-transition="pop" data-nstest-rel=
+      "dialog">Dialog</a>
+    </div>
+  </div>
 
-<div id="skip-dialog-second" data-nstest-role="page">
-	<a href="#" data-nstest-rel="back">Go Back</a>
-</div>
+  <div id="skip-dialog" data-nstest-role="dialog">
+    <div data-nstest-role="content">
+      <a href="#skip-dialog-second">Page 2</a>
+    </div>
+  </div>
 
-<div id="dialog-double-hash-test-dialog" data-nstest-role="dialog">
-	<div data-nstest-role="header">
-		<h1>Dialog</h1>
-	</div>
-</div>
+  <div id="skip-dialog-second" data-nstest-role="page">
+    <a href="#" data-nstest-rel="back">Go Back</a>
+  </div>
 
-<div id="dialog-double-hash-test" data-nstest-role="page">
-	<div data-nstest-role="content">
-		<a href="#dialog-double-hash-test-dialog">Dialog</a>
-	</div>
-</div>
+  <div id="dialog-double-hash-test-dialog" data-nstest-role=
+  "dialog">
+    <div data-nstest-role="header">
+      <h1>Dialog</h1>
+    </div>
+  </div>
 
-<div id="nested-dialog-page" data-nstest-role="page">
-	<div data-nstest-role="content">
-		<a href="#nested-dialog-first">Dialog</a>
-	</div>
-</div>
+  <div id="dialog-double-hash-test" data-nstest-role="page">
+    <div data-nstest-role="content">
+      <a href="#dialog-double-hash-test-dialog">Dialog</a>
+    </div>
+  </div>
 
-<div id="nested-dialog-first" data-nstest-role="dialog">
-	<div data-nstest-role="content">
-		<a href="#nested-dialog-second">Dialog 2</a>
-	</div>
-</div>
+  <div id="nested-dialog-page" data-nstest-role="page">
+    <div data-nstest-role="content">
+      <a href="#nested-dialog-first">Dialog</a>
+    </div>
+  </div>
 
-<div id="nested-dialog-second" data-nstest-role="dialog">
-</div>
+  <div id="nested-dialog-first" data-nstest-role="dialog">
+    <div data-nstest-role="content">
+      <a href="#nested-dialog-second">Dialog 2</a>
+    </div>
+  </div>
 
-<div id="relative-after-embeded-page-first" data-nstest-role="page">
-	<div data-nstest-role="content">
-		<a href="#relative-after-embeded-page-second">second page</a>
-	</div>
-</div>
+  <div id="nested-dialog-second" data-nstest-role="dialog"></div>
 
-<div id="relative-after-embeded-page-second" data-nstest-role="page">
-	<div data-nstest-role="content">
-		<a href="data-url-tests/data-url.html">file path page</a>
-	</div>
-</div>
+  <div id="relative-after-embeded-page-first" data-nstest-role=
+  "page">
+    <div data-nstest-role="content">
+      <a href="#relative-after-embeded-page-second">second page</a>
+    </div>
+  </div>
 
-<div id="ajax-title-page" data-nstest-title="Title Attr 1" data-nstest-role="page">
-	<a href="title1.html" id="titletest1" data-nstest-transition="none">test</a>
-	<a href="title2.html" id="titletest2" data-nstest-transition="none">test</a>
-	<a href="title3.html" id="titletest3" data-nstest-transition="none">test</a>
-</div>
+  <div id="relative-after-embeded-page-second" data-nstest-role=
+  "page">
+    <div data-nstest-role="content">
+      <a href="data-url-tests/data-url.html">file path page</a>
+    </div>
+  </div>
 
-<div data-nstest-role="page" id="titletest4" data-nstest-title="Title Attr 2">
-	<div data-nstest-role="header"><h1>Title Heading</h1></div>
-</div>
+  <div id="ajax-title-page" data-nstest-title="Title Attr 1"
+  data-nstest-role="page">
+    <a href="title1.html" id="titletest1" data-nstest-transition=
+    "none">test</a> <a href="title2.html" id="titletest2"
+    data-nstest-transition="none">test</a> <a href="title3.html"
+    id="titletest3" data-nstest-transition="none">test</a>
+  </div>
 
-<div data-nstest-role="page" id="titletest5" data-nstest-title="Title Attr">
-	<div data-nstest-role="header"><h1>Title Heading</h1></div>
-</div>
+  <div data-nstest-role="page" id="titletest4" data-nstest-title=
+  "Title Attr 2">
+    <div data-nstest-role="header">
+      <h1>Title Heading</h1>
+    </div>
+  </div>
 
-<div data-nstest-role="page" id="self-link">
-	<a href="#self-link">self!</a>
-</div>
+  <div data-nstest-role="page" id="titletest5" data-nstest-title=
+  "Title Attr">
+    <div data-nstest-role="header">
+      <h1>Title Heading</h1>
+    </div>
+  </div>
 
-<div data-nstest-role="page" id="dialog-param-link">
-	<a href="dialog-param-test/dialog-param.html">go</a>
-</div>
+  <div data-nstest-role="page" id="self-link">
+    <a href="#self-link">self!</a>
+  </div>
 
-<div data-nstest-role="page" id="dialog-base-tag-test-page">
-	<a href="go-to-dialog.html">go</a>
-</div>
+  <div data-nstest-role="page" id="dialog-param-link">
+    <a href="dialog-param-test/dialog-param.html">go</a>
+  </div>
 
-<div data-nstest-role="page" id="pathing-tests">
-	<!-- doc rel links -->
-	<a href="file.html" id="doc-rel-test-one">go</a>
-	<a href="path-tests/file.html" id="doc-rel-test-two">go</a>
-	<a href="path-tests/sub-dir/file.html" id="doc-rel-test-three">go</a>
-	<a href="path-tests/sub-dir/" id="doc-rel-test-four">go</a>
-	<a href="../../unit/navigation/path-tests/parent-ref.html" id="doc-rel-test-five">go</a>
-	<a href="../../unit/navigation/path-tests/parent/" id="doc-rel-test-six">go</a>
+  <div data-nstest-role="page" id="dialog-base-tag-test-page">
+    <a href="go-to-dialog.html">go</a>
+  </div>
 
-	<!-- site rel links -->
-	<!-- these will be altered before the test suite runs to use the current path -->
-	<a href="file.html" id="site-rel-test-one" class="site-rel">go</a>
-	<a href="path-tests/file.html" id="site-rel-test-two" class="site-rel">go</a>
-	<a href="path-tests/sub-dir/file.html" id="site-rel-test-three" class="site-rel">go</a>
-	<a href="path-tests/sub-dir/" id="site-rel-test-four" class="site-rel">go</a>
-	<a href="../../unit/navigation/path-tests/parent-ref.html" id="site-rel-test-five" class="site-rel">go</a>
-	<a href="../../unit/navigation/path-tests/parent/" id="site-rel-test-six" class="site-rel">go</a>
+  <div data-nstest-role="page" id="pathing-tests">
+    <!-- doc rel links -->
+    <a href="file.html" id="doc-rel-test-one">go</a> <a href=
+    "path-tests/file.html" id="doc-rel-test-two">go</a> <a href=
+    "path-tests/sub-dir/file.html" id="doc-rel-test-three">go</a>
+    <a href="path-tests/sub-dir/" id="doc-rel-test-four">go</a>
+    <a href="../../unit/navigation/path-tests/parent-ref.html" id=
+    "doc-rel-test-five">go</a> <a href=
+    "../../unit/navigation/path-tests/parent/" id=
+    "doc-rel-test-six">go</a> <!-- site rel links -->
+     
+    <!-- these will be altered before the test suite runs to use the current path -->
+     <a href="file.html" id="site-rel-test-one" class=
+    "site-rel">go</a> <a href="path-tests/file.html" id=
+    "site-rel-test-two" class="site-rel">go</a> <a href=
+    "path-tests/sub-dir/file.html" id="site-rel-test-three" class=
+    "site-rel">go</a> <a href="path-tests/sub-dir/" id=
+    "site-rel-test-four" class="site-rel">go</a> <a href=
+    "../../unit/navigation/path-tests/parent-ref.html" id=
+    "site-rel-test-five" class="site-rel">go</a> <a href=
+    "../../unit/navigation/path-tests/parent/" id=
+    "site-rel-test-six" class="site-rel">go</a> 
+    <!-- protocol rel links -->
+     
+    <!-- these will be altered before the test suite runs to use the
+                         current domain and path -->
+     <a href="file.html" id="protocol-rel-test-one" class=
+    "protocol-rel">go</a> <a href="path-tests/file.html" id=
+    "protocol-rel-test-two" class="protocol-rel">go</a> <a href=
+    "path-tests/sub-dir/file.html" id="protocol-rel-test-three"
+    class="protocol-rel">go</a> <a href="path-tests/sub-dir/" id=
+    "protocol-rel-test-four" class="protocol-rel">go</a> <a href=
+    "../../unit/navigation/path-tests/parent-ref.html" id=
+    "protocol-rel-test-five" class="protocol-rel">go</a> <a href=
+    "../../unit/navigation/path-tests/parent/" id=
+    "protocol-rel-test-six" class="protocol-rel">go</a> 
+    <!-- absolute links -->
+     
+    <!-- these will be altered before the test suite runs to use the
+                         current protocol, domain and path -->
+     <a href="file.html" id="absolute-test-one" class=
+    "absolute">go</a> <a href="path-tests/file.html" id=
+    "absolute-test-two" class="absolute">go</a> <a href=
+    "path-tests/sub-dir/file.html" id="absolute-test-three" class=
+    "absolute">go</a> <a href="path-tests/sub-dir/" id=
+    "absolute-test-four" class="absolute">go</a> <a href=
+    "../../unit/navigation/path-tests/parent-ref.html" id=
+    "absolute-test-five" class="absolute">go</a> <a href=
+    "../../unit/navigation/path-tests/parent/" id=
+    "absolute-test-six" class="absolute">go</a>
+  </div>
 
-	<!-- protocol rel links -->
-	<!-- these will be altered before the test suite runs to use the
-			 current domain and path -->
-	<a href="file.html" id="protocol-rel-test-one" class="protocol-rel">go</a>
-	<a href="path-tests/file.html" id="protocol-rel-test-two" class="protocol-rel">go</a>
-	<a href="path-tests/sub-dir/file.html" id="protocol-rel-test-three" class="protocol-rel">go</a>
-	<a href="path-tests/sub-dir/" id="protocol-rel-test-four" class="protocol-rel">go</a>
-	<a href="../../unit/navigation/path-tests/parent-ref.html" id="protocol-rel-test-five" class="protocol-rel">go</a>
-	<a href="../../unit/navigation/path-tests/parent/" id="protocol-rel-test-six" class="protocol-rel">go</a>
+  <div data-nstest-role="page" id="pathing-tests-reset">
+    <div class="reset-value">
+      page didn't change!
+    </div>
+  </div>
 
-	<!-- absolute links -->
-	<!-- these will be altered before the test suite runs to use the
-			 current protocol, domain and path -->
-	<a href="file.html" id="absolute-test-one" class="absolute">go</a>
-	<a href="path-tests/file.html" id="absolute-test-two" class="absolute">go</a>
-	<a href="path-tests/sub-dir/file.html" id="absolute-test-three" class="absolute">go</a>
-	<a href="path-tests/sub-dir/" id="absolute-test-four" class="absolute">go</a>
-	<a href="../../unit/navigation/path-tests/parent-ref.html" id="absolute-test-five" class="absolute">go</a>
-	<a href="../../unit/navigation/path-tests/parent/" id="absolute-test-six" class="absolute">go</a>
+  <div data-nstest-role="page" id="internal-no-action-form-page">
+    <div data-nstest-role="content">
+      <form>
+        <input type="hidden" name="foo" value="1"> <input type=
+        "hidden" name="bar" value="2">
+      </form><a href="form-tests/form-no-action.html">External page
+      containing form with no action.</a>
+    </div>
+  </div>
 
-</div>
+  <div id="active-state-page1" data-nstest-role="page">
+    <div data-nstest-role="content">
+      <a href="#active-state-page2" data-nstest-role=
+      "button">page2</a>
+    </div>
+  </div>
 
-<div data-nstest-role="page" id="pathing-tests-reset">
-	<div class="reset-value">page didn't change!</div>
-</div>
+  <div id="active-state-page2" data-nstest-role="page">
+    <div data-nstest-role="content">
+      <a href="#active-state-page1" data-nstest-role="button">href
+      button</a> <a href="#active-state-page1" data-nstest-rel=
+      "back" data-nstest-role="button">back button</a>
+    </div>
+  </div>
 
-<div data-nstest-role="page" id="internal-no-action-form-page">
-	<div data-nstest-role="content">
-		<form>
-			<input type="hidden" name="foo" value="1">
-			<input type="hidden" name="bar" value="2">
-		</form>
-				<a href="form-tests/form-no-action.html">External page containing form with no action.</a>
-		</div>
-</div>
+  <div id="odd-clicks-page" data-nstest-role="page">
+    <a href="#odd-clicks-page-dest" id=
+    "right-or-middle-click">foo</a>
+  </div>
 
-<div id="active-state-page1" data-nstest-role="page">
-	<div data-nstest-role="content">
-		<a href="#active-state-page2" data-nstest-role="button">page2</a>
-	</div>
-</div>
+  <div id="odd-clicks-page-dest" data-nstest-role="page"></div>
 
-<div id="active-state-page2" data-nstest-role="page">
-	<div data-nstest-role="content">
-		<a href="#active-state-page1" data-nstest-role="button">href button</a>
-		<a href="#active-state-page1" data-nstest-rel="back" data-nstest-role="button">back button</a>
-	</div>
-</div>
+  <div id="inject-links-page" data-nstest-role="page">
+    <a href="#injected-test-page" id=
+    "static-injected-test-page-link">static link</a>
+  </div>
 
+  <div id="prefetched-dialog-page" data-nstest-role="page">
+    <a href="prefetched-dialog.html" id="prefetched-dialog-link"
+    data-nstest-role="prefetch" data-nstest-rel="dialog">static
+    link</a>
+  </div>
 
+  <div id="link-hijacking-test" data-nstest-role="page">
+    <div id="hijackable">
+      <a href="#link-hijacking-destination" id="hijacked-link"></a>
+      <a href="#link-hijacking-destination" id=
+      "unhijacked-link-by-attr" data-nstest-ajax="false"></a>
+    </div>
 
-<div id="odd-clicks-page" data-nstest-role="page">
-  <a href="#odd-clicks-page-dest" id="right-or-middle-click">foo</a>
-</div>
+    <div id="not-hijackable" data-nstest-ajax="false">
+      <a href="#link-hijacking-destination" id=
+      "unhijacked-link-by-parent"></a>
+    </div>
+  </div>
 
-<div id="odd-clicks-page-dest" data-nstest-role="page"></div>
-
-<div id="inject-links-page" data-nstest-role="page">
-  <a href="#injected-test-page" id="static-injected-test-page-link">static link</a>
-</div>
-
-<div id="prefetched-dialog-page" data-nstest-role="page">
-  <a href="prefetched-dialog.html"
-     id="prefetched-dialog-link"
-     data-nstest-role="prefetch"
-     data-nstest-rel="dialog">
-    static link
-  </a>
-</div>
-
-<div id="link-hijacking-test" data-nstest-role="page">
-	<div id="hijackable">
-		<a href="#link-hijacking-destination" id="hijacked-link"></a>
-		<a href="#link-hijacking-destination" id="unhijacked-link-by-attr" data-nstest-ajax="false"></a>
-	</div>
-
-	<div id="not-hijackable" data-nstest-ajax="false">
-		<a href="#link-hijacking-destination" id="unhijacked-link-by-parent"></a>
-	</div>
-</div>
-
-<div id="link-hijacking-destination" data-nstest-role="page">
-	hello!
-</div>
+  <div id="link-hijacking-destination" data-nstest-role="page">
+    hello!
+  </div>
 </body>
 </html>

--- a/tests/unit/navigation/navigation_core.js
+++ b/tests/unit/navigation/navigation_core.js
@@ -368,6 +368,15 @@ $.testHelper.delayStart();
 		var url = "foo/bar/single.html";
 		testDataUrlHash( "#single-quotes-data-url a", {hashOrPush: home + url } );
 	});
+	test( "data url works for single quote in url", function(){
+		var url = "foo/bar/single.html?foo=o'bar&bar=foobar";
+		testDataUrlHash( "#single-quote-in-data-url a", {hashOrPush: home + url } );
+	});
+
+	test( "data url works for double quote in url", function(){
+		var url = "foo/bar/double.html?foo=o%22bar&bar=foobar";
+		testDataUrlHash( "#double-quote-in-data-url a", {hashOrPush: home + url } );
+	});	
 
 	test( "data url works when role and url are reversed on the page element", function(){
 		var url = "foo/bar/reverse.html";


### PR DESCRIPTION
In my comment to this issue (https://github.com/jquery/jquery-mobile/issues/1383), there's a sample page that reproduces this issue.

In this branch, I first committed new unit tests that fail against against the current navigation code. Next I committed a couple of changes needed to handle these quote characters. I've only tested the fixes in Chrome & FireFox. Please let me know if you have any questions about the changes or the use case. Thanks for the consideration!
