### PR TITLE
Navigation: Calling replaceState causes an error inside FF iframes, so ...

### DIFF
--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -193,6 +193,8 @@ $.extend( $.support, {
 	// https://developers.google.com/chrome/mobile/docs/user-agent#chrome_for_ios_user-agent
 	pushState: "pushState" in history &&
 		"replaceState" in history &&
+		// must not be inside a FF iframe, where calling replaceState errors out.
+		!( window.navigator.userAgent.indexOf( "Firefox" ) >= 0 && window.top !== window ) &&
 		( window.navigator.userAgent.search(/CriOS/) === -1 ),
 
 	mediaquery: $.mobile.media( "only all" ),


### PR DESCRIPTION
... disable pushState for those

Once this change is in place, we can remove the extra script added to API doc examples as a fix to API docs issue [#11](https://github.com/jquery/api.jquerymobile.com/issues/11), and jQM will no longer die inside FF iframes.
