### PR TITLE
buttonMarkup called many times on init

### DIFF
--- a/js/widgets/forms/button.js
+++ b/js/widgets/forms/button.js
@@ -24,20 +24,8 @@ $.widget( "mobile.button", $.mobile.widget, {
 	_create: function() {
 		var $el = this.element,
 			$button,
-			// create a copy of this.options we can pass to buttonMarkup
-			o = ( function( tdo ) {
-				var key, ret = {};
-
-				for ( key in tdo ) {
-					if ( tdo[ key ] !== null && key !== "initSelector" ) {
-						ret[ key ] = tdo[ key ];
-					}
-				}
-
-				return ret;
-			} )( this.options ),
-			classes = "",
-			$buttonPlaceholder;
+			o,
+			classes = "";
 
 		// if this is a link, check if it's been enhanced and, if not, use the right function
 		if ( $el[ 0 ].tagName === "A" ) {
@@ -46,6 +34,18 @@ $.widget( "mobile.button", $.mobile.widget, {
 			}
 			return;
 		}
+		// create a copy of this.options we can pass to buttonMarkup
+		o = ( function( tdo ) {
+			var key, ret = {};
+
+			for ( key in tdo ) {
+				if ( tdo[ key ] !== null && key !== "initSelector" ) {
+					ret[ key ] = tdo[ key ];
+				}
+			}
+
+			return ret;
+		} )( this.options );
 
 		// get the inherited theme
 		// TODO centralize for all widgets
@@ -70,6 +70,7 @@ $.widget( "mobile.button", $.mobile.widget, {
 		}
 		$( "label[for='" + $el.attr( "id" ) + "']" ).addClass( "ui-submit" );
 
+		o.disabled = $el.prop("disabled");
 		// Add ARIA role
 		this.button = $( "<div></div>" )
 			[ $el.html() ? "html" : "text" ]( $el.html() || $el.val() )
@@ -90,7 +91,9 @@ $.widget( "mobile.button", $.mobile.widget, {
 			}
 		});
 
+		this._initialRefresh = true;
 		this.refresh();
+		this._initialRefresh = false;
 	},
 
 	_setOption: function( key, value ) {
@@ -98,7 +101,10 @@ $.widget( "mobile.button", $.mobile.widget, {
 
 		op[ key ] = value;
 		if ( key !== "initSelector" ) {
-			this.button.buttonMarkup( op );
+			if (!this._initialRefresh) {
+				//make sure buttonMarkup is called only once on create
+				this.button.buttonMarkup( op );
+			}
 			// Record the option change in the options and in the DOM data-* attributes
 			this.element.attr( "data-" + ( $.mobile.ns || "" ) + ( key.replace( /([A-Z])/, "-$1" ).toLowerCase() ), value );
 		}

--- a/js/widgets/forms/checkboxradio.js
+++ b/js/widgets/forms/checkboxradio.js
@@ -57,13 +57,13 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, $.extend( {
 			o.theme = $.mobile.getInheritedTheme( this.element, "c" );
 		}
 
-		label.buttonMarkup({
+		//save buttonMarkup options to use them in refresh
+		this._labelButtonMarkupOptions = {
 			theme: o.theme,
-			icon: uncheckedState,
 			shadow: false,
 			mini: mini,
 			iconpos: iconpos
-		});
+		};
 
 		// Wrap the input + label in a div
 		var wrapper = document.createElement('div');
@@ -138,6 +138,7 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, $.extend( {
 
 		this._handleFormReset();
 		this.refresh();
+		this._labelButtonMarkupOptions = null;
 	},
 
 	_cacheVals: function() {
@@ -177,12 +178,15 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, $.extend( {
 		var input = this.element[ 0 ],
 			active = " " + $.mobile.activeBtnClass,
 			checkedClass = this.checkedClass + ( this.element.parents( ".ui-controlgroup-horizontal" ).length ? active : "" ),
-			label = this.label;
+			label = this.label,
+			options = this._labelButtonMarkupOptions || {};
 
 		if ( input.checked ) {
-			label.removeClass( this.uncheckedClass + active ).addClass( checkedClass ).buttonMarkup( { icon: this.checkedicon } );
+			options.icon = this.checkedicon;
+			label.removeClass( this.uncheckedClass + active ).addClass( checkedClass ).buttonMarkup( options );
 		} else {
-			label.removeClass( checkedClass ).addClass( this.uncheckedClass ).buttonMarkup( { icon: this.uncheckedicon } );
+			options.icon = this.uncheckedicon;
+			label.removeClass( checkedClass ).addClass( this.uncheckedClass ).buttonMarkup( options );
 		}
 
 		if ( input.disabled ) {

--- a/js/widgets/forms/slider.js
+++ b/js/widgets/forms/slider.js
@@ -58,8 +58,7 @@ $.widget( "mobile.slider", $.mobile.widget, $.extend( {
 		domHandle.className = "ui-slider-handle";
 		domSlider.appendChild( domHandle );
 
-		handle.buttonMarkup({ corners: true, theme: theme, shadow: true })
-				.attr({
+		handle.attr({
 					"role": "slider",
 					"aria-valuemin": min,
 					"aria-valuemax": max,


### PR DESCRIPTION
I found that buttonMarkup is called many times on the same objects at init.
- Slider - calls with the same params in create and refresh (which is called by create...)
- Button - in refresh calls again only to send option disabled true/false - disabled param is ignored by buttonMarkup but I didn't remove it.
- Checkboxradio - calls again to determine checked state and change icon

I made 3 commits because Slider is a bug and should be merged, in 2 others I use solution which may not be accepted :)

buttonMarkup is also called again on the same objects when controlgroup and rangeslider is used - both widgets call refresh on checkboxes and sliders inside them. I haven't found solution yet. This should probably fixed in other way.
