### PR TITLE
Table refresh method for 1.3.x. Fixes #5841 and fixes #5842.

### DIFF
--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -34,11 +34,11 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function( e ) {
-
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", function( e ) {
+	
 	var $table = $( this ),
-		event = e.type,
 		self = $table.data( "mobile-table" ),
+		event = e.type,
 		o = self.options,
 		ns = $.mobile.ns,
 		id = ( $table.attr( "id" ) || o.classes.popup ) + "-popup"; //TODO BETTER FALLBACK ID HERE
@@ -47,7 +47,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		return;
 	}
 
-	if ( event !== "tableupdate" ) {
+	if ( event !== "refresh" ) {
 		self.element.addClass( o.classes.columnToggleTable );
 
 		var $menuButton = $( "<a href='#" + id + "' class='" + o.classes.columnBtn + "' data-" + ns + "rel='popup' data-" + ns + "mini='true'>" + o.columnBtnText + "</a>" ),
@@ -65,7 +65,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 
 			$cells.addClass( o.classes.priorityPrefix + priority );
 
-			if ( event !== "tableupdate" ) {
+			if ( event !== "refresh" ) {
 				$("<label><input type='checkbox' checked />" + $( this ).text() + "</label>" )
 					.appendTo( $menu )
 					.children( 0 )
@@ -78,7 +78,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 			}
 		}
 	});
-	if ( event !== "tableupdate" ) {
+	if ( event !== "refresh" ) {
 		$menu.appendTo( $popup );
 	}
 
@@ -89,7 +89,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		$switchboard = $menu;
 	}
 
-	if (event !== "tableupdate") {
+	if (event !== "refresh") {
 		$switchboard.on( "change", "input", function( e ){
 			if( this.checked ){
 				$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-hidden" ).addClass( "ui-table-cell-visible" );
@@ -114,7 +114,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		$switchboard.find( "input" ).each( function(){
 			if (this.checked) {
 				this.checked = $( this ).jqmData( "cells" ).eq(0).css( "display" ) === "table-cell";
-				if (event === "tableupdate") {
+				if (event === "refresh") {
 					$( this ).jqmData( "cells" ).addClass('ui-table-cell-visible');
 				}
 			} else {
@@ -129,6 +129,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	self.update();
 
 });
+
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -34,26 +34,29 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() {
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function(e) {
 
 	var $table = $( this ),
+		event = e.type,
 		self = $table.data( "mobile-table" ),
 		o = self.options,
-		ns = $.mobile.ns;
+		ns = $.mobile.ns,
+		id = ( $table.attr( "id" ) || o.classes.popup ) + "-popup"; //TODO BETTER FALLBACK ID HERE
 
 	if( o.mode !== "columntoggle" ){
 		return;
 	}
 
-	self.element.addClass( o.classes.columnToggleTable );
+	if ( event !== "tableupdate") {
+		self.element.addClass( o.classes.columnToggleTable );
 
-	var id = ( $table.attr( "id" ) || o.classes.popup ) + "-popup", //TODO BETTER FALLBACK ID HERE
-		$menuButton = $( "<a href='#" + id + "' class='" + o.classes.columnBtn + "' data-" + ns + "rel='popup' data-" + ns + "mini='true'>" + o.columnBtnText + "</a>" ),
-		$popup = $( "<div data-" + ns + "role='popup' data-" + ns + "role='fieldcontain' class='" + o.classes.popup + "' id='" + id + "'></div>"),
-		$menu = $("<fieldset data-" + ns + "role='controlgroup'></fieldset>");
+		var $menuButton = $( "<a href='#" + id + "' class='" + o.classes.columnBtn + "' data-" + ns + "rel='popup' data-" + ns + "mini='true'>" + o.columnBtnText + "</a>" ),
+			$popup = $( "<div data-" + ns + "role='popup' data-" + ns + "role='fieldcontain' class='" + o.classes.popup + "' id='" + id + "'></div>"),
+			$menu = $("<fieldset data-" + ns + "role='controlgroup'></fieldset>");
+	}
 
 	// create the hide/show toggles
-	self.headers.not( "td" ).each(function(){
+	self.headers.not( "td" ).each(function(i){
 
 		var priority = $( this ).jqmData( "priority" ),
 			$cells = $( this ).add( $( this ).jqmData( "cells" ) );
@@ -62,48 +65,68 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() 
 
 			$cells.addClass( o.classes.priorityPrefix + priority );
 
-			$("<label><input type='checkbox' checked />" + $( this ).text() + "</label>" )
-				.appendTo( $menu )
-				.children( 0 )
-				.jqmData( "cells", $cells )
-				.checkboxradio({
-					theme: o.columnPopupTheme
-				});
+			if (event !== "tableupdate") {
+				$("<label><input type='checkbox' checked />" + $( this ).text() + "</label>" )
+					.appendTo( $menu )
+					.children( 0 )
+					.jqmData( "cells", $cells )
+					.checkboxradio({
+						theme: o.columnPopupTheme
+					});
+			} else {
+				$('#'+id+ ' fieldset div:eq('+i+')').find('input').jqmData("cells", $cells)
+			}
 		}
 	});
+	if (event !== "tableupdate") {
 		$menu.appendTo( $popup );
+	}
 
 	// bind change event listeners to inputs - TODO: move to a private method?
-	$menu.on( "change", "input", function( e ){
-		if( this.checked ){
-			$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-hidden" ).addClass( "ui-table-cell-visible" );
-		}
-		else {
-			$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-visible" ).addClass( "ui-table-cell-hidden" );
-		}
-	});
+	if ($menu === undefined) { 
+		$switchboard = $('#'+id+' fieldset');
+	} else {
+		$switchboard = $menu;
+	}
 
-	$menuButton
-		.insertBefore( $table )
-		.buttonMarkup({
-			theme: o.columnBtnTheme
+	if (event !== "tableupdate") {
+		$switchboard.on( "change", "input", function( e ){
+			if( this.checked ){
+				$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-hidden" ).addClass( "ui-table-cell-visible" );
+			} else {
+				$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-visible" ).addClass( "ui-table-cell-hidden" );
+			}
 		});
 
-	$popup
-		.insertBefore( $table )
-		.popup();
+		$menuButton
+			.insertBefore( $table )
+			.buttonMarkup({
+				theme: o.columnBtnTheme
+			});
+
+		$popup
+			.insertBefore( $table )
+			.popup();
+	}
 
 	// refresh method
-	self.refresh = function(){
-		$menu.find( "input" ).each( function(){
-			this.checked = $( this ).jqmData( "cells" ).eq(0).css( "display" ) === "table-cell";
+	self.update = function(){
+		$switchboard.find( "input" ).each( function(){
+			if (this.checked) {
+				this.checked = $( this ).jqmData( "cells" ).eq(0).css( "display" ) === "table-cell";
+				if (event === "tableupdate") {
+					$( this ).jqmData( "cells" ).addClass('ui-table-cell-visible');
+				}
+			} else {
+				$( this ).jqmData( "cells" ).addClass('ui-table-cell-hidden');
+			}
 			$( this ).checkboxradio( "refresh" );
 		});
 	};
 
-	$.mobile.window.on( "throttledresize", self.refresh );
+	$.mobile.window.on( "throttledresize", self.update );
 
-	self.refresh();
+	self.update();
 
 });
 

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -34,7 +34,7 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function(e) {
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function( e ) {
 
 	var $table = $( this ),
 		event = e.type,
@@ -47,7 +47,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		return;
 	}
 
-	if ( event !== "tableupdate") {
+	if ( event !== "tableupdate" ) {
 		self.element.addClass( o.classes.columnToggleTable );
 
 		var $menuButton = $( "<a href='#" + id + "' class='" + o.classes.columnBtn + "' data-" + ns + "rel='popup' data-" + ns + "mini='true'>" + o.columnBtnText + "</a>" ),
@@ -56,7 +56,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	}
 
 	// create the hide/show toggles
-	self.headers.not( "td" ).each(function(i){
+	self.headers.not( "td" ).each(function( i ){
 
 		var priority = $( this ).jqmData( "priority" ),
 			$cells = $( this ).add( $( this ).jqmData( "cells" ) );
@@ -65,7 +65,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 
 			$cells.addClass( o.classes.priorityPrefix + priority );
 
-			if (event !== "tableupdate") {
+			if ( event !== "tableupdate" ) {
 				$("<label><input type='checkbox' checked />" + $( this ).text() + "</label>" )
 					.appendTo( $menu )
 					.children( 0 )
@@ -74,17 +74,17 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 						theme: o.columnPopupTheme
 					});
 			} else {
-				$('#'+id+ ' fieldset div:eq('+i+')').find('input').jqmData("cells", $cells)
+				$('#' + id + ' fieldset div:eq(' + i +')').find('input').jqmData("cells", $cells)
 			}
 		}
 	});
-	if (event !== "tableupdate") {
+	if ( event !== "tableupdate" ) {
 		$menu.appendTo( $popup );
 	}
 
 	// bind change event listeners to inputs - TODO: move to a private method?
-	if ($menu === undefined) { 
-		$switchboard = $('#'+id+' fieldset');
+	if ( $menu === undefined ) {
+		$switchboard = $('#' + id + ' fieldset');
 	} else {
 		$switchboard = $menu;
 	}

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -129,7 +129,6 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	self.update();
 
 });
-
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -47,7 +47,6 @@ $.widget( "mobile.table", $.mobile.widget, {
 
 					var span = parseInt( $( this ).attr( "colspan" ), 10 ),
 						sel = ":nth-child(" + ( coltally + 1 ) + ")";
-
 					$( this )
 						.jqmData( "colstart", coltally + 1 );
 
@@ -58,21 +57,22 @@ $.widget( "mobile.table", $.mobile.widget, {
 						}
 					}
 
-					if (create === undefined) {
-						$(this).jqmData("cells","");
+					if ( create === undefined ) {
+						$(this).jqmData("cells", "");
 					}
 					// Store "cells" data on header as a reference to all cells in the same column as this TH
 					$( this )
 						.jqmData( "cells", self.element.find( "tr" ).not( trs.eq(0) ).not( this ).children( sel ) );
 
 					coltally++;
+
 				});
 
 			});
 
 			// update table modes
-			if (create === undefined) {
-				this.element.trigger('tableupdate');
+			if ( create === undefined ) {
+				this.element.trigger( 'tableupdate' );
 			}
 	}
 

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -24,7 +24,6 @@ $.widget( "mobile.table", $.mobile.widget, {
 		},
 
 		refresh: function (create) {
-
 			var self = this,
 				trs = this.element.find( "thead tr" );
 
@@ -72,7 +71,7 @@ $.widget( "mobile.table", $.mobile.widget, {
 
 			// update table modes
 			if ( create === undefined ) {
-				this.element.trigger( 'tableupdate' );
+				this.element.trigger( 'refresh' );
 			}
 	}
 
@@ -82,6 +81,7 @@ $.widget( "mobile.table", $.mobile.widget, {
 $.mobile.document.bind( "pagecreate create", function( e ) {
 	$.mobile.table.prototype.enhanceWithin( e.target );
 });
+
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -19,11 +19,18 @@ $.widget( "mobile.table", $.mobile.widget, {
 		},
 
 		_create: function() {
+			var self = this;
+			self.refresh( true );
+		},
+
+		refresh: function (create) {
 
 			var self = this,
 				trs = this.element.find( "thead tr" );
 
-			this.element.addClass( this.options.classes.table );
+			if ( create ) {
+				this.element.addClass( this.options.classes.table );
+			}
 
 			// Expose headers and allHeaders properties on the widget
 			// headers references the THs within the first TR in the table
@@ -40,7 +47,7 @@ $.widget( "mobile.table", $.mobile.widget, {
 
 					var span = parseInt( $( this ).attr( "colspan" ), 10 ),
 						sel = ":nth-child(" + ( coltally + 1 ) + ")";
-					
+
 					$( this )
 						.jqmData( "colstart", coltally + 1 );
 
@@ -51,16 +58,22 @@ $.widget( "mobile.table", $.mobile.widget, {
 						}
 					}
 
+					if (create === undefined) {
+						$(this).jqmData("cells","");
+					}
 					// Store "cells" data on header as a reference to all cells in the same column as this TH
 					$( this )
 						.jqmData( "cells", self.element.find( "tr" ).not( trs.eq(0) ).not( this ).children( sel ) );
 
 					coltally++;
-
 				});
 
 			});
 
+			// update table modes
+			if (create === undefined) {
+				this.element.trigger('tableupdate');
+			}
 	}
 
 });

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -82,7 +82,6 @@ $.widget( "mobile.table", $.mobile.widget, {
 $.mobile.document.bind( "pagecreate create", function( e ) {
 	$.mobile.table.prototype.enhanceWithin( e.target );
 });
-
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -19,7 +19,7 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function(e) {
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function( e ) {
 
 	var $table = $( this ),
 		event = e.type,
@@ -31,7 +31,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		return;
 	}
 
-	if (event !== "tableupdate") {
+	if ( event !== "tableupdate" ) {
 		self.element.addClass( o.classes.reflowTable );
 	}
 
@@ -39,15 +39,18 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	var reverseHeaders =  $( self.allHeaders.get().reverse() );
 
 	// create the hide/show toggles
-	reverseHeaders.each(function(i){
+	reverseHeaders.each(function( i ){
 		var $cells = $( this ).jqmData( "cells" ),
 			colstart = $( this ).jqmData( "colstart" ),
 			hierarchyClass = $cells.not( this ).filter( "thead th" ).length && " ui-table-cell-label-top",
 			text = $(this).text();
+
 			if( text !== ""  ){
+
 				if( hierarchyClass ){
 					var iteration = parseInt( $( this ).attr( "colspan" ), 10 ),
 						filter = "";
+
 					if( iteration ){
 						filter = "td:nth-child("+ iteration +"n + " + ( colstart ) +")";
 					}
@@ -56,8 +59,10 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 				else {
 					$cells.prepend( "<b class='" + o.classes.cellLabels + "'>" + text + "</b>"  );
 				}
+
 			}
 	});
+
 });
 
 })( jQuery );

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -19,7 +19,7 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function( e ) {
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", function( e ) {
 
 	var $table = $( this ),
 		event = e.type,
@@ -31,7 +31,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 		return;
 	}
 
-	if ( event !== "tableupdate" ) {
+	if ( event !== "refresh" ) {
 		self.element.addClass( o.classes.reflowTable );
 	}
 
@@ -64,6 +64,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	});
 
 });
+
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -64,7 +64,6 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate",
 	});
 
 });
-
 })( jQuery );
 //>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
 });

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -19,9 +19,10 @@ $.mobile.table.prototype.options.classes = $.extend(
 	}
 );
 
-$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() {
+$.mobile.document.delegate( ":jqmData(role='table')", "tablecreate tableupdate", function(e) {
 
 	var $table = $( this ),
+		event = e.type,
 		self = $table.data( "mobile-table" ),
 		o = self.options;
 
@@ -30,7 +31,9 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() 
 		return;
 	}
 
-	self.element.addClass( o.classes.reflowTable );
+	if (event !== "tableupdate") {
+		self.element.addClass( o.classes.reflowTable );
+	}
 
 	// get headers in reverse order so that top-level headers are appended last
 	var reverseHeaders =  $( self.allHeaders.get().reverse() );
@@ -41,13 +44,10 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() 
 			colstart = $( this ).jqmData( "colstart" ),
 			hierarchyClass = $cells.not( this ).filter( "thead th" ).length && " ui-table-cell-label-top",
 			text = $(this).text();
-
 			if( text !== ""  ){
-
 				if( hierarchyClass ){
 					var iteration = parseInt( $( this ).attr( "colspan" ), 10 ),
 						filter = "";
-
 					if( iteration ){
 						filter = "td:nth-child("+ iteration +"n + " + ( colstart ) +")";
 					}
@@ -56,10 +56,8 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate", function() 
 				else {
 					$cells.prepend( "<b class='" + o.classes.cellLabels + "'>" + text + "</b>"  );
 				}
-
 			}
 	});
-
 });
 
 })( jQuery );

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -8,7 +8,7 @@
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../../js/requirejs.config.js"></script>
 	<script src="../../../js/jquery.tag.inserter.js"></script>
-	<script src="../jquery.setNameSpace.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
 	<script src="../../jquery.testHelper.js"></script>
 	<script src="../../../external/qunit.js"></script>
 	<script type="text/javascript">
@@ -32,19 +32,19 @@
 	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css" />
 	<link rel="stylesheet" href="../../../external/qunit.css"/>
 
-	<script src="../swarminject.js"></script>
-
-  <script type="text/javascript">
-  // basic
-  $(window).on('refresh_test_table', function (e, data) {
-    var tb = $(data).find('tbody'),
-				newRow = '<tr><th data-test="abc">1</th><td>2</td><td>3</td><td data-col="3">4</td><td>5</td></tr>';
-    tb.empty()
-      .append(newRow)
-      .closest('table')
-      .table('refresh');
-  });
-</script>
+	<script src="../../swarminject.js"></script>
+	
+	<script type="text/javascript">
+		// basic
+		$(window).on('refresh_test_table', function (e, data) {
+			var tb = $(data).find('tbody'),
+					newRow = '<tr><th data-test="abc">1</th><td>2</td><td>3</td><td data-col="3">4</td><td>5</td></tr>';
+			tb.empty()
+				.append(newRow)
+				.closest('table')
+				.table('refresh');
+		});
+	</script>
 
 </head>
 <body>

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -35,7 +35,6 @@
 	<script src="../../swarminject.js"></script>
 	
 	<script type="text/javascript">
-		// basic
 		$(window).on('refresh_test_table', function (e, data) {
 			var tb = $(data).find('tbody'),
 					newRow = '<tr><th data-test="abc">1</th><td>2</td><td>3</td><td data-col="3">4</td><td>5</td></tr>';

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -33,6 +33,19 @@
 	<link rel="stylesheet" href="../../../external/qunit.css"/>
 
 	<script src="../swarminject.js"></script>
+
+  <script type="text/javascript">
+  // basic
+  $(window).on('refresh_test_table', function (e, data) {
+    var tb = $(data).find('tbody'),
+				newRow = '<tr><th data-test="abc">1</th><td>2</td><td>3</td><td data-col="3">4</td><td>5</td></tr>';
+    tb.empty()
+      .append(newRow)
+      .closest('table')
+      .table('refresh');
+  });
+</script>
+
 </head>
 <body>
 

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -63,11 +63,11 @@
 		<table data-nstest-role="table" id="movie-table">
 			<thead>
 				<tr>
-					<th data-priority="1">Rank</th>
-					<th data-priority="persist">Movie Title</th>
-					<th data-priority="2">Year</th>
-					<th data-priority="3"><abbr title="Rotten Tomato Rating">Rating</abbr></th>
-					<th data-priority="4">Reviews</th>
+					<th data-nstest-priority="1">Rank</th>
+					<th data-nstest-priority="persist">Movie Title</th>
+					<th data-nstest-priority="2">Year</th>
+					<th data-nstest-priority="3"><abbr title="Rotten Tomato Rating">Rating</abbr></th>
+					<th data-nstest-priority="4">Reviews</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -90,11 +90,11 @@
 		<table data-nstest-role="table" data-nstest-mode="reflow" id="movie-table-reflow">
 			<thead>
 				<tr>
-					<th data-priority="1">Rank</th>
-					<th data-priority="persist">Movie Title</th>
-					<th data-priority="2">Year</th>
-					<th data-priority="3"><abbr title="Rotten Tomato Rating">Rating</abbr></th>
-					<th data-priority="4">Reviews</th>
+					<th data-nstest-priority="1">Rank</th>
+					<th data-nstest-priority="persist">Movie Title</th>
+					<th data-nstest-priority="2">Year</th>
+					<th data-nstest-priority="3"><abbr title="Rotten Tomato Rating">Rating</abbr></th>
+					<th data-nstest-priority="4">Reviews</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -8,7 +8,7 @@
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../../js/requirejs.config.js"></script>
 	<script src="../../../js/jquery.tag.inserter.js"></script>
-	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../jquery.setNameSpace.js"></script>
 	<script src="../../jquery.testHelper.js"></script>
 	<script src="../../../external/qunit.js"></script>
 	<script type="text/javascript">
@@ -32,7 +32,7 @@
 	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css" />
 	<link rel="stylesheet" href="../../../external/qunit.css"/>
 
-	<script src="../../swarminject.js"></script>
+	<script src="../swarminject.js"></script>
 	
 	<script type="text/javascript">
 		$(window).on('refresh_test_table', function (e, data) {

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -61,6 +61,7 @@
 					"cell stored is a refreshed cell (currently in the table");
 				equal($cellLookUp, $firstHeaderCell.jqmData('cells').eq(0).jqmData("test"),
 					"referenced cell is in the correct column");
+				start();
 		}, 1200);
 	});
 	module( "Reflow Mode", {
@@ -105,6 +106,7 @@
 			labels = $tds.find( "b.ui-table-cell-label" );
 		ok( $table.length, "table still enhanced");
 		ok( labels = $tds.find( "b.ui-table-cell-label" ), "Labels still there");
+		start();
 		}, 1200);
 	});
 	module( "Column toggle table Mode", {

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -46,23 +46,23 @@
 			start();
 		}, 800);
 	});
-  asyncTest("Refresh updates table headers correctly",
-    function () {
-      setTimeout(function () {
-        $(window).trigger("refresh_test_table", ["#basic-table-test"]);
-        var $table = $('#basic-table-test .ui-table'),
-          $firstHeaderCell = $table.find('thead tr th').eq(0),
-          $cellLookUp = $table.find('tbody tr').eq(0).find('th td').eq(0).jqmData("test");
-        ok($table.length, "table still enhanced");
-        ok($firstHeaderCell.jqmData("cells").length,
-          "column cells still assigned to header cell");
-        equal($firstHeaderCell.jqmData('cells').eq(0).closest("table").attr('id'),
-          "basic-table-test",
-          "cell stored is a refreshed cell (currently in the table");
-        equal($cellLookUp, $firstHeaderCell.jqmData('cells').eq(0).jqmData("test"),
-          "referenced cell is in the correct column");
+	asyncTest("Refresh updates table headers correctly",
+		function () {
+			setTimeout(function () {
+				$(window).trigger("refresh_test_table", ["#basic-table-test"]);
+				var $table = $('#basic-table-test .ui-table'),
+					$firstHeaderCell = $table.find('thead tr th').eq(0),
+					$cellLookUp = $table.find('tbody tr').eq(0).find('th td').eq(0).jqmData("test");
+				ok($table.length, "table still enhanced");
+				ok($firstHeaderCell.jqmData("cells").length,
+					"column cells still assigned to header cell");
+				equal($firstHeaderCell.jqmData('cells').eq(0).closest("table").attr('id'),
+					"basic-table-test",
+					"cell stored is a refreshed cell (currently in the table");
+				equal($cellLookUp, $firstHeaderCell.jqmData('cells').eq(0).jqmData("test"),
+					"referenced cell is in the correct column");
 		}, 1200);
-  });
+	});
 	module( "Reflow Mode", {
 		setup: function(){
 			var hash = "#reflow-table-test";
@@ -97,16 +97,16 @@
 			start();
 		}, 800);
 	});
-  asyncTest( "Reflow table refresh" , function(){
-    setTimeout(function () {
-    // refresh table
-    $(window).trigger("refresh_test_table", ["#reflow-table-test"]);
-    var $table = $('#reflow-table-test .ui-table'),
-      labels = $tds.find( "b.ui-table-cell-label" );
-    ok( $table.length, "table still enhanced");
-    ok( labels = $tds.find( "b.ui-table-cell-label" ), "Labels still there");
-    }, 1200);
-  });
+	asyncTest( "Reflow table refresh" , function(){
+		setTimeout(function () {
+		// refresh table
+		$(window).trigger("refresh_test_table", ["#reflow-table-test"]);
+		var $table = $('#reflow-table-test .ui-table'),
+			labels = $tds.find( "b.ui-table-cell-label" );
+		ok( $table.length, "table still enhanced");
+		ok( labels = $tds.find( "b.ui-table-cell-label" ), "Labels still there");
+		}, 1200);
+	});
 	module( "Column toggle table Mode", {
 		setup: function(){
 			var hash = "#column-table-test";
@@ -136,29 +136,28 @@
 			start();
 		}, 800);
 	});
-  asyncTest( "Column toggle table refresh" , function(){
-    setTimeout(function () {
-      // hide one column and refresh
-      var $input = $( ".ui-popup-container" ).find( "input" ).eq(2);
-      
-      $input.trigger('click', function(){
-        $(window).trigger("refresh_test_table", ["#column-table-test"]);
-          var $table = $('#column-table-test .ui-table'),
-            $second_input = $( ".ui-popup-container" ).find( "input" ).eq(0),
-            $visibleCells = $table.find("tbody tr").eq(1).find("th, td").not('.ui-table-cell-hidden'),
-            $visibleHeaders = $table.find("tbody tr").eq(0).find("th, td").not('.ui-table-cell-hidden');
-            
-          ok( $table.length, "table still enhanced");
-          equal( $table.find('tbody tr').eq(1)
-                  .find("th, td").eq(2).hasClass('ui-table-cell-hidden'), true, 
-                   "random cell on hidden column has ui-table-cell-hidden, class");
-          ok( $input.is( ":checked" ), false, "input is still not checked after refresh");
-          equal($second_input.jqmData("cells").eq(0).jqmData("test"), "abc",
-            "cell reference in popup is to cell currently in table");
-          equal($visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible");
-      });
-    }, 1200);
-  });
+
+	asyncTest( "Column toggle table refresh" , function(){
+		setTimeout(function () {
+			// hide one column and refresh
+			var $input = $( ".ui-popup-container" ).find( "input" ).eq(2);
+			$input.trigger('click', function(){
+				$(window).trigger("refresh_test_table", ["#column-table-test"]);
+					var $table = $('#column-table-test .ui-table'),
+						$second_input = $( ".ui-popup-container" ).find( "input" ).eq(0),
+						$visibleCells = $table.find("tbody tr").eq(1).find("th, td").not('.ui-table-cell-hidden'),
+						$visibleHeaders = $table.find("tbody tr").eq(0).find("th, td").not('.ui-table-cell-hidden');
+					ok( $table.length, "table still enhanced");
+					equal( $table.find('tbody tr').eq(1)
+									.find("th, td").eq(2).hasClass('ui-table-cell-hidden'), true, 
+									 "random cell on hidden column has ui-table-cell-hidden, class");
+					ok( $input.is( ":checked" ), false, "input is still not checked after refresh");
+					equal($second_input.jqmData("cells").eq(0).jqmData("test"), "abc",
+						"cell reference in popup is to cell currently in table");
+					equal($visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible");
+			});
+		}, 1200);
+	});
 	asyncTest( "The dialog should become visible when button is clicked" , function(){
 		expect( 2 );
 		var $input;

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -22,46 +22,57 @@
 		}
 	});
 	asyncTest( "The page should be enhanced correctly" , function(){
+		expect( 1 );
+		
 		setTimeout(function() {
 			var $table = $('#basic-table-test .ui-table');
+			
 			ok( $table.length, ".ui-table class added to table element" );
 			start();
 		}, 800);
 	});
 	asyncTest( "Has data object attributed to table" , function(){
+		expect( 1 );
+		
 		setTimeout(function(){
 			var $table = $('#basic-table-test .ui-table'),
 				self = $table.data( "mobile-table" );
+				
 			ok( self , "Data object is available" );
 			start();
 		}, 800);
 	});
 	asyncTest( "Has headers option" , function(){
+		expect( 2 );
+		
 		setTimeout(function() {
 			var $table = $('#basic-table-test .ui-table'),
 				self = $table.data( "mobile-table" );
+				
 			ok( self.headers.length , "Header array is not empty");
 			equal( 5 , self.headers.length , "Number of headers is correct");
 			start();
 		}, 800);
 	});
-	asyncTest("Refresh updates table headers correctly",
-		function () {
-			setTimeout(function () {
-				$(window).trigger("refresh_test_table", ["#basic-table-test"]);
-				var $table = $('#basic-table-test .ui-table'),
-					$firstHeaderCell = $table.find('thead tr th').eq(0),
-					$cellLookUp = $table.find('tbody tr').eq(0).find('th td').eq(0).jqmData("test");
-				ok($table.length, "table still enhanced");
-				ok($firstHeaderCell.jqmData("cells").length,
-					"column cells still assigned to header cell");
-				equal($firstHeaderCell.jqmData('cells').eq(0).closest("table").attr('id'),
-					"movie-table",
-					"cell stored is a refreshed cell (currently in the table");
-				equal($cellLookUp, $firstHeaderCell.jqmData('cells').eq(0).jqmData("test"),
-					"referenced cell is in the correct column");
-				start();
-		}, 1200);
+	asyncTest("Refresh updates table headers correctly", function () {
+		expect( 4 );
+		
+		setTimeout(function () {
+			$(window).trigger("refresh_test_table", ["#basic-table-test"]);
+			var $table = $('#basic-table-test .ui-table'),
+				$firstHeaderCell = $table.find('thead tr th').eq(0),
+				$cellLookUp = $table.find('tbody tr').eq(0).find('th td').eq(0).jqmData("test");
+				
+			ok($table.length, "table still enhanced");
+			ok($firstHeaderCell.jqmData("cells").length,
+				"column cells still assigned to header cell");
+			equal($firstHeaderCell.jqmData('cells').eq(0).closest("table").attr('id'),
+				"movie-table",
+				"cell stored is a refreshed cell (currently in the table");
+			equal($cellLookUp, $firstHeaderCell.jqmData('cells').eq(0).jqmData("test"),
+				"referenced cell is in the correct column");
+			start();
+		}, 800);
 	});
 	module( "Reflow Mode", {
 		setup: function(){
@@ -81,33 +92,41 @@
 		}
 	});
 	asyncTest( "The page should be enhanced correctly" , function(){
+		expect( 1 );
+		
 		setTimeout(function() {
 			ok($('#reflow-table-test .ui-table-reflow').length, ".ui-table-reflow class added to table element");
 			start();
 		}, 800);
 	});
 	asyncTest( "The appropriate label is added" , function(){
+		expect( 2 );
+		
 		setTimeout(function(){
 			var $table = $( "#reflow-table-test table" ),
 				$body = $table.find( "tbody" ),
 				$tds = $body.find( "td" ),
 				labels = $tds.find( "b.ui-table-cell-label" );
+				
 			ok( labels , "Appropriate label placed" );
 			equal( $( labels[0] ).text(), "Movie Title" , "Appropriate label placed" );
 			start();
 		}, 800);
 	});
 	asyncTest( "Reflow table refresh" , function(){
+		expect( 2 );
+		
 		setTimeout(function () {
-		// refresh table
-		$(window).trigger("refresh_test_table", ["#reflow-table-test"]);
-		var $table = $('#reflow-table-test .ui-table'),
-			$tds = $table.find( "td" ),
-			labels = $tds.find( "b.ui-table-cell-label" );
-		ok( $table.length, "table still enhanced");
-		ok( labels = $tds.find( "b.ui-table-cell-label" ), "Labels still there");
-		start();
-		}, 1200);
+			// refresh table
+			$(window).trigger("refresh_test_table", ["#reflow-table-test"]);
+			var $table = $('#reflow-table-test .ui-table'),
+				$tds = $table.find( "td" ),
+				labels = $tds.find( "b.ui-table-cell-label" );
+				
+			ok( $table.length, "table still enhanced");
+			ok( labels = $tds.find( "b.ui-table-cell-label" ), "Labels still there");
+			start();
+		}, 800);
 	});
 	module( "Column toggle table Mode", {
 		setup: function(){
@@ -127,8 +146,11 @@
 		}
 	});
 	asyncTest( "The page should be enhanced correctly" , function(){
+		expect( 6 );
+		
 		setTimeout(function() {
 			var $popup = $('#column-table-test #movie-table-column-popup-popup');
+			
 			ok($('#column-table-test .ui-table-columntoggle').length, ".ui-table-columntoggle class added to table element");
 			ok($('#column-table-test .ui-table-columntoggle-btn').length, ".ui-table-columntoggle-btn button added");
 			equal($('#column-table-test .ui-table-columntoggle-btn').text(), "Columns...",  "Column toggle button has correct text");
@@ -139,26 +161,45 @@
 		}, 800);
 	});
 	asyncTest( "Column toggle table refresh" , function(){
-		setTimeout(function () {
-			// hide one column and refresh
-			var $input = $( ".ui-popup-container" ).find( "input" ).eq(2);
-			$input.trigger('click', function(){
-				$(window).trigger("refresh_test_table", ["#column-table-test"]);
+		expect( 5 );
+		
+		var $input;
+		
+		$.testHelper.pageSequence([
+			function() {
+				$( ".ui-table-columntoggle-btn" ).click();
+			},
+			function() {
+				$input = $( "#movie-table-column-popup-popup" ).find( "input" ).eq(0);
+				$input.click();
+			},
+			function(){
+				setTimeout(function () {
+					$(window).trigger("refresh_test_table", ["#column-table-test"]);
+					
 					var $table = $('#column-table-test .ui-table'),
-						$second_input = $( ".ui-popup-container" ).find( "input" ).eq(0),
-						$visibleCells = $table.find("tbody tr").eq(1).find("th, td").not('.ui-table-cell-hidden'),
-						$visibleHeaders = $table.find("tbody tr").eq(0).find("th, td").not('.ui-table-cell-hidden');
+						$first_input = $( "#movie-table-column-popup-popup" ).find( "input" ).eq(0),
+						$visibleCells = $table.find("tbody tr:first").find("th, td").not('.ui-table-cell-hidden'),
+						$visibleHeaders = $table.find("thead tr:first").find("th, td").not('.ui-table-cell-hidden');
+						
 					ok( $table.length, "table still enhanced");
-					equal( $table.find('tbody tr').eq(1)
-									.find("th, td").eq(2).hasClass('ui-table-cell-hidden'), true, 
-									 "random cell on hidden column has ui-table-cell-hidden, class");
+					equal( $table.find('tbody tr:first')
+						.find("th, td").eq(2).hasClass('ui-table-cell-hidden'), true, "random cell in hidden column has ui-table-cell-hidden class");
 					ok( $input.is( ":checked" ), false, "input is still not checked after refresh");
-					equal($second_input.jqmData("cells").eq(0).jqmData("test"), "abc",
+					
+					equal( $first_input.jqmData("cells").eq(1).data("test"), "abc",
 						"cell reference in popup is to cell currently in table");
-					equal($visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible");
-					start();
-			});
-		}, 1200);
+						
+						var test = $first_input.jqmData("cells").eq(1);
+						console.log(test);
+						
+					equal( $visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible" );
+				}, 800);
+			},
+			function() {
+				start();
+			}
+		]);
 	});
 	asyncTest( "The dialog should become visible when button is clicked" , function(){
 		expect( 2 );

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -137,7 +137,6 @@
 			start();
 		}, 800);
 	});
-
 	asyncTest( "Column toggle table refresh" , function(){
 		setTimeout(function () {
 			// hide one column and refresh

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -1,4 +1,3 @@
-
 /*
  * mobile table unit tests
  */

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -186,13 +186,8 @@
 					equal( $table.find('tbody tr:first')
 						.find("th, td").eq(2).hasClass('ui-table-cell-hidden'), true, "random cell in hidden column has ui-table-cell-hidden class");
 					ok( $input.is( ":checked" ), false, "input is still not checked after refresh");
-					
 					equal( $first_input.jqmData("cells").eq(1).data("test"), "abc",
 						"cell reference in popup is to cell currently in table");
-						
-						var test = $first_input.jqmData("cells").eq(1);
-						console.log(test);
-						
 					equal( $visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible" );
 				}, 800);
 			},

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -155,6 +155,7 @@
 					equal($second_input.jqmData("cells").eq(0).jqmData("test"), "abc",
 						"cell reference in popup is to cell currently in table");
 					equal($visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible");
+					start();
 			});
 		}, 1200);
 	});

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -102,6 +102,7 @@
 		// refresh table
 		$(window).trigger("refresh_test_table", ["#reflow-table-test"]);
 		var $table = $('#reflow-table-test .ui-table'),
+			$tds = $table.find( "td" ),
 			labels = $tds.find( "b.ui-table-cell-label" );
 		ok( $table.length, "table still enhanced");
 		ok( labels = $tds.find( "b.ui-table-cell-label" ), "Labels still there");

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -46,6 +46,23 @@
 			start();
 		}, 800);
 	});
+  asyncTest("Refresh updates table headers correctly",
+    function () {
+      setTimeout(function () {
+        $(window).trigger("refresh_test_table", ["#basic-table-test"]);
+        var $table = $('#basic-table-test .ui-table'),
+          $firstHeaderCell = $table.find('thead tr th').eq(0),
+          $cellLookUp = $table.find('tbody tr').eq(0).find('th td').eq(0).jqmData("test");
+        ok($table.length, "table still enhanced");
+        ok($firstHeaderCell.jqmData("cells").length,
+          "column cells still assigned to header cell");
+        equal($firstHeaderCell.jqmData('cells').eq(0).closest("table").attr('id'),
+          "basic-table-test",
+          "cell stored is a refreshed cell (currently in the table");
+        equal($cellLookUp, $firstHeaderCell.jqmData('cells').eq(0).jqmData("test"),
+          "referenced cell is in the correct column");
+		}, 1200);
+  });
 	module( "Reflow Mode", {
 		setup: function(){
 			var hash = "#reflow-table-test";
@@ -80,6 +97,16 @@
 			start();
 		}, 800);
 	});
+  asyncTest( "Reflow table refresh" , function(){
+    setTimeout(function () {
+    // refresh table
+    $(window).trigger("refresh_test_table", ["#reflow-table-test"]);
+    var $table = $('#reflow-table-test .ui-table'),
+      labels = $tds.find( "b.ui-table-cell-label" );
+    ok( $table.length, "table still enhanced");
+    ok( labels = $tds.find( "b.ui-table-cell-label" ), "Labels still there");
+    }, 1200);
+  });
 	module( "Column toggle table Mode", {
 		setup: function(){
 			var hash = "#column-table-test";
@@ -109,7 +136,29 @@
 			start();
 		}, 800);
 	});
-
+  asyncTest( "Column toggle table refresh" , function(){
+    setTimeout(function () {
+      // hide one column and refresh
+      var $input = $( ".ui-popup-container" ).find( "input" ).eq(2);
+      
+      $input.trigger('click', function(){
+        $(window).trigger("refresh_test_table", ["#column-table-test"]);
+          var $table = $('#column-table-test .ui-table'),
+            $second_input = $( ".ui-popup-container" ).find( "input" ).eq(0),
+            $visibleCells = $table.find("tbody tr").eq(1).find("th, td").not('.ui-table-cell-hidden'),
+            $visibleHeaders = $table.find("tbody tr").eq(0).find("th, td").not('.ui-table-cell-hidden');
+            
+          ok( $table.length, "table still enhanced");
+          equal( $table.find('tbody tr').eq(1)
+                  .find("th, td").eq(2).hasClass('ui-table-cell-hidden'), true, 
+                   "random cell on hidden column has ui-table-cell-hidden, class");
+          ok( $input.is( ":checked" ), false, "input is still not checked after refresh");
+          equal($second_input.jqmData("cells").eq(0).jqmData("test"), "abc",
+            "cell reference in popup is to cell currently in table");
+          equal($visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible");
+      });
+    }, 1200);
+  });
 	asyncTest( "The dialog should become visible when button is clicked" , function(){
 		expect( 2 );
 		var $input;

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -56,7 +56,7 @@
 				ok($firstHeaderCell.jqmData("cells").length,
 					"column cells still assigned to header cell");
 				equal($firstHeaderCell.jqmData('cells').eq(0).closest("table").attr('id'),
-					"basic-table-test",
+					"movie-table",
 					"cell stored is a refreshed cell (currently in the table");
 				equal($cellLookUp, $firstHeaderCell.jqmData('cells').eq(0).jqmData("test"),
 					"referenced cell is in the correct column");


### PR DESCRIPTION
Branch table-refresh-1.3 has been created out of 1.3-stable.

@frequent's commits from PR #5845 (except the "merge branch master" commit) have been cherry-picked into this branch. After that another two PR's (each containing one commit) have been merged into this branch.

Branch table-refresh-1.3 will be merged into branch 1.3-stable so none of these commits will land in branch master. Those refresh methods for the table widget are only meant for 1.3.1 and following 1.3.x maintenance releases.
