### PR TITLE
Dialog: unable to set any options but "closeBtn"

### DIFF
--- a/js/widgets/dialog.js
+++ b/js/widgets/dialog.js
@@ -108,6 +108,8 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 			this._setCloseBtn( value );
 			this._super( key, value );
 			this.element.attr( "data-" + ( $.mobile.ns || "" ) + "close-btn", value );
+		} else {
+			this._super( key, value );
 		}
 	},
 


### PR DESCRIPTION
1. **Description:** `dialog`'s `_setOption` override prevents any options but `closeBtn` from being set.
2. **Test page:** http://jsbin.com/onibuc/250/edit
3. **Steps to reproduce:** `dialog.dialog({key: 'value'}); console.log(dialog.dialog('option', 'key'))`
4. **Expected outcome:** `'value'`
5. **Actual outcome:** `null`
6. **jQuery Mobile version:** 1.3.0rc1
