### PR TITLE
Listview Persistence

### DIFF
--- a/docs/widgets/listviews/index.php
+++ b/docs/widgets/listviews/index.php
@@ -85,7 +85,7 @@
 			</div><!--/demo-html -->
 
 			<h2 id="list-filter">Filter</h2>
-			<p>To make a list filterable, simply add the <code>data-filter="true"</code> attribute to the list. The framework will then append a search box above the list and add the behavior to filter out list items that don't contain the current search string as the user types. The input's placeholder text defaults to "Filter items...". To configure the placeholder text in the search input, use the <code>data-filter-placeholder</code> attribute. By default the search box will inherit its theme from its parent. The search box theme can be configured using the data attribute <code>data-filter-theme</code> on your listview.</p>
+			<p>To make a list filterable, simply add the <code>data-filter="true"</code> attribute to the list. The framework will then append a search box above the list and add the behavior to filter out list items that don't contain the current search string as the user types. The input's placeholder text defaults to "Filter items...". To configure the placeholder text in the search input, use the <code>data-filter-placeholder</code> attribute. By default the search box will inherit its theme from its parent. The search box theme can be configured using the data attribute <code>data-filter-theme</code> on your listview. To keep a list item visible, even if it does not match the filter criteria, add <code>data-persist="true"</code>.</p>
 			<div data-demo-html="true">
 				<ul data-role="listview" data-filter="true" data-filter-placeholder="Search fruits..." data-inset="true">
 					<li><a href="#">Apple</a></li>
@@ -125,7 +125,7 @@
 			</div><!--/demo-html -->
 
 			<h2 id="list-autodividers">Autodividers</h2>
-			<p><p>A listview can be configured to automatically generate dividers for its items by adding a <code>data-autodividers="true"</code> attribute to any listview. By default, the text used to create dividers is the uppercased first letter of the item's text. Alternatively you can specify divider text by setting the <code>autodividersSelector</code> option on the listview programmatically. This feature is designed to work seamlessly with the filter.</p>
+			<p><p>A listview can be configured to automatically generate dividers for its items by adding a <code>data-autodividers="true"</code> attribute to any listview. By default, the text used to create dividers is the uppercased first letter of the item's text. Alternatively you can specify divider text by setting the <code>autodividersSelector</code> option on the listview programmatically. Any existing dividers will be removed by default, prior to generating new dividers. To keep manually added dividers, add a <code>data-persist="true"</code> attribute. This feature is designed to work seamlessly with the filter.</p>
 			<div data-demo-html="true">
 				<ul data-role="listview" data-autodividers="true"  data-filter="true" data-inset="true">
 					<li><a href="index.html">Adam Kinkaid</a></li>

--- a/js/widgets/listview.autodividers.js
+++ b/js/widgets/listview.autodividers.js
@@ -31,9 +31,9 @@ $.mobile.document.delegate( "ul,ol", "listviewcreate", function() {
 	}
 
 	var replaceDividers = function () {
-		list.find( "li:jqmData(role='list-divider')" ).remove();
+		list.find( "li:jqmData(role='list-divider')" ).not( "li:jqmData(persist='true')" ).remove();
 
-		var lis = list.find( 'li' ),
+		var lis = list.find( 'li' ).not( "li:jqmData(role='list-divider')" ),
 			lastDividerText = null, li, dividerText;
 
 		for ( var i = 0; i < lis.length ; i++ ) {

--- a/js/widgets/listview.filter.js
+++ b/js/widgets/listview.filter.js
@@ -73,7 +73,7 @@ $.mobile.document.delegate( "ul, ol", "listviewcreate", function() {
 				listItems = list.children( ":not(.ui-screen-hidden)" );
 
 				if ( !listItems.not( persistentItems ).length && listview.options.filterReveal ) {
-					listItems = list.children( ".ui-screen-hidden" );
+					listItems = list.children();
 				}
 			}
 

--- a/js/widgets/listview.filter.js
+++ b/js/widgets/listview.filter.js
@@ -22,14 +22,17 @@ $.mobile.listview.prototype.options.filterCallback = defaultFilterCallback;
 $.mobile.document.delegate( "ul, ol", "listviewcreate", function() {
 
 	var list = $( this ),
-		listview = list.data( "mobile-listview" );
+		listview = list.data( "mobile-listview" ),
+		persistentItems = $( "li:jqmData(role='list-divider')" , this ).filter(function(){
+			return !!$( this ).nextUntil( "li:jqmData(role='list-divider')" , "li:jqmData(persist='true')").length;
+		}).add( "li:jqmData(persist='true')" );
 
 	if ( !listview.options.filter ) {
 		return;
 	}
 
 	if ( listview.options.filterReveal ) {
-		list.children().addClass( "ui-screen-hidden" );
+		list.children().not( persistentItems ).addClass( "ui-screen-hidden" );
 	}
 
 	var wrapper = $( "<form>", {
@@ -69,7 +72,7 @@ $.mobile.document.delegate( "ul, ol", "listviewcreate", function() {
 				// Only chars added, not removed, only use visible subset
 				listItems = list.children( ":not(.ui-screen-hidden)" );
 
-				if ( !listItems.length && listview.options.filterReveal ) {
+				if ( !listItems.not( persistentItems ).length && listview.options.filterReveal ) {
 					listItems = list.children( ".ui-screen-hidden" );
 				}
 			}
@@ -83,7 +86,12 @@ $.mobile.document.delegate( "ul, ol", "listviewcreate", function() {
 					item = $( listItems[ i ] );
 					itemtext = item.jqmData( "filtertext" ) || item.text();
 
-					if ( item.is( "li:jqmData(role=list-divider)" ) ) {
+					if ( item.is( "li:jqmData(persist=true)" ) ) {
+
+						// Flag for divider inclusion, do not modify visibility
+						childItems = !item.is( "li:jqmData(role='list-divider')" );
+
+					} else if ( item.is( "li:jqmData(role=list-divider)" ) ) {
 
 						item.toggleClass( "ui-filter-hidequeue" , !childItems );
 
@@ -115,7 +123,7 @@ $.mobile.document.delegate( "ul, ol", "listviewcreate", function() {
 			} else {
 
 				//filtervalue is empty => show all
-				listItems.toggleClass( "ui-screen-hidden", !!listview.options.filterReveal );
+				listItems.not( persistentItems ).toggleClass( "ui-screen-hidden", !!listview.options.filterReveal );
 			}
 			listview._addFirstLastClasses( li, listview._getVisibles( li, false ), false );
 		},

--- a/tests/unit/listview/index.html
+++ b/tests/unit/listview/index.html
@@ -245,6 +245,21 @@
 	</div>
 </div>
 
+<div data-nstest-role="page" id="autodividers-persist-test">
+	<div data-nstest-role="header" data-nstest-position="inline">
+		<h1>Autodivider with Persistence Test</h1>
+	</div>
+	<div data-nstest-role="content">
+		<ul data-nstest-role="listview" data-nstest-autodividers="true">
+			<li data-nstest-role="list-divider" data-nstest-persist="true">SHOULD KEEP</li>
+			<li>a is for aquaman</li>
+			<li>b is for batman</li>
+			<li>c is for catwoman</li>
+			<li>d is for darkwing</li>
+		</ul>
+	</div>
+</div>
+
 <div data-nstest-role="page" id="autodividers-selector-test">
 	<div data-nstest-role="header" data-nstest-position="inline">
 		<h1>Autodivider Selector Test</h1>
@@ -281,6 +296,21 @@
 	</div>
 </div>
 
+<!-- Search bar filter with persistence -->
+<div data-nstest-role="page" id='search-persist-test'>
+	<div data-nstest-role="header" data-nstest-position="inline">
+		<h1>Filter with Persistence</h1>
+	</div>
+	<div data-nstest-role="content">
+		<ul data-nstest-role="listview" data-nstest-filter="true">
+			<li>a is for aquaman</li>
+			<li data-nstest-persist="true">b is for batman</li>
+			<li>c is for catwoman</li>
+			<li>d is for darkwing</li>
+		</ul>
+	</div>
+</div>
+
 <!-- Search bar filter -->
 <div data-nstest-role="page" id='search-customfilter-test'>
 	<div data-nstest-role="header" data-nstest-position="inline">
@@ -307,6 +337,26 @@
 			<li>a is for aquaman</li>
 			<li data-nstest-role="list-divider">b</li>
 			<li>b is for batman</li>
+			<li data-nstest-role="list-divider">c</li>
+			<li>c is for catwoman</li>
+			<li data-nstest-role="list-divider">d</li>
+			<li>d is for darkwing</li>
+		</ul>
+	</div>
+</div>
+
+<!-- Search bar filter with list-dividers and persistence -->
+<div data-nstest-role="page" id='search-filter-with-dividers-persist-test'>
+	<div data-nstest-role="header" data-nstest-position="inline">
+		<h1>Filter with Dividers and Persist</h1>
+	</div>
+	<div data-nstest-role="content">
+		<ul data-nstest-role="listview" data-nstest-filter="true">
+			<li data-nstest-role="list-divider" data-nstest-persist="true">Superheros by Alpha</li>
+			<li data-nstest-role="list-divider">a</li>
+			<li>a is for aquaman</li>
+			<li data-nstest-role="list-divider">b</li>
+			<li data-nstest-persist="true">b is for batman</li>
 			<li data-nstest-role="list-divider">c</li>
 			<li>c is for catwoman</li>
 			<li data-nstest-role="list-divider">d</li>
@@ -362,6 +412,39 @@
         </ul>
     </div>
 </div>
+
+<!-- Search bar reveal filter with persistence -->
+<div data-nstest-role="page" id='search-filter-reveal-persist-test'>
+    <div data-nstest-role="header" data-nstest-position="inline">
+        <h1>Reveal Listview with Persistence</h1>
+    </div>
+    <div data-nstest-role="content">
+        <ul data-nstest-role="listview" data-nstest-filter="true" data-nstest-filter-reveal="true">
+            <li>Acura</a></li>
+            <li>Audi</li>
+            <li>BMW</li>
+            <li>Cadillac</li>
+            <li>Chrysler</li>
+            <li>Dodge</li>
+            <li>Ferrari</li>
+            <li data-nstest-persist="true">Ford</li>
+            <li>GMC</li>
+            <li>Honda</li>
+            <li>Hyundai</li>
+            <li>Infiniti</li>
+            <li>Jeep</li>
+            <li>Kia</li>
+            <li>Lexus</li>
+            <li>Mini</li>
+            <li>Nissan</li>
+            <li>Porsche</li>
+            <li>Subaru</li>
+            <li>Toyota</li>
+            <li>Volkswagon</li>
+            <li>Volvo</li>
+        </ul>
+    </div>
+</div><!-- /page -->
 
 <!-- Programmatically generated list items !-->
 <div data-nstest-role="page" id="programmatically-generated-list">

--- a/tests/unit/listview/listview_core.js
+++ b/tests/unit/listview/listview_core.js
@@ -345,6 +345,23 @@
 		]);
 	});
 
+	module( "Autodividers with Persistence" );
+
+	asyncTest( "Adds Autodividers but keep existing dividers flagged persistent", function() {
+		$.testHelper.pageSequence([
+			function() {
+				$.testHelper.openPage( '#autodividers-persist-test' );
+			},
+
+			function() {
+				var $new_page = $( '#autodividers-persist-test' );
+				ok( $new_page.hasClass( 'ui-page-active' ) );
+				ok( $new_page.find( '.ui-li-divider' ).length === 5 );
+				start();
+			}
+		]);
+	});
+
 	module( "Autodividers Selector" );
 
 	asyncTest( "Adds right divider text.", function() {
@@ -504,6 +521,40 @@
 		ok(ul.find("#fiz img").hasClass("ui-li-thumb"));
 	});
 
+	asyncTest( "Keep persistent items when the user enters information", function() {
+		var $searchPage = $("#search-persist-test");
+		$.testHelper.pageSequence([
+			function() {
+				$.mobile.changePage("#search-persist-test");
+			},
+
+			function() {
+				$searchPage.find('input').val('ar');
+				$searchPage.find('input').trigger('change');
+
+				deepEqual($searchPage.find('li.ui-screen-hidden').length, 2); // darkwing and batman (persist)
+				start();
+			}
+		]);
+	});
+
+	asyncTest( "Keep persistent items when user changes values", function() {
+		var $searchPage = $("#search-persist-test");
+		$.testHelper.pageSequence([
+			function() {
+				$.mobile.changePage("#search-persist-test");
+			},
+
+			function() {
+				$searchPage.find('input').val('a');
+				$searchPage.find('input').trigger('change');
+
+				deepEqual($searchPage.find("li[style^='display: none;']").length, 0);
+				start();
+			}
+		]);
+	});
+
 	asyncTest( "Filter downs results and dividers when the user enters information", function() {
 		var	$searchPage = $("#search-filter-with-dividers-test");
 		$.testHelper.pageSequence([
@@ -559,6 +610,73 @@
 				var $page = $('.ui-page-active');
 
 				$page.find('input').val('at');
+				$page.find('input').trigger('change');
+
+				setTimeout(function() {
+					deepEqual($page.find('li:jqmData(role=list-divider):hidden').length, 2);
+					deepEqual($page.find('li:jqmData(role=list-divider):hidden + li:not(:jqmData(role=list-divider)):hidden').length, 2);
+					deepEqual($page.find('li:jqmData(role=list-divider):not(:hidden) + li:not(:jqmData(role=list-divider)):not(:hidden)').length, 2);
+					start();
+				}, 1000);
+			}
+		]);
+	});
+
+	asyncTest( "Keep persistent items and dividers when the user enters information", function() {
+		var	$searchPage = $("#search-filter-with-dividers-persist-test");
+		$.testHelper.pageSequence([
+			function() {
+				$.mobile.changePage("#search-filter-with-dividers-persist-test");
+			},
+
+			// wait for the page to become active/enhanced
+			function(){
+				$searchPage.find('input').val('ar');
+				$searchPage.find('input').trigger('change');
+				setTimeout(function() {
+					//there should be four hidden list entries
+					deepEqual($searchPage.find('li.ui-screen-hidden').length, 4);
+
+					//there should be two list entries that are list dividers and hidden
+					deepEqual($searchPage.find('li.ui-screen-hidden:jqmData(role=list-divider)').length, 2);
+
+					//there should be two list entries that are not list dividers and hidden
+					deepEqual($searchPage.find('li.ui-screen-hidden:not(:jqmData(role=list-divider))').length, 2);
+					start();
+				}, 1000);
+			}
+		]);
+	});
+
+	asyncTest( "Keep persistent items and dividers when user removes values", function() {
+		$.testHelper.pageSequence([
+			function() {
+				$.mobile.changePage("#search-filter-with-dividers-persist-test");
+			},
+
+			function() {
+				$('.ui-page-active input').val('a');
+				$('.ui-page-active input').trigger('change');
+
+				setTimeout(function() {
+					deepEqual($('.ui-page-active input').val(), 'a');
+					deepEqual($('.ui-page-active li[style^="display: none;"]').length, 0);
+					start();
+				}, 1000);
+			}
+		]);
+	});
+
+	asyncTest( "Dividers are hidden when preceding hidden rows and shown when preceding shown rows", function () {
+		$.testHelper.pageSequence([
+			function() {
+				$.mobile.changePage("#search-filter-with-dividers-persist-test");
+			},
+
+			function() {
+				var $page = $('.ui-page-active');
+
+				$page.find('input').val('ar');
 				$page.find('input').trigger('change');
 
 				setTimeout(function() {
@@ -736,6 +854,34 @@
 			}
 		]);
 	});
+
+	asyncTest( "Keep persistent items when the user enters information", 3, function() {
+		var $searchPage = $( "#search-filter-reveal-persist-test" );
+		$.testHelper.pageSequence([
+			function() {
+				$.mobile.changePage( $searchPage );
+			},
+
+			function() {
+				deepEqual( $searchPage.find( 'li.ui-screen-hidden' ).length, 21);
+			},
+
+			function() {
+				$searchPage.find( 'input' ).val( 'a' );
+				$searchPage.find( 'input' ).trigger('change');
+
+				deepEqual( $searchPage.find('li.ui-screen-hidden').length, 10);
+			},
+
+			function() {
+				$searchPage.find( 'input' ).val( '' );
+				$searchPage.find( 'input' ).trigger('change');
+
+				deepEqual( $searchPage.find('li.ui-screen-hidden').length, 21);
+				start();
+			}
+		]);
+	}); // commit fix
 
 	module( "Programmatically generated list items", {
 		setup: function(){


### PR DESCRIPTION
This pull request adds a `data-persist` option for Listview items that will keep it visible for a few different Listview "modes":
1. **Autodividers** - When a `data-role="list-divider"` also has the attribute `data-persist="true"` the "manually added" divider will NOT be removed, keeping it visible
2. **Filter** - When a user enters criteria, the `data-persist="true"` list items/dividers will always stay visible
3. **Reveal Filter** - When a reveal filter is initialized or the user enters criteria, the `data-persist="true"` list items/dividers will always stay visible

I've also included documentation changes to briefly mention this feature along with related test cases. If accepted, I'll also submit a API Pull Request to update documentation changes there.

Thank you for considering this feature. I'm more than willing to answer questions, make changes as needed.
