### PR TITLE
Active state logic

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -1113,9 +1113,6 @@ define( [
 				}
 			} else {
 				target = findClosestLink( target );
-				if ( !( target && path.parseUrl( target.getAttribute( "href" ) || "#" ).hash !== "#" ) ) {
-					return;
-				}
 
 				// TODO teach $.mobile.hijackable to operate on raw dom elements so the
 				// link wrapping can be avoided

--- a/js/widgets/navbar.js
+++ b/js/widgets/navbar.js
@@ -37,23 +37,6 @@ $.widget( "mobile.navbar", $.mobile.widget, {
 			iconpos:	iconpos
 		});
 
-		$navbar.delegate( "a", "vclick", function( event ) {
-			// ui-btn-inner is returned as target
-			var target = $( event.target ).is( "a" ) ? $( this ) : $( this ).parent( "a" );
-			
-			if ( !target.is( ".ui-disabled, .ui-btn-active" ) ) {
-				$navbtns.removeClass( $.mobile.activeBtnClass );
-				$( this ).addClass( $.mobile.activeBtnClass );
-				
-				// The code below is a workaround to fix #1181
-				var activeBtn = $( this );
-				
-				$( document ).one( "pagehide", function() {
-					activeBtn.removeClass( $.mobile.activeBtnClass );
-				});
-			}
-		});
-
 		// Buttons in the navbar with ui-state-persist class should regain their active state before page show
 		$navbar.closest( ".ui-page" ).bind( "pagebeforeshow", function() {
 			$navbtns.filter( ".ui-state-persist" ).addClass( $.mobile.activeBtnClass );


### PR DESCRIPTION
In navigation we prevent the active state being applied to button-style links with `href="#"` and in the navbar widget we have code to make that work again.

This causes all kind of issues with the navbar. See https://github.com/jquery/jquery-mobile/issues/1181 and https://github.com/jquery/jquery-mobile/issues/5707 which have been fixed with a workaround.

Besides this there have been a few feature requests for making those buttons getting the active state. See https://github.com/jquery/jquery-mobile/issues/5009 and https://github.com/jquery/jquery-mobile/issues/4469. This was just partly fixed by https://github.com/jquery/jquery-mobile/pull/5337.
