### PR TITLE
Performance: replace several jqmData() function calls with getAttribute() to improve performance.

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -11,6 +11,7 @@ define( [ "jquery", "./jquery.mobile.core", "./jquery.mobile.vmouse" ], function
 
 $.fn.buttonMarkup = function( options ) {
 	var $workingSet = this,
+		prefix = "data-" + $.mobile.ns,
 		mapToDataAttr = function( key, value ) {
 			e.setAttribute( "data-" + $.mobile.ns + key, value );
 			el.jqmData( key, value );
@@ -22,14 +23,14 @@ $.fn.buttonMarkup = function( options ) {
 		var el = $workingSet.eq( i ),
 			e = el[ 0 ],
 			o = $.extend( {}, $.fn.buttonMarkup.defaults, {
-				icon:       options.icon       !== undefined ? options.icon       : el.jqmData( "icon" ),
-				iconpos:    options.iconpos    !== undefined ? options.iconpos    : el.jqmData( "iconpos" ),
-				theme:      options.theme      !== undefined ? options.theme      : el.jqmData( "theme" ) || $.mobile.getInheritedTheme( el, "c" ),
-				inline:     options.inline     !== undefined ? options.inline     : el.jqmData( "inline" ),
-				shadow:     options.shadow     !== undefined ? options.shadow     : el.jqmData( "shadow" ),
-				corners:    options.corners    !== undefined ? options.corners    : el.jqmData( "corners" ),
-				iconshadow: options.iconshadow !== undefined ? options.iconshadow : el.jqmData( "iconshadow" ),
-				mini:       options.mini       !== undefined ? options.mini       : el.jqmData( "mini" )
+				icon:       options.icon       !== undefined ? options.icon       : ( e.getAttribute( prefix + "icon" ) || undefined ),
+				iconpos:    options.iconpos    !== undefined ? options.iconpos    : ( e.getAttribute( prefix + "iconpos" ) || undefined ),
+				theme:      options.theme      !== undefined ? options.theme      : e.getAttribute( prefix + "theme" ) || $.mobile.getInheritedTheme( el, "c" ),
+				inline:     options.inline     !== undefined ? options.inline     : /^true$/i.test( e.getAttribute( prefix + "inline" ) ),
+				shadow:     options.shadow     !== undefined ? options.shadow     : !/^false$/i.test( e.getAttribute( prefix + "shadow" ) ),
+				corners:    options.corners    !== undefined ? options.corners    : !/^false$/i.test( e.getAttribute( prefix + "corners" ) ),
+				iconshadow: options.iconshadow !== undefined ? options.iconshadow : !/^false$/i.test( e.getAttribute( prefix + "iconshadow" ) ),
+				mini:       options.mini       !== undefined ? options.mini       : /^true$/i.test( e.getAttribute( prefix + "mini" ) )
 			}, options ),
 
 			// Classes Defined
@@ -46,7 +47,7 @@ $.fn.buttonMarkup = function( options ) {
 
 		$.each( o, mapToDataAttr );
 
-		if ( el.jqmData( "rel" ) === "popup" && el.attr( "href" ) ) {
+		if ( e.getAttribute( prefix + "rel" ) === "popup" && el.attr( "href" ) ) {
 			e.setAttribute( "aria-haspopup", true );
 			e.setAttribute( "aria-owns", e.getAttribute( "href" ) );
 		}

--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -68,7 +68,7 @@ define([
 				var $this = $( this );
 
 				// unless the data url is already set set it to the pathname
-				if ( !$this.jqmData( "url" ) ) {
+				if ( !$this[0].getAttribute( "data-" + $.mobile.ns + "url" ) ) {					
 					$this.attr( "data-" + $.mobile.ns + "url", $this.attr( "id" ) || location.pathname + location.search );
 				}
 			});

--- a/js/widgets/page.sections.js
+++ b/js/widgets/page.sections.js
@@ -21,7 +21,8 @@ $.mobile.page.prototype.options.contentTheme = null;
 $.mobile.document.bind( "pagecreate", function( e ) {
 	var $page = $( e.target ),
 		o = $page.data( "mobile-page" ).options,
-		pageRole = $page.jqmData( "role" ),
+		prefix = "data-"+$.mobile.ns,
+		pageRole = $page[0].getAttribute( prefix + "role" ) || undefined,
 		pageTheme = o.theme;
 
 	$( ":jqmData(role='header'), :jqmData(role='footer'), :jqmData(role='content')", $page )
@@ -29,8 +30,8 @@ $.mobile.document.bind( "pagecreate", function( e ) {
 		.each(function() {
 
 		var $this = $( this ),
-			role = $this.jqmData( "role" ),
-			theme = $this.jqmData( "theme" ),
+			role = $this[0].getAttribute( prefix + "role" ) || undefined,
+			theme = $this[0].getAttribute( prefix + "theme" ) || undefined,
 			contentTheme = theme || o.contentTheme || ( pageRole === "dialog" && pageTheme ),
 			$headeranchors,
 			leftbtn,
@@ -65,7 +66,7 @@ $.mobile.document.bind( "pagecreate", function( e ) {
 			if ( o.addBackBtn &&
 				role === "header" &&
 				$( ".ui-page" ).length > 1 &&
-				$page.jqmData( "url" ) !== $.mobile.path.stripHash( location.hash ) &&
+				$page[0].getAttribute( prefix + "url" ) !== $.mobile.path.stripHash( location.hash ) &&
 				!leftbtn ) {
 
 				backBtn = $( "<a href='javascript:void(0);' class='ui-btn-left' data-"+ $.mobile.ns +"rel='back' data-"+ $.mobile.ns +"icon='arrow-l'>"+ o.backBtnText +"</a>" )


### PR DESCRIPTION
Hi, All.
Actually, I tried to do a PR last week but I couldn't because there were many issues on Tizen project, so I'm sorry that I couldn't have enough time to do it. I'm opening the third PR regarding performance improvement now.

My team found another performance issue about using jqmData() function.
As you know, jqmData() calls jQuery data() function. "data()" function is complicated and not small. Also it takes time to call the function because many cases call jQuery.extend() function in data() and extend() calls other functions and has for loop and does a lot of things. Hence, my team found several jqmData() function calls which can be replaced with getAttribute() JavaScript(JS) function. (Some cases can not do like that.)
After replacing jqmData() function calls with getAttribute(), my team checked Web App.'s launching time and got a big performance improvement. Web App.'s average launching time decreased to 130ms on GalaxyS2 class devices.
My team has been looking for other codes which are able to replace jqmData() function call since then and if my team finds other codes to replace, I'll do a PR again.

Additionally, some codes using jqmData() return number or boolean value, hence some of committed codes on jquery.mobile.buttonMarkup.js are modified according to the return value's type.
- Tests : The code has been tested on several jQM widgets using qunit.js.
- Modified code is followed the jQuery Core Style guide.
- Scope : Performance improvement.

If there are any problems or mistakes on that PR, please let me know. Thanks in advance.
