### PR TITLE
Disabled textarea don't get extra height for an extra line

### DIFF
--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -125,7 +125,11 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 					clientHeight = input[ 0 ].clientHeight;
 
 				if ( clientHeight < scrollHeight ) {
-					input.height( scrollHeight + extraLineHeight );
+					if ( this.options.disabled ) {
+						input.height( scrollHeight );
+					} else {
+						input.height( scrollHeight + extraLineHeight );
+					}
 				}
 			};
 


### PR DESCRIPTION
This is a fix for #5688.
