### PR TITLE
Rangeslider: missing argument in function _dragFirstHandle

### DIFF
--- a/js/widgets/forms/rangeslider.js
+++ b/js/widgets/forms/rangeslider.js
@@ -69,7 +69,7 @@ define( [ "jquery", "../../jquery.mobile.core", "../../jquery.mobile.widget", ".
 			});
 		},
 
-		_dragFirstHandle: function() {
+		_dragFirstHandle: function(event) {
 			//if the first handle is dragged send the event to the first slider
 			$.data( this._inputFirst.get(0), "mobileSlider" ).dragging = true;
 			$.data( this._inputFirst.get(0), "mobileSlider" ).refresh( event );


### PR DESCRIPTION
Argument "event" is missing in function. It worked on Webkit (event is somewhere set as global variable) but caused exceptions to be thrown in Firefox.

There should be more tests for rangeslider events (checking if sliders are refreshed etc).
