### PR TITLE
Fixed #5480 - Panel should close after, and not during, page animation

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -230,7 +230,7 @@ $.widget( "mobile.panel", $.mobile.widget, {
 				}
 			})
 			// clean up open panels after page hide
-			.on(  "pagebeforehide", function( e ) {
+			.on(  "pagehide", function( e ) {
 				if ( self._open ) {
 					self.close( true );
 				}


### PR DESCRIPTION
[The issue.](https://github.com/jquery/jquery-mobile/issues/5480)

And here's the fix.
