### PR TITLE
Performance: Lazy widget initialization.

### DIFF
--- a/js/jquery.mobile.widget.js
+++ b/js/jquery.mobile.widget.js
@@ -39,8 +39,20 @@ $.widget( "mobile.widget", {
 		return options;
 	},
 
-	enhanceWithin: function( target, useKeepNative ) {
-		this.enhance( $( this.options.initSelector, $( target )), useKeepNative );
+	enhanceWithin: function( target, useKeepNative, selector, widgetName, istarget ) {
+
+		// check what widgets are needed on a Web App. page.
+		// "istarget" is true in case of dialog widget.
+		var $targets = istarget ? $( target ) :  $( selector, $( target ));
+		if ( $targets.length ) {
+
+			// If the widget havn't been used, add the widget to $.mobile[] object
+			// to check whether the widget is loaded or not.
+			if ( !$.mobile[ widgetName ] ) {
+				$.mobile.registeWidget( widgetName );
+			}
+			$.mobile[ widgetName ].prototype.enhance( $targets, useKeepNative );
+		}
 	},
 
 	enhance: function( targets, useKeepNative ) {

--- a/js/jquery.ui.widget.js
+++ b/js/jquery.ui.widget.js
@@ -208,6 +208,47 @@ $.widget.bridge = function( name, object ) {
 	};
 };
 
+// To store variables of $.widget() methods - "$.widget( "widget name", ..., { ... });"
+$.mobile.widgetReigsters = {};
+
+// Add a variable for $.widget() method call into $.mobile.widgetReigsters[] object
+// to store the variable and check dependencies of widgets.
+// Each widget's IIFE calls $.mobile.addWidgetRegister() method.
+$.mobile.addWidgetRegister = function ( widgetName, register, dependencies ) {
+	var index,
+		length = dependencies ? dependencies.length : 0;
+	if ( !$.mobile.widgetReigsters[ widgetName ] ) {
+		$.mobile.widgetReigsters[ widgetName ] = {
+			widgetmethods : [],
+			dependencies : []
+		};
+	}
+	if ( register ) {
+		$.mobile.widgetReigsters[ widgetName ].widgetmethods.push( register );
+	}
+	for ( index = 0 ; index < length ; index++ ) {
+		$.mobile.widgetReigsters[ widgetName ].dependencies.push( dependencies[ index ] );
+	}
+};
+
+// Check dependencies and call $.widget() methods
+$.mobile.registeWidget = function ( widgetName ) {
+	var $registers = $.mobile.widgetReigsters[ widgetName ],
+		widgetReigsters = $registers ? $registers.widgetmethods : [],
+		dependencies = $registers ? $registers.dependencies : [],
+		index;
+
+	for ( index = 0 ; index < dependencies.length ; index++ ) {
+		if ( !$.mobile[ dependencies[ index ] ] ) {
+			$.mobile.registeWidget( dependencies[ index ] );
+		}
+	}
+
+	for ( index = 0 ; index < widgetReigsters.length ; index++ ) {
+		widgetReigsters[ index ]();
+	}
+};
+
 $.Widget = function( /* options, element */ ) {};
 $.Widget._childConstructors = [];
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.buttonMarkup" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "collapsible",
+	selector = ":jqmData(role='collapsible')";
 
+var widgetRegister = function () {
 $.widget( "mobile.collapsible", $.mobile.widget, {
 	options: {
 		expandCueText: " click to expand contents",
@@ -156,10 +159,13 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 			});
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.collapsible.prototype.enhanceWithin( e.target );
+	$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/collapsibleSet.js
+++ b/js/widgets/collapsibleSet.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../jquery.mobile.widget", "./collapsible", "./addFirstLastClasses" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "collapsibleset",
+	selector = ":jqmData(role='collapsible-set')";
 
+var widgetRegister = function () {
 $.widget( "mobile.collapsibleset", $.mobile.widget, $.extend( {
 	options: {
 		initSelector: ":jqmData(role='collapsible-set')"
@@ -79,10 +82,13 @@ $.widget( "mobile.collapsibleset", $.mobile.widget, $.extend( {
 		this._refresh( false );
 	}
 }, $.mobile.behaviors.addFirstLastClasses ) );
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.collapsibleset.prototype.enhanceWithin( e.target );
+	$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/controlgroup.js
+++ b/js/widgets/controlgroup.js
@@ -11,7 +11,10 @@ define( [ "jquery",
 	"../jquery.mobile.widget" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "controlgroup",
+	selector = ":jqmData(role='controlgroup')";
 
+var widgetRegister = function () {
 	$.widget( "mobile.controlgroup", $.mobile.widget, $.extend( {
 		options: {
 			shadow: false,
@@ -96,6 +99,9 @@ define( [ "jquery",
 			this._initialRefresh = false;
 		}
 	}, $.mobile.behaviors.addFirstLastClasses ) );
+};
+
+	$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 	// TODO: Implement a mechanism to allow widgets to become enhanced in the
 	// correct order when their correct enhancement depends on other widgets in
@@ -104,7 +110,7 @@ define( [ "jquery",
 	// Dom ready was insufficient for preventing timing issues, use the page init
 	// event to run this widget after all else. Widget registry incoming.
 	$.mobile.document.bind( "pageinit create", function( e )  {
-		$.mobile.controlgroup.prototype.enhanceWithin( e.target, true );
+		$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName, false );
 	});
 })(jQuery);
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);

--- a/js/widgets/dialog.js
+++ b/js/widgets/dialog.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.navigation" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, window, undefined ) {
+var widgetName = "dialog",
+	selector = ":jqmData(role='dialog')";
 
+var widgetRegister = function () {
 $.widget( "mobile.dialog", $.mobile.widget, {
 	options: {
 		closeBtn: "left",
@@ -156,10 +159,13 @@ $.widget( "mobile.dialog", $.mobile.widget, {
 		}
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
-$.mobile.document.delegate( $.mobile.dialog.prototype.options.initSelector, "pagecreate", function() {
-	$.mobile.dialog.prototype.enhance( this );
+$.mobile.document.delegate( selector, "pagecreate", function() {
+	$.mobile.widget.prototype.enhanceWithin( this, false, selector, widgetName, true );
 });
 
 })( jQuery, this );

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -8,8 +8,10 @@
 define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jquery.mobile.navigation", "./page", "./page.sections", "../jquery.mobile.zoom" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var selector = ":jqmData(position='fixed')",
+	widgetName = "fixedtoolbar";
 
-
+var widgetRegister = function () {
 	$.widget( "mobile.fixedtoolbar", $.mobile.widget, {
 		options: {
 			visibleOnPageShow: true,
@@ -268,6 +270,9 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 		}
 
 	});
+};
+
+	$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 	//auto self-init widgets
 	$.mobile.document
@@ -279,7 +284,7 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 				$( $.mobile.fixedtoolbar.prototype.options.initSelector, e.target ).not( ":jqmData(fullscreen)" ).jqmData( "fullscreen", true );
 			}
 
-			$.mobile.fixedtoolbar.prototype.enhanceWithin( e.target );
+			$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName );
 		});
 
 })( jQuery );

--- a/js/widgets/fixedToolbar.workarounds.js
+++ b/js/widgets/fixedToolbar.workarounds.js
@@ -6,6 +6,9 @@
 define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jquery.mobile.navigation", "./page", "./page.sections", "../jquery.mobile.zoom", "./fixedToolbar" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = 'fixedtoolbar';
+
+var	widgetRegister = function() {
 	$.widget( "mobile.fixedtoolbar", $.mobile.fixedtoolbar, {
 
 			_create: function() {
@@ -97,6 +100,9 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 				this.element.closest(".ui-page-active").removeClass( "ui-android-2x-fix" );
 			}
 	});
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 	})( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);

--- a/js/widgets/forms/button.js
+++ b/js/widgets/forms/button.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../../jquery.mobile.widget", "../../jquery.mobile.buttonMarkup"  ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "button",
+	selector = "button, [type='button'], [type='submit'], [type='reset']";
 
+var widgetRegister = function () {
 function splitOptions( o ) {
 	var key, ret = { btn: {}, widget: {} };
 
@@ -155,10 +158,13 @@ $.widget( "mobile.button", $.mobile.widget, {
 		$( this.button.data( 'buttonElements' ).text )[ $el.html() ? "html" : "text" ]( $el.html() || $el.val() );
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.button.prototype.enhanceWithin( e.target, true );
+	$.mobile.widget.prototype.enhanceWithin( e.target, true, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/forms/checkboxradio.js
+++ b/js/widgets/forms/checkboxradio.js
@@ -12,7 +12,10 @@
 define( [ "jquery", "../../jquery.mobile.core", "../../jquery.mobile.widget", "../../jquery.mobile.buttonMarkup", "./reset" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "checkboxradio",
+	selector = "input[type='checkbox'],input[type='radio']";
 
+var widgetRegister = function () {
 $.widget( "mobile.checkboxradio", $.mobile.widget, $.extend( {
 	options: {
 		theme: null,
@@ -207,10 +210,13 @@ $.widget( "mobile.checkboxradio", $.mobile.widget, $.extend( {
 		this.element.prop( "disabled", false ).parent().removeClass( "ui-disabled" );
 	}
 }, $.mobile.behaviors.formReset ) );
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.checkboxradio.prototype.enhanceWithin( e.target, true );
+	$.mobile.widget.prototype.enhanceWithin( e.target, true, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/forms/rangeslider.js
+++ b/js/widgets/forms/rangeslider.js
@@ -8,6 +8,10 @@
 define( [ "jquery", "../../jquery.mobile.core", "../../jquery.mobile.widget", "./textinput", "../../jquery.mobile.buttonMarkup", "./reset", "./slider" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "rangeslider",
+	selector = ":jqmData(role='rangeslider')";
+
+var widgetRegister = function () {
 	$.widget( "mobile.rangeslider", $.mobile.widget, $.extend( {
 
 		options: {
@@ -194,10 +198,13 @@ define( [ "jquery", "../../jquery.mobile.core", "../../jquery.mobile.widget", ".
 		}
 
 	}, $.mobile.behaviors.formReset ) );
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $( document ).bind( "pagecreate create", function( e ) {
-	$.mobile.rangeslider.prototype.enhanceWithin( e.target, true );
+	$.mobile.widget.prototype.enhanceWithin( e.target, true, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/forms/select.custom.js
+++ b/js/widgets/forms/select.custom.js
@@ -544,6 +544,8 @@ define( [
 		});
 	};
 
+	$.mobile.addWidgetRegister( 'selectmenu', undefined, [ 'popup', 'listview' ] );
+
 	// issue #3894 - core doesn't trigger events on disabled delegates
 	$.mobile.document.bind( "selectmenubeforecreate", function( event ) {
 		var selectmenuWidget = $( event.target ).data( "mobile-selectmenu" );

--- a/js/widgets/forms/select.js
+++ b/js/widgets/forms/select.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../../jquery.mobile.core", "../../jquery.mobile.widget", "../../jquery.mobile.buttonMarkup", "../../jquery.mobile.zoom", "./reset" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "selectmenu",
+	selector = "select:not( :jqmData(role='slider') )";
 
+var widgetRegister = function () {
 $.widget( "mobile.selectmenu", $.mobile.widget, $.extend( {
 	options: {
 		theme: null,
@@ -285,10 +288,13 @@ $.widget( "mobile.selectmenu", $.mobile.widget, $.extend( {
 		this.button.removeClass( "ui-disabled" );
 	}
 }, $.mobile.behaviors.formReset ) );
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.selectmenu.prototype.enhanceWithin( e.target, true );
+	$.mobile.widget.prototype.enhanceWithin( e.target, true, selector, widgetName, false );
 });
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);

--- a/js/widgets/forms/slider.js
+++ b/js/widgets/forms/slider.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../../jquery.mobile.core", "../../jquery.mobile.widget", "./textinput", "../../jquery.mobile.buttonMarkup", "./reset" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "slider",
+	selector = "input[type='range'], :jqmData(type='range'), :jqmData(role='slider')";
 
+var widgetRegister = function () {
 $.widget( "mobile.slider", $.mobile.widget, $.extend( {
 	widgetEventPrefix: "slide",
 
@@ -503,10 +506,13 @@ $.widget( "mobile.slider", $.mobile.widget, $.extend( {
 	}
 
 }, $.mobile.behaviors.formReset ) );
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.slider.prototype.enhanceWithin( e.target, true );
+	$.mobile.widget.prototype.enhanceWithin( e.target, true, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/forms/slider.tooltip.js
+++ b/js/widgets/forms/slider.tooltip.js
@@ -8,7 +8,9 @@
 define( [ "jquery", "./slider" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "slider";
 
+var widgetRegister = function () {
 $.widget( "mobile.slider", $.mobile.slider, {
 	options: {
 		popupEnabled: false,
@@ -116,6 +118,9 @@ $.widget( "mobile.slider", $.mobile.slider, {
 		}
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);

--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../../jquery.mobile.core", "../../jquery.mobile.widget", "../../jquery.mobile.degradeInputs", "../../jquery.mobile.buttonMarkup", "../../jquery.mobile.zoom"  ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "textinput",
+	selector = "input[type='text'], input[type='search'], :jqmData(type='search'), input[type='number'], :jqmData(type='number'), input[type='password'], input[type='email'], input[type='url'], input[type='tel'], textarea, input[type='time'], input[type='date'], input[type='month'], input[type='week'], input[type='datetime'], input[type='datetime-local'], input[type='color'], input:not([type]), input[type='file']";
 
+var widgetRegister = function () {
 $.widget( "mobile.textinput", $.mobile.widget, {
 	options: {
 		theme: null,
@@ -180,10 +183,13 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 		return this._setOption( "disabled", false );
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.textinput.prototype.enhanceWithin( e.target, true );
+	$.mobile.widget.prototype.enhanceWithin( e.target, true, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/listview.autodividers.js
+++ b/js/widgets/listview.autodividers.js
@@ -5,7 +5,7 @@
 define( [ "jquery", "./listview" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
-
+var widgetRegister = function () {
 $.mobile.listview.prototype.options.autodividers = false;
 $.mobile.listview.prototype.options.autodividersSelector = function( elt ) {
 	// look for the text in the given element
@@ -20,6 +20,9 @@ $.mobile.listview.prototype.options.autodividersSelector = function( elt ) {
 
 	return text;
 };
+};
+
+$.mobile.addWidgetRegister( 'listview', widgetRegister );
 
 $.mobile.document.delegate( "ul,ol", "listviewcreate", function() {
 

--- a/js/widgets/listview.filter.js
+++ b/js/widgets/listview.filter.js
@@ -7,7 +7,7 @@
 define( [ "jquery", "./listview", "./forms/textinput" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
-
+var widgetRegister = function () {
 $.mobile.listview.prototype.options.filter = false;
 $.mobile.listview.prototype.options.filterPlaceholder = "Filter items...";
 $.mobile.listview.prototype.options.filterTheme = "c";
@@ -18,6 +18,9 @@ var defaultFilterCallback = function( text, searchValue, item ) {
 	};
 
 $.mobile.listview.prototype.options.filterCallback = defaultFilterCallback;
+};
+
+$.mobile.addWidgetRegister( 'listview', widgetRegister );
 
 $.mobile.document.delegate( "ul, ol", "listviewcreate", function() {
 	var list = $( this ),

--- a/js/widgets/listview.js
+++ b/js/widgets/listview.js
@@ -13,7 +13,10 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.buttonMarkup", 
 //This allows support for multiple nested list in the same page
 //https://github.com/jquery/jquery-mobile/issues/1617
 var listCountPerPage = {};
+var selector = ":jqmData(role='listview')",
+	widgetName = "listview";
 
+var widgetRegister = function () {
 $.widget( "mobile.listview", $.mobile.widget, $.extend( {
 
 	options: {
@@ -379,10 +382,13 @@ $.widget( "mobile.listview", $.mobile.widget, $.extend( {
 		return $( ":jqmData(url^='"+  parentUrl + "&" + $.mobile.subPageUrlKey + "')" );
 	}
 }, $.mobile.behaviors.addFirstLastClasses ) );
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.listview.prototype.enhanceWithin( e.target );
+	$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName );
 });
 
 })( jQuery );

--- a/js/widgets/navbar.js
+++ b/js/widgets/navbar.js
@@ -9,7 +9,10 @@
 define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.buttonMarkup", "../jquery.mobile.grid" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "navbar",
+	selector = ":jqmData(role='navbar')";
 
+var widgetRegister = function () {
 $.widget( "mobile.navbar", $.mobile.widget, {
 	options: {
 		iconpos: "top",
@@ -55,10 +58,13 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 		});
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.navbar.prototype.enhanceWithin( e.target );
+	$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../jquery.mobile.widget", "./page", "./page.sections" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "panel",
+	selector = ":jqmData(role='panel')";
 
+var widgetRegister = function () {
 $.widget( "mobile.panel", $.mobile.widget, {
 	options: {
 		classes: {
@@ -457,10 +460,13 @@ $.widget( "mobile.panel", $.mobile.widget, {
 			.removeClass( [ classes.panelUnfixed, classes.panelClosed, classes.panelOpen ].join( " " ) );
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $( document ).bind( "pagecreate create", function( e ) {
-	$.mobile.panel.prototype.enhanceWithin( e.target );
+	$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/popup.arrow.js
+++ b/js/widgets/popup.arrow.js
@@ -11,7 +11,9 @@ function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 
 ( function( $, undefined ) {
+var widgetName = "popup";
 
+var widgetRegister = function () {
 var ieHack = ( $.mobile.browser.oldIE && $.mobile.browser.oldIE <= 8 ),
 	uiTemplate = $(
 		'<div class="arrow-guide"></div>' +
@@ -212,6 +214,9 @@ $.widget( "mobile.popup", $.mobile.popup, {
 		}
 	}
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 })( jQuery );
 

--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -24,7 +24,10 @@ define( [
 	"depend!../jquery.hashchange[jquery]" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "popup",
+	selector = ":jqmData(role='popup')";
 
+var widgetRegister = function () {
 	function fitSegmentInsideSegment( winSize, segSize, offset, desired ) {
 		var ret = desired;
 
@@ -897,6 +900,9 @@ define( [
 			$link.removeClass( $.mobile.activeBtnClass );
 		}, 300 );
 	};
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 	// TODO move inside _create
 	$.mobile.document.bind( "pagebeforechange", function( e, data ) {
@@ -907,7 +913,7 @@ define( [
 	});
 
 	$.mobile.document.bind( "pagecreate create", function( e )  {
-		$.mobile.popup.prototype.enhanceWithin( e.target, true );
+		$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName, false );
 	});
 
 })( jQuery );

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -8,7 +8,7 @@
 define( [ "jquery", "./table", "../jquery.mobile.buttonMarkup", "./popup", "../jquery.mobile.fieldContain", "widgets/controlgroup", "widgets/forms/checkboxradio" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
-
+var widgetRegister = function () {
 $.mobile.table.prototype.options.mode = "columntoggle";
 
 $.mobile.table.prototype.options.columnBtnTheme = null;
@@ -26,6 +26,9 @@ $.mobile.table.prototype.options.classes = $.extend(
 		columnToggleTable: "ui-table-columntoggle"
 	}
 );
+};
+
+$.mobile.addWidgetRegister( 'table', widgetRegister, [ 'popup', 'controlgroup', 'checkboxradio' ] );
 
 $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() {
 

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -8,7 +8,10 @@
 define( [ "jquery", "../jquery.mobile.widget", "./page", "./page.sections" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
+var widgetName = "table",
+	selector = ":jqmData(role='table')";
 
+var widgetRegister = function () {
 $.widget( "mobile.table", $.mobile.widget, {
 
 		options: {
@@ -64,10 +67,13 @@ $.widget( "mobile.table", $.mobile.widget, {
 	}
 
 });
+};
+
+$.mobile.addWidgetRegister( widgetName, widgetRegister );
 
 //auto self-init widgets
 $.mobile.document.bind( "pagecreate create", function( e ) {
-	$.mobile.table.prototype.enhanceWithin( e.target );
+	$.mobile.widget.prototype.enhanceWithin( e.target, false, selector, widgetName, false );
 });
 
 })( jQuery );

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -8,7 +8,7 @@
 define( [ "jquery", "./table" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
-
+var widgetRegister = function () {
 $.mobile.table.prototype.options.mode = "reflow";
 
 $.mobile.table.prototype.options.classes = $.extend(
@@ -18,6 +18,9 @@ $.mobile.table.prototype.options.classes = $.extend(
 		cellLabels: "ui-table-cell-label"
 	}
 );
+};
+
+$.mobile.addWidgetRegister( 'table', widgetRegister );
 
 $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() {
 


### PR DESCRIPTION
Hello, All.

I'll try to propose a way of lazy jQM widgets initialization to improve Web App's launching time. I think, @gabrielschulhof told jQM team about my PR last week, so I think you can guess what I'll suggest to you. 
My team's idea is as follows.

If a user makes a jQM javascript file including all of widgets(example: jquery.mobile-1.3.0.js) and adds it on a Web App's HTML page, and a Web browser loads the javascript file, All of jQM widgets' $.widget() methods are compiled and executed first. 
In short, regardless of what widgets are defined on a Web App's HTML page, all widgets are loaded and initialized first. 
All widgets also call the bind method as below, when "pagecreate" event is fired,

```
//auto self-init widgets
$.mobile.document.bind( "pagecreate create", function( e ) {
    ...
    $.mobile.selectmenu.prototype.enhanceWithin( e.target, true );
    ...
});
```

and then, enhanceWithin method calls enhance method as below and enhance method eventually calls _createWidget method and each widget's _create method. So, all widgets are loaded and initialized first, after a Web browser loads the javascript file.

```
// all widgets call that line and this.enhance method loads and initializes each widget.
enhanceWithin: function( target, useKeepNative ) {
    this.enhance( $( this.options.initSelector, $( target )), useKeepNative );
},
```

So, my team thought that we should find what widgets are used on a Web App's HTML page to load and initialize essential jQM widgets. And my team developed some methods and modified some codes in each widget with two processes as follows.
1. My team stored $.widget() method call in a variable, so that JS engine can not call(compile and execute) the $.widget() method.
   
   // Before
   (function( $, undefined ) {
       $.widget( "mobile.widgetname", $.mobile.widget, { ... } );
   })( jQuery ); 
   
   // After
   (function( $, undefined ) {
       var widgetRegister = function () { 
                                              $.widget( "mobile.dialog", $.mobile.widget, { ... } ) };
       ...
       // Store widget's body method using a new method - addWidgetRegister.
       $.mobile.addWidgetRegister( widgetName, widgetRegister );
   })( jQuery ); 
2. My team updated enhanceWithin method to load and initialize essential widgets on a Web App's HTML page.
   
   // Updated enhanceWithin method
   enhanceWithin: function( target, useKeepNative, selector, widgetName, istarget ) {
       // check what widgets are needed on a Web App.
       var $targets = istarget ? $( target ) :  $( selector, $( target ));
       if ( $targets.length ) {
           ...
           $.mobile[widgetName].prototype.enhance( $targets, useKeepNative );
       }
   }
- Tests : The code has been tested on several jQM widgets using qunit.js.
- Modified code is followed the jQuery Core Style guide.
- Scope : Performance improvement.

If there are any problems or mistakes on that PR, please let me know. Thanks in advance.
