### PR TITLE
Textinput: height correctly calculated (without extra padding) for box-sizing

### DIFF
--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -125,7 +125,11 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 					clientHeight = input[ 0 ].clientHeight;
 
 				if ( clientHeight < scrollHeight ) {
-					input.height( scrollHeight + extraLineHeight );
+					var paddingTop = parseFloat( input.css( "padding-top" ) ) || 0,
+						paddingBottom = parseFloat( input.css( "padding-bottom" ) ) || 0,
+						paddingHeight = paddingTop + paddingBottom;
+					
+					input.height( scrollHeight - paddingHeight + extraLineHeight );
 				}
 			};
 

--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -125,8 +125,8 @@ $.widget( "mobile.textinput", $.mobile.widget, {
 					clientHeight = input[ 0 ].clientHeight;
 
 				if ( clientHeight < scrollHeight ) {
-					var paddingTop = parseFloat( input.css( "padding-top" ) ) || 0,
-						paddingBottom = parseFloat( input.css( "padding-bottom" ) ) || 0,
+					var paddingTop = parseFloat( input.css( "padding-top" ) ),
+						paddingBottom = parseFloat( input.css( "padding-bottom" ) ),
 						paddingHeight = paddingTop + paddingBottom;
 					
 					input.height( scrollHeight - paddingHeight + extraLineHeight );


### PR DESCRIPTION
Fixes #5690. As I explained there, scrollHeight contains the padding of the element as well, while the height passed to `.height()` should only be of the content. Because of that we subtract the padding height.
