### PR TITLE
Cache page object

### DIFF
--- a/js/jquery.mobile.widget.js
+++ b/js/jquery.mobile.widget.js
@@ -56,9 +56,10 @@ $.widget( "mobile.widget", {
 			// TODO remove dependency on the page widget for the keepNative.
 			// Currently the keepNative value is defined on the page prototype so
 			// the method is as well
-			if ( typeof $pagetCtx !== 'undefined' && $pagetCtx.data( "mobile-page" ) ) {
+			if ( typeof $pagetCtx !== 'undefined' ) {
 				page = $pagetCtx.data( "mobile-page" );
-			} else {
+			}
+			if ( !page) {
 				page = $.mobile.closestPageData( $widgetElements );
 			}
 			keepNative = ( page && page.keepNativeSelector()) || "";

--- a/js/jquery.mobile.widget.js
+++ b/js/jquery.mobile.widget.js
@@ -40,11 +40,12 @@ $.widget( "mobile.widget", {
 	},
 
 	enhanceWithin: function( target, useKeepNative ) {
-		this.enhance( $( this.options.initSelector, $( target )), useKeepNative );
+		var $target = $( target );
+		this.enhance( $( this.options.initSelector, $target), useKeepNative, $target );
 	},
 
-	enhance: function( targets, useKeepNative ) {
-		var page, keepNative, $widgetElements = $( targets ), self = this;
+	enhance: function( targets, useKeepNative, /*INTERNAL*/ $pagetCtx ) {
+		var page, keepNative, $widgetElements = $( targets );
 
 		// if ignoreContentEnabled is set to true the framework should
 		// only enhance the selected elements when they do NOT have a
@@ -55,7 +56,11 @@ $.widget( "mobile.widget", {
 			// TODO remove dependency on the page widget for the keepNative.
 			// Currently the keepNative value is defined on the page prototype so
 			// the method is as well
-			page = $.mobile.closestPageData( $widgetElements );
+			if ( typeof $pagetCtx !== 'undefined' && $pagetCtx.data( "mobile-page" ) ) {
+				page = $pagetCtx.data( "mobile-page" );
+			} else {
+				page = $.mobile.closestPageData( $widgetElements );
+			}
 			keepNative = ( page && page.keepNativeSelector()) || "";
 
 			$widgetElements = $widgetElements.not( keepNative );


### PR DESCRIPTION
Hi. I found that method $.mobile.widget.prototype.enhance calls $.mobile.closestPageData() function every time widget has useKeepNative = true.
This $.mobile.closestPageData() is looking for page widget in which current widget is created. In most cases $.mobile.widget.prototype.enhance is called from $.mobile.widget.prototype.enhanceWithin where target is current page, the same we are looking for in enhance method.
I added internal param to enhance method which allows to use cached earlier page object.

There are a lot of widgets with useKeepNative=true and on mobile devices it gives about 40ms of performance boost on average page.
