### PR TITLE
Replaced the calls to deprecated functions show/hidePageLoadingMsg

### DIFF
--- a/js/jquery.mobile.init.js
+++ b/js/jquery.mobile.init.js
@@ -84,7 +84,7 @@ define([
 			$window.trigger( "pagecontainercreate" );
 
 			// cue page loading message
-			$.mobile.showPageLoadingMsg();
+			$.mobile.loading( "show" );
 
 			//remove initial build class (only present on first pageshow)
 			hideRenderingClass();

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -264,7 +264,7 @@ define( [
 		toPage.data( "mobile-page" )._trigger( "beforeshow", null, { prevPage: fromPage || $( "" ) } );
 
 		//clear page loader
-		$.mobile.hidePageLoadingMsg();
+		$.mobile.loading( "hide" );
 
 		transition = $.mobile._maybeDegradeTransition( transition );
 
@@ -481,7 +481,7 @@ define( [
 
 			// This configurable timeout allows cached pages a brief delay to load without showing a message
 			var loadMsgDelay = setTimeout(function() {
-					$.mobile.showPageLoadingMsg();
+					$.mobile.loading( "show" );
 				}, settings.loadMsgDelay ),
 
 				// Shared logic for clearing timeout and removing message.
@@ -491,7 +491,7 @@ define( [
 					clearTimeout( loadMsgDelay );
 
 					// Hide loading message
-					$.mobile.hidePageLoadingMsg();
+					$.mobile.loading( "hide" );
 				};
 		}
 
@@ -640,7 +640,7 @@ define( [
 						$.mobile.showPageLoadingMsg( $.mobile.pageLoadErrorMessageTheme, $.mobile.pageLoadErrorMessage, true );
 
 						// hide after delay
-						setTimeout( $.mobile.hidePageLoadingMsg, 1500 );
+						setTimeout( function() { $.mobile.loading( "hide" ); }, 1500 );
 					}
 
 					deferred.reject( absUrl, options );


### PR DESCRIPTION
Replaced the calls to the deprecated functions showPageLoadingMsg/hidePageLoadingMsg with the correspondent .loading() calls
