### PR TITLE
Automatic resizing now works for disabled textareas with pre-filled values

### DIFF
--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -136,13 +136,13 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 
 			// binding to pagechange here ensures that for pages loaded via
 			// ajax the height is recalculated without user input
-			this._on( $.mobile.document, { "pagechange": "_keyup" });
+			this._on( true, $.mobile.document, { "pagechange": "_keyup" });
 
 			// Issue 509: the browser is not providing scrollHeight properly until the styles load
 			if ( $.trim( input.val() ) ) {
 				// bind to the window load to make sure the height is calculated based on BOTH
 				// the DOM and CSS
-				this._on( $.mobile.window, {"load": "_keyup"});
+				this._on( true, $.mobile.window, {"load": "_keyup"});
 			}
 		}
 		if ( input.attr( "disabled" ) ) {


### PR DESCRIPTION
This is a fix for #509. See my [comment](https://github.com/jquery/jquery-mobile/issues/509#issuecomment-14012937) because the issue changed through time.
