### PR TITLE
_private: New NS to bunch up stuff that has to be exposed to other parts...

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -16,6 +16,10 @@ define( [ "jquery", "./jquery.mobile.ns", "json!../package.json" ], function( jQ
 	// jQuery.mobile configurable options
 	$.mobile = $.extend($.mobile, {
 
+		// Functions internal to the library, which need to be shared across modules
+		// should be defined here
+		_private: {},
+
 		// Version of the jQuery Mobile Framework
 		version: __version__,
 

--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -250,7 +250,7 @@ define( [
 	$window.bind( "scrollstop", delayedSetLastScroll );
 
 	// No-op implementation of transition degradation
-	$.mobile._maybeDegradeTransition = $.mobile._maybeDegradeTransition || function( transition ) {
+	$.mobile._private.maybeDegradeTransition = $.mobile._private.maybeDegradeTransition || function( transition ) {
 		return transition;
 	};
 
@@ -266,7 +266,7 @@ define( [
 		//clear page loader
 		$.mobile.hidePageLoadingMsg();
 
-		transition = $.mobile._maybeDegradeTransition( transition );
+		transition = $.mobile._private.maybeDegradeTransition( transition );
 
 		//find the transition handler for the specified transition. If there
 		//isn't one in our transitionHandlers dictionary, use the default one.
@@ -346,7 +346,7 @@ define( [
 	//enable cross-domain page support
 	$.mobile.allowCrossDomainPages = false;
 
-	$.mobile._bindPageRemove = function() {
+	$.mobile._private.bindPageRemove = function() {
 		var page = $( this );
 
 		// when dom caching is not enabled or the page is embedded bind to remove the page on hide
@@ -584,7 +584,7 @@ define( [
 						.appendTo( settings.pageContainer );
 
 					// wait for page creation to leverage options defined on widget
-					page.one( 'pagecreate', $.mobile._bindPageRemove );
+					page.one( 'pagecreate', $.mobile._private.bindPageRemove );
 
 					enhancePage( page, settings.role );
 
@@ -995,7 +995,7 @@ define( [
 	//The following event bindings should be bound after mobileinit has been triggered
 	//the following deferred is resolved in the init file
 	$.mobile.navreadyDeferred = $.Deferred();
-	$.mobile._registerInternalEvents = function() {
+	$.mobile._private.registerInternalEvents = function() {
 		var getAjaxFormData = function( $form, calculateOnly ) {
 			var type, target, url, ret = true, formData, vclickedName;
 			if ( !$.mobile.ajaxEnabled ||
@@ -1259,7 +1259,7 @@ define( [
 			});
 		});
 
-		$.mobile._handleHashChange = function( url, data ) {
+		$.mobile._private.handleHashChange = function( url, data ) {
 			//find first page via hash
 			var to = path.stripHash(url),
 				//transition is false if it's the first page, undefined otherwise (and may be overridden by default)
@@ -1347,7 +1347,7 @@ define( [
 				url = location.href;
 			}
 
-			$.mobile._handleHashChange( url, data.state );
+			$.mobile._private.handleHashChange( url, data.state );
 		});
 
 		//set page min-heights to be device specific
@@ -1358,7 +1358,7 @@ define( [
 
 	$( function() { domreadyDeferred.resolve(); } );
 
-	$.when( domreadyDeferred, $.mobile.navreadyDeferred ).done( function() { $.mobile._registerInternalEvents(); } );
+	$.when( domreadyDeferred, $.mobile.navreadyDeferred ).done( function() { $.mobile._private.registerInternalEvents(); } );
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/jquery.mobile.transition.js
+++ b/js/jquery.mobile.transition.js
@@ -160,7 +160,7 @@ $.mobile.transitionHandlers = {
 $.mobile.transitionFallbacks = {};
 
 // If transition is defined, check if css 3D transforms are supported, and if not, if a fallback is specified
-$.mobile._maybeDegradeTransition = function( transition ) {
+$.mobile._private.maybeDegradeTransition = function( transition ) {
 		if ( transition && !$.support.cssTransform3d && $.mobile.transitionFallbacks[ transition ] ) {
 			transition = $.mobile.transitionFallbacks[ transition ];
 		}

--- a/js/widgets/forms/select.custom.js
+++ b/js/widgets/forms/select.custom.js
@@ -252,7 +252,7 @@ define( [
 					// of a dialog sized custom select
 					//
 					// doing this here provides for the back button on the custom select dialog
-					$.mobile._bindPageRemove.call( self.thisPage );
+					$.mobile._private.bindPageRemove.call( self.thisPage );
 				});
 
 				// Events on the popup

--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -320,7 +320,7 @@ define( [
 		_applyTransition: function( value ) {
 			this._ui.container.removeClass( this._fallbackTransition );
 			if ( value && value !== "none" ) {
-				this._fallbackTransition = $.mobile._maybeDegradeTransition( value );
+				this._fallbackTransition = $.mobile._private.maybeDegradeTransition( value );
 				if ( this._fallbackTransition === "none" ) {
 					this._fallbackTransition = "";
 				}


### PR DESCRIPTION
... of the library

_handleHashChange and _registerInternalEvents do not need to be exposed at all, because they are internal to jquery.mobile.navigation.js. Nevertheless, there's a plugin (splitview) that uses _registerInternalEvents (https://github.com/jquery/jquery-mobile/issues/4984) so we should probably keep exposing it as private, at least until we also implement the ability to work with multiple page containers, presumably rendering the plugin obsolete. I'm not sure if _handleHashChange could be un-exposed. We can try it and see if it causes an uproar.
