### PR TITLE
Update textinput.js - 'refresh'  method for textinput

### DIFF
--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -178,6 +178,10 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 		}
 		$el.removeClass( "ui-disabled" );
 		return this._setOption( "disabled", false );
+	},
+	
+	refresh: function() {
+		this.element.trigger("change"); 
 	}
 });
 


### PR DESCRIPTION
reference to https://github.com/jquery/jquery-mobile/issues/5708

added 'refresh' method to textinput by triggering 'change' on input.
assuming 'clearBtn' is the only possible item to refresh.

test case : http://jsbin.com/onibuc/338/
