### PR TITLE
Panel: Make sure active state is applied to and removed from buttons in header too.

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -222,7 +222,7 @@ $.widget( "mobile.panel", $.mobile.widget, {
 			if ( this.href.split( "#" )[ 1 ] === self._panelID && self._panelID !== undefined ) {
 				e.preventDefault();
 				var $link = $( this );
-				if ( $link.is( ":jqmData(role='button')" ) ) {
+				if ( ! $link.hasClass( "ui-link" ) ) {
 					$link.addClass( $.mobile.activeBtnClass );
 					self.element.one( "panelopen panelclose", function() {
 						$link.removeClass( $.mobile.activeBtnClass );


### PR DESCRIPTION
Fix for #5583.

Tested on iOS6.1, Android 4.1, Linux/Chromium, Linux/Firefox, Win7/Chrome, Win7/Firefox. All unit tests pass.
