### PR TITLE
option to disable automatic resetActivePageHeight

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -49,6 +49,9 @@ define( [ "jquery", "./jquery.mobile.ns", "text!../version.txt" ], function( $, 
 		// Set maximum window width for transitions to apply - 'false' for no limit
 		maxTransitionWidth: false,
 
+		// Set maximum window width for resetActivePageHeight - 'false' for no limit
+		maxAutoHeightAdjustmentWidth: false,
+
 		// Minimum scroll distance that will be remembered when returning to a page
 		minScrollBack: 250,
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -285,12 +285,18 @@ define( [
 	}
 
 	//simply set the active page's minimum height to screen height, depending on orientation
-	$.mobile.resetActivePageHeight = function resetActivePageHeight( height ) {
+	$.mobile.resetActivePageHeight = function( height ) {
 		var aPage = $( "." + $.mobile.activePageClass ),
 			aPagePadT = parseFloat( aPage.css( "padding-top" ) ),
 			aPagePadB = parseFloat( aPage.css( "padding-bottom" ) ),
 			aPageBorderT = parseFloat( aPage.css( "border-top-width" ) ),
 			aPageBorderB = parseFloat( aPage.css( "border-bottom-width" ) );
+
+                // configurable option to avoid automatically resizing page on large screens
+                if (typeof height !== "number" && $.mobile.maxAutoHeightAdjustmentWidth !== false && $.mobile.window.width() > $.mobile.maxAutoHeightAdjustmentWidth) {
+                        aPage.css( "min-height", "");
+                        return;
+                }
 
 		height = ( typeof height === "number" )? height : getScreenHeight();
 		

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -292,11 +292,11 @@ define( [
 			aPageBorderT = parseFloat( aPage.css( "border-top-width" ) ),
 			aPageBorderB = parseFloat( aPage.css( "border-bottom-width" ) );
 
-                // configurable option to avoid automatically resizing page on large screens
-                if (typeof height !== "number" && $.mobile.maxAutoHeightAdjustmentWidth !== false && $.mobile.window.width() > $.mobile.maxAutoHeightAdjustmentWidth) {
-                        aPage.css( "min-height", "");
-                        return;
-                }
+		// configurable option to avoid automatically resizing page on large screens
+		if (typeof height !== "number" && $.mobile.maxAutoHeightAdjustmentWidth !== false && $.mobile.window.width() > $.mobile.maxAutoHeightAdjustmentWidth) {
+			aPage.css( "min-height", "");
+			return;
+		}
 
 		height = ( typeof height === "number" )? height : getScreenHeight();
 		


### PR DESCRIPTION
As I'm increasingly using jQM for "mobile-first, but not mobile only," I'm finding it useful to add a healthy margin around the page for larger screen sizes.  This could be done using only CSS breakpoints were it not for the automated resetActivePageHeight.  This patch allows resetActivePageHeight to function differently above a configurable screen width (like $.mobile.maxTransitionWidth).  Above the specified maxAutoHeightAdjustmentWidth, resetActivePageHeight will clear out the min-height, allowing it to be configured via CSS for larger screen sizes.
