### PR TITLE
Textinput: height correctly calculated (without extra padding) for box-sizing

### DIFF
--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -125,7 +125,8 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 					clientHeight = input[ 0 ].clientHeight;
 
 				if ( clientHeight < scrollHeight ) {
-					input.height( scrollHeight + extraLineHeight );
+					var paddingHeight = parseFloat( input.css( "padding-top" ) ) + parseFloat( input.css( "padding-top" ) );
+					input.height( scrollHeight - paddingHeight + ( this.options.disabled ? 0 : extraLineHeight ) );
 				}
 			};
 


### PR DESCRIPTION
Fixes #5690. As I explained there, scrollHeight contains the padding of the element as well, while the height passed to `.height()` should only be of the content. Because of that we subtract the padding height.
