### PR TITLE
Fix breakage on Firefox <4

### DIFF
--- a/js/jquery.mobile.support.js
+++ b/js/jquery.mobile.support.js
@@ -83,7 +83,7 @@ function transform3dTest() {
 	for ( t in transforms ) {
 		if( el.style[ t ] !== undefined ){
 			el.style[ t ] = "translate3d( 100px, 1px, 1px )";
-			ret = window.getComputedStyle( el ).getPropertyValue( transforms[ t ] );
+			ret = window.getComputedStyle( el, null ).getPropertyValue( transforms[ t ] );
 		}
 	}
 	return ( !!ret && ret !== "none" );


### PR DESCRIPTION
Prior to Gecko 2.0 (Firefox 4) getComputedStyle requires a second parameter.. See https://developer.mozilla.org/en/docs/DOM/window.getComputedStyle. This was introduced in 1.3.0.
