### PR TITLE
A fix for issue #5775

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1345,7 +1345,13 @@ define( [
 
 		// TODO roll the logic here into the handleHashChange method
 		$window.bind( "navigate", function( e, data ) {
-			var url = $.event.special.navigate.originalEventName.indexOf( "hashchange" ) > -1 ? data.state.hash : data.state.url;
+			var url;
+
+			if ( e.originalEvent && e.originalEvent.isDefaultPrevented() ) {
+				return;
+			}
+
+			url = $.event.special.navigate.originalEventName.indexOf( "hashchange" ) > -1 ? data.state.hash : data.state.url;
 
 			if( !url ) {
 				url = $.mobile.path.parseLocation().hash;

--- a/js/navigation/navigator.js
+++ b/js/navigation/navigator.js
@@ -190,6 +190,7 @@ define(["jquery",
 				this.ignoreInitialHashChange ) {
 				this.ignoreInitialHashChange = false;
 
+				event.preventDefault();
 				return;
 			}
 

--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -429,6 +429,13 @@
 					start();
 				});
 
+				// If the popstate resulting from the hash assignment below happens
+				// early enough during initial page load, the initial popstate emitted
+				// by webkit browsers (which needs to be ignored) will actually coincide
+				// with the popstate event caused by the assignment below. If that is
+				// the case, then we must ensure that the navigator does not treat the
+				// popstate event as the initial popstate event, thereby ignoring it.
+				$.mobile.navigate.navigator.ignoreInitialHashChange = false;
 				location.hash = location.hash.replace("#", "") === hash ? "" : "#" + hash;
 			};
 


### PR DESCRIPTION
The fix:
1. In navigator, we preventDefault() on the initial popstate.
2. In jquery.mobile.navigation we do not call _handleHashChange if the originalEvent for "navigate" has .isDefaultPrevented()
3. In testHelper's navReset method, unset the navigator's ignoreInitialHashChange flag, because webkit consolidates the popstate resulting from setting location.hash inside navReset with the initial popstate event it fires.

This should unify the startup event sequence between FF and Webkit. That is, in webkit we no longer have a superfluous call to changePage resulting in 3 pagebeforechange events being fired on initial page load.

@johnbender Could you please review this when you get a chance? TIA!
