### PR TITLE
Add missing semicolons to jquery.mobile.transition.slidefade.css

### DIFF
--- a/css/structure/jquery.mobile.transition.slidefade.css
+++ b/css/structure/jquery.mobile.transition.slidefade.css
@@ -42,9 +42,9 @@
 	-webkit-animation-name: fadein;
 	-webkit-animation-duration: 200ms;
 	-moz-transform: translateX(0);
-	-moz-animation-name: fadein
+	-moz-animation-name: fadein;
 	-moz-animation-duration: 200ms;
 	transform: translateX(0);
-	animation-name: fadein
+	animation-name: fadein;
 	animation-duration: 200ms;
 }


### PR DESCRIPTION
I tried copying jquery.mobile.structure-1.3.0-beta.1.css to a .SCSS file to use it in a SASS project, but the .SCSS file wouldn't compile because of two missing semicolons on lines 385 and 388. These two lines come from css/structure/jquery.mobile.transition.slidefade.css. This pull request adds those two missing semicolons.
