### PR TITLE
table: added refresh method and tests for 1.3.1 - fixes #5842 and #5841 missing table-refresh methods

### DIFF
--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -34,11 +34,11 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function( e ) {
-
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", function( e ) {
+	
 	var $table = $( this ),
-		event = e.type,
 		self = $table.data( "mobile-table" ),
+		event = e.type,
 		o = self.options,
 		ns = $.mobile.ns,
 		id = ( $table.attr( "id" ) || o.classes.popup ) + "-popup"; //TODO BETTER FALLBACK ID HERE
@@ -47,7 +47,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		return;
 	}
 
-	if ( event !== "tableupdate" ) {
+	if ( event !== "refresh" ) {
 		self.element.addClass( o.classes.columnToggleTable );
 
 		var $menuButton = $( "<a href='#" + id + "' class='" + o.classes.columnBtn + "' data-" + ns + "rel='popup' data-" + ns + "mini='true'>" + o.columnBtnText + "</a>" ),
@@ -65,7 +65,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 
 			$cells.addClass( o.classes.priorityPrefix + priority );
 
-			if ( event !== "tableupdate" ) {
+			if ( event !== "refresh" ) {
 				$("<label><input type='checkbox' checked />" + $( this ).text() + "</label>" )
 					.appendTo( $menu )
 					.children( 0 )
@@ -78,7 +78,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 			}
 		}
 	});
-	if ( event !== "tableupdate" ) {
+	if ( event !== "refresh" ) {
 		$menu.appendTo( $popup );
 	}
 
@@ -89,7 +89,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		$switchboard = $menu;
 	}
 
-	if (event !== "tableupdate") {
+	if (event !== "refresh") {
 		$switchboard.on( "change", "input", function( e ){
 			if( this.checked ){
 				$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-hidden" ).addClass( "ui-table-cell-visible" );
@@ -114,7 +114,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		$switchboard.find( "input" ).each( function(){
 			if (this.checked) {
 				this.checked = $( this ).jqmData( "cells" ).eq(0).css( "display" ) === "table-cell";
-				if (event === "tableupdate") {
+				if (event === "refresh") {
 					$( this ).jqmData( "cells" ).addClass('ui-table-cell-visible');
 				}
 			} else {
@@ -129,6 +129,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	self.update();
 
 });
+
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -24,7 +24,6 @@ $.widget( "mobile.table", $.mobile.widget, {
 		},
 
 		refresh: function (create) {
-
 			var self = this,
 				trs = this.element.find( "thead tr" );
 
@@ -72,7 +71,7 @@ $.widget( "mobile.table", $.mobile.widget, {
 
 			// update table modes
 			if ( create === undefined ) {
-				this.element.trigger( 'tableupdate' );
+				this.element.trigger( 'refresh' );
 			}
 	}
 
@@ -82,6 +81,7 @@ $.widget( "mobile.table", $.mobile.widget, {
 $.mobile.document.bind( "pagecreate create", function( e ) {
 	$.mobile.table.prototype.enhanceWithin( e.target );
 });
+
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -19,7 +19,7 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function( e ) {
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", function( e ) {
 
 	var $table = $( this ),
 		event = e.type,
@@ -31,7 +31,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		return;
 	}
 
-	if ( event !== "tableupdate" ) {
+	if ( event !== "refresh" ) {
 		self.element.addClass( o.classes.reflowTable );
 	}
 
@@ -64,6 +64,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	});
 
 });
+
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -35,7 +35,6 @@
 	<script src="../../swarminject.js"></script>
 	
 	<script type="text/javascript">
-		// basic
 		$(window).on('refresh_test_table', function (e, data) {
 			var tb = $(data).find('tbody'),
 					newRow = '<tr><th data-test="abc">1</th><td>2</td><td>3</td><td data-col="3">4</td><td>5</td></tr>';

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -137,7 +137,6 @@
 			start();
 		}, 800);
 	});
-
 	asyncTest( "Column toggle table refresh" , function(){
 		setTimeout(function () {
 			// hide one column and refresh


### PR DESCRIPTION
[toggle](http://www.franckreich.de/jqm/refresh/toggle.html) and [reflow](http://www.franckreich.de/jqm/refresh/reflow.html) sample pages.
