### PR TITLE
unit/table: correct path for 1.3.1 swarminject/setnamespace

### DIFF
--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -8,7 +8,7 @@
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../../js/requirejs.config.js"></script>
 	<script src="../../../js/jquery.tag.inserter.js"></script>
-	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../jquery.setNameSpace.js"></script>
 	<script src="../../jquery.testHelper.js"></script>
 	<script src="../../../external/qunit.js"></script>
 	<script type="text/javascript">
@@ -32,7 +32,7 @@
 	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css" />
 	<link rel="stylesheet" href="../../../external/qunit.css"/>
 
-	<script src="../../swarminject.js"></script>
+	<script src="../swarminject.js"></script>
 	
 	<script type="text/javascript">
 		$(window).on('refresh_test_table', function (e, data) {


### PR DESCRIPTION
Corrected path of swarminject.js / setNameSpace.js in unit test. Files were moved from [here](https://github.com/jquery/jquery-mobile/tree/master/tests) in 1.4 to [here](https://github.com/jquery/jquery-mobile/tree/table-refresh-1.3/tests/unit)
