### PR TITLE
Slider: drag should start only for left mouse button

### DIFF
--- a/js/widgets/forms/slider.js
+++ b/js/widgets/forms/slider.js
@@ -262,7 +262,7 @@ $.widget( "mobile.slider", $.mobile.widget, {
 	_sliderVMouseDown: function( event ) {
 		// NOTE: we don't do this in refresh because we still want to
 		//       support programmatic alteration of disabled inputs
-		if ( this.options.disabled ) {
+		if ( this.options.disabled || event.which != 1 ) {
 			return false;
 		}
 		if ( this._trigger( "beforestart", event ) === false ) {

--- a/tests/unit/slider/index.html
+++ b/tests/unit/slider/index.html
@@ -99,6 +99,11 @@
 
 	<div data-role="fieldcontain">
 		<label for="start-stop-events">Input slider:</label>
+		<input type="range" name="slider" id="mousedown-which-events" value="25" min="0" max="100"/>
+	</div>
+
+	<div data-role="fieldcontain">
+		<label for="start-stop-events">Input slider:</label>
 		<input type="range" name="slider" id="start-stop-events" value="25" min="0" max="100"/>
 	</div>
 

--- a/tests/unit/slider/slider_events.js
+++ b/tests/unit/slider/slider_events.js
@@ -374,6 +374,26 @@
 		], 500);
 	});
 
+	test( "drag should start only when clicked with left button", function(){
+		expect(1);
+		var control = $( "#mousedown-which-events" ),
+			widget = control.data( "mobile-slider" ),
+			slider = widget.slider,
+			handle = widget.handle,
+			startFunc = function() {
+				ok( true, "drag started" );
+			},
+			event = $.Event( "mousedown", { target: handle[ 0 ] } );
+		control.bind( 'slidestart', startFunc);
+		event.which = 1; //left button
+		slider.trigger(event);
+		event.which = 2; //middle button
+		slider.trigger(event);
+		event.which = 3; //right button
+		slider.trigger(event);
+		control.unbind( 'start', startFunc);
+	});
+
 	asyncTest( "moving the slider triggers 'slidestart' and 'slidestop' events", function() {
 		var control = $( "#start-stop-events" ),
 			widget = control.data( "mobile-slider" ),


### PR DESCRIPTION
Hi.
On desktop browsers there is a problem when slider is clicked with right mouse button.
Context menu appears and slider's drag starts - you need to click again somewhere to stop drag.
Shouldn't slider start only for left mouse?
