### PR TITLE
Table: toggle changed self.update() fixes #5839 - toggle breaks table priority hiding

### DIFF
--- a/css/structure/jquery.mobile.table.columntoggle.css
+++ b/css/structure/jquery.mobile.table.columntoggle.css
@@ -74,20 +74,3 @@
 		display: table-cell;
 	}
 }
-
-
-/* Unchecked manually: Always hide */
-.ui-table-columntoggle th.ui-table-cell-hidden,
-.ui-table-columntoggle td.ui-table-cell-hidden,
-.ui-table-columntoggle.ui-responsive th.ui-table-cell-hidden,
-.ui-table-columntoggle.ui-responsive td.ui-table-cell-hidden {
-	display: none;
-}
-
-/* Checked manually: Always show */
-.ui-table-columntoggle th.ui-table-cell-visible,
-.ui-table-columntoggle td.ui-table-cell-visible,
-.ui-table-columntoggle.ui-responsive th.ui-table-cell-visible,
-.ui-table-columntoggle.ui-responsive td.ui-table-cell-visible {
-	display: table-cell;
-}

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -95,13 +95,9 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", fun
 	}
 
 	if ( event !== "refresh" ) {
-		$switchboard.on( "change", "input", function( e ){
-			if( this.checked ){
-				$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-hidden" ).addClass( "ui-table-cell-visible" );
-			} else {
-				$( this ).jqmData( "cells" ).removeClass( "ui-table-cell-visible" ).addClass( "ui-table-cell-hidden" );
-			}
-		});
+    $switchboard.on( "change", "input", function( e ){
+      self.update( $(this), true );
+    });
 
 		$menuButton
 			.insertBefore( $table )
@@ -114,24 +110,38 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", fun
 			.popup();
 	}
 
-	// refresh method
-	self.update = function(){
-		$switchboard.find( "input" ).each( function(){
-			if (this.checked) {
-				this.checked = $( this ).jqmData( "cells" ).eq(0).css( "display" ) === "table-cell";
-				if (event === "refresh") {
-					$( this ).jqmData( "cells" ).addClass('ui-table-cell-visible');
-				}
-			} else {
-				$( this ).jqmData( "cells" ).addClass('ui-table-cell-hidden');
-			}
-			$( this ).checkboxradio( "refresh" );
-		});
-	};
+  // toggle popup handler
+  self.update = function( pass, override ){
+    var elems = pass === true ? $switchboard.find( "input" ) : pass;
 
-	$.mobile.window.on( "throttledresize", self.update );
+    elems.each(function(){
+      var blocker;
 
-	self.update();
+      // manual toggling via popup "locks" columns
+      if ( override ) {
+        if (this.checked) {
+          this.setAttribute("locked", "show");
+        } else {
+          this.setAttribute("locked", "hide");
+        }
+      }
+
+      blocker = this.getAttribute("locked");
+
+      if (blocker) {
+        // override CSS and keep input as-is
+        $( this ).jqmData( "cells" )[blocker]();
+      } else {
+        // update input status based on responsive CSS
+        this.checked = $(this).jqmData( "cells" ).eq(0).css( "display" ) !== "none";
+        $( this ).checkboxradio( "refresh" );
+      }
+    });
+  };
+
+  $.mobile.window.on( "throttledresize", function () { self.update(true) });
+
+  self.update(true);
 
 });
 

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -110,29 +110,35 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", fun
 			.popup();
 	}
 
-  // toggle popup handler
+  // toggle handler
   self.update = function( pass, override ){
     var elems = pass === true ? $switchboard.find( "input" ) : pass;
 
     elems.each(function(){
-      var blocker;
+      var blocker, undo;
 
-      // manual toggling via popup "locks" columns
+			// manual toggle lock/unlock
       if ( override ) {
-        if (this.checked) {
-          this.setAttribute("locked", "show");
+        if (this.getAttribute("set")) {
+          undo = this.getAttribute("locked") === "show" ? "hide" : "show";
+          this.removeAttribute("set");
+          this.removeAttribute("locked");
         } else {
-          this.setAttribute("locked", "hide");
+					if (this.checked) {
+						blocker = "show";
+          } else {
+						blocker = "hide";
+          }
+          this.setAttribute("set",true);
+					this.setAttribute("locked", blocker);
         }
       }
 
-      blocker = this.getAttribute("locked");
-
       if (blocker) {
-        // override CSS and keep input as-is
         $( this ).jqmData( "cells" )[blocker]();
+      } else if (undo) {
+        $( this ).jqmData( "cells" ).removeAttr("style");
       } else {
-        // update input status based on responsive CSS
         this.checked = $(this).jqmData( "cells" ).eq(0).css( "display" ) !== "none";
         $( this ).checkboxradio( "refresh" );
       }

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -47,7 +47,7 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", fun
 		$menu,
 		$switchboard;
 
-	if ( o.mode !== "columntoggle" ) {
+	if ( $table.jqmData("mode") !== "columntoggle" ) {
 		return;
 	}
 
@@ -95,9 +95,11 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", fun
 	}
 
 	if ( event !== "refresh" ) {
-    $switchboard.on( "change", "input", function( e ){
-      self.update( $(this), true );
-    });
+		$switchboard.on( "change", "input", function( e ){
+			if (e.bubbles === undefined) {
+				self.update( $(this), true );
+			}
+		});
 
 		$menuButton
 			.insertBefore( $table )
@@ -137,10 +139,12 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", fun
 
 			if (blocker) {
 				$( this ).jqmData( "cells" )[blocker]();
-			} else if (undo) {
-				$( this ).jqmData( "cells" ).removeAttr("style");
 			} else {
-				this.checked = $(this).jqmData( "cells" ).eq(0).css( "display" ) !== "none";
+				if (undo) {
+					$( this ).jqmData( "cells" ).removeAttr("style");
+				} else {
+					this.checked = $(this).jqmData( "cells" ).eq(0).css( "display" ) !== "none";
+				}
 				$( this ).checkboxradio( "refresh" );
 			}
 		});

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -110,44 +110,45 @@ $.mobile.document.delegate( ":jqmData(role='table')", "tablecreate refresh", fun
 			.popup();
 	}
 
-  // toggle handler
-  self.update = function( pass, override ){
-    var elems = pass === true ? $switchboard.find( "input" ) : pass;
+	// toggle handler
+	self.update = function( pass, override ){
+		var elems = pass === true ? $switchboard.find( "input" ) : pass;
 
-    elems.each(function(){
-      var blocker, undo;
-
+		elems.each(function(){
+			var blocker, undo;
 			// manual toggle lock/unlock
-      if ( override ) {
-        if (this.getAttribute("set")) {
-          undo = this.getAttribute("locked") === "show" ? "hide" : "show";
-          this.removeAttribute("set");
-          this.removeAttribute("locked");
-        } else {
-					if (this.checked) {
-						blocker = "show";
-          } else {
-						blocker = "hide";
-          }
-          this.setAttribute("set",true);
+			if ( override ) {
+				if (this.getAttribute("set")) {
+					undo = this.getAttribute("locked");
+					this.removeAttribute("set");
+					this.removeAttribute("locked");
+				} else {
+					blocker = this.checked ? "show" : "hide";
+					this.setAttribute("set",true);
 					this.setAttribute("locked", blocker);
-        }
-      }
+				}
+			}
 
-      if (blocker) {
-        $( this ).jqmData( "cells" )[blocker]();
-      } else if (undo) {
-        $( this ).jqmData( "cells" ).removeAttr("style");
-      } else {
-        this.checked = $(this).jqmData( "cells" ).eq(0).css( "display" ) !== "none";
-        $( this ).checkboxradio( "refresh" );
-      }
-    });
-  };
+			if (event === "refresh") {
+				if (this.getAttribute("set")) {
+					blocker = this.checked ? "show" : "hide";
+				}
+			}
 
-  $.mobile.window.on( "throttledresize", function () { self.update(true) });
+			if (blocker) {
+				$( this ).jqmData( "cells" )[blocker]();
+			} else if (undo) {
+				$( this ).jqmData( "cells" ).removeAttr("style");
+			} else {
+				this.checked = $(this).jqmData( "cells" ).eq(0).css( "display" ) !== "none";
+				$( this ).checkboxradio( "refresh" );
+			}
+		});
+	};
 
-  self.update(true);
+	$.mobile.window.on( "throttledresize", function () { self.update(true) });
+
+	self.update(true);
 
 });
 

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -61,7 +61,7 @@ $.widget( "mobile.table", $.mobile.widget, {
 					}
 					// Store "cells" data on header as a reference to all cells in the same column as this TH
 					$( this )
-						.jqmData( "cells", self.element.find( "tr" ).not( trs.eq(0) ).not( this ).children( sel ) );
+						.jqmData( "cells", self.element.find( "tr" ).not( trs.eq(0) ).children( sel ) );
 
 					coltally++;
 

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -179,12 +179,12 @@
 					
 					var $table = $('#column-table-test .ui-table'),
 						$first_input = $( "#movie-table-column-popup-popup" ).find( "input" ).eq(0),
-						$visibleCells = $table.find("tbody tr:first").find("th, td").not('.ui-table-cell-hidden'),
-						$visibleHeaders = $table.find("thead tr:first").find("th, td").not('.ui-table-cell-hidden');
+						$visibleCells = $table.find("tbody tr:first").find("th, td").filter( ":visible" ),
+						$visibleHeaders = $table.find("thead tr:first").find("th, td").filter( ":visible" );
 						
 					ok( $table.length, "table still enhanced");
 					equal( $table.find('tbody tr:first')
-						.find("th, td").eq(2).hasClass('ui-table-cell-hidden'), true, "random cell in hidden column has ui-table-cell-hidden class");
+						.find("th, td").eq(2).is(":visible"), false, "random cell in hidden column is not visible");
 					ok( $input.is( ":checked" ), false, "input is still not checked after refresh");
 					equal( $first_input.jqmData("cells").eq(1).data("test"), "abc",
 						"cell reference in popup is to cell currently in table");
@@ -216,9 +216,9 @@
 				setTimeout(function(){
 					var headers = $( "#column-table-test table tr" ).find( "th:first" );
 					if( $input.is( ":checked" ) ){
-						ok( headers.not( ".ui-table-cell-hidden" ) );
+						ok( headers.is( ":hidden" )  );
 					} else {
-						ok( headers.is( ".ui-table-cell-hidden" ) );
+						ok( headers.is( ":visible" ) );
 					}
 				}, 800);
 			},

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -216,9 +216,9 @@
 				setTimeout(function(){
 					var headers = $( "#column-table-test table tr" ).find( "th:first" );
 					if( $input.is( ":checked" ) ){
-						ok( headers.is( ":hidden" )  );
+						ok( headers.is( ":visible" )  );
 					} else {
-						ok( headers.is( ":visible" ) );
+						ok( headers.is( ":hidden" ) );
 					}
 				}, 800);
 			},

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -185,7 +185,7 @@
 					ok( $table.length, "table still enhanced");
 					equal( $table.find('tbody tr:first')
 						.find("th, td").eq(2).is(":visible"), false, "random cell in hidden column is not visible");
-					ok( $input.is( ":checked" ), false, "input is still not checked after refresh");
+					equal( $input.is( ":checked" ), false, "input is still not checked after refresh");
 					equal( $first_input.jqmData("cells").eq(1).data("test"), "abc",
 						"cell reference in popup is to cell currently in table");
 					equal( $visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible" );
@@ -216,9 +216,9 @@
 				setTimeout(function(){
 					var headers = $( "#column-table-test table tr" ).find( "th:first" );
 					if( $input.is( ":checked" ) ){
-						ok( headers.is( ":visible" )  );
+						ok( headers.is( ":hidden" )  );
 					} else {
-						ok( headers.is( ":hidden" ) );
+						ok( headers.is( ":visible" ) );
 					}
 				}, 800);
 			},

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -162,39 +162,25 @@
 	});
 	asyncTest( "Column toggle table refresh" , function(){
 		expect( 5 );
-		
-		var $input;
-		
-		$.testHelper.pageSequence([
-			function() {
-				$( ".ui-table-columntoggle-btn" ).click();
-			},
-			function() {
-				$input = $( "#movie-table-column-popup-popup" ).find( "input" ).eq(0);
-				$input.click();
-			},
-			function(){
-				setTimeout(function () {
-					$(window).trigger("refresh_test_table", ["#column-table-test"]);
-					
-					var $table = $('#column-table-test .ui-table'),
-						$first_input = $( "#movie-table-column-popup-popup" ).find( "input" ).eq(0),
-						$visibleCells = $table.find("tbody tr:first").find("th, td").filter( ":visible" ),
-						$visibleHeaders = $table.find("thead tr:first").find("th, td").filter( ":visible" );
-						
-					ok( $table.length, "table still enhanced");
-					equal( $table.find('tbody tr:first')
-						.find("th, td").eq(2).is(":visible"), false, "random cell in hidden column is not visible");
-					equal( $input.is( ":checked" ), false, "input is still not checked after refresh");
-					equal( $first_input.jqmData("cells").eq(1).data("test"), "abc",
-						"cell reference in popup is to cell currently in table");
-					equal( $visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible" );
-				}, 800);
-			},
-			function() {
-				start();
-			}
-		]);
+		var $input = $( "#movie-table-column-popup-popup" ).find( "input" ).eq(0);
+		$input.click();
+
+		setTimeout(function () {
+			$(window).trigger("refresh_test_table", ["#column-table-test"]);
+
+			var $table = $('#column-table-test .ui-table'),
+				$first_input = $( "#movie-table-column-popup-popup" ).find( "input" ).eq(0),
+				$visibleCells = $table.find("tbody tr:first").find("th, td").filter( ":visible" ),
+				$visibleHeaders = $table.find("thead tr:first").find("th, td").filter( ":visible" );
+			ok( $table.length, "table still enhanced");
+			equal( $table.find('tbody tr:first')
+				.find("th, td").eq(2).is(":visible"), false, "random cell in hidden column is not visible");
+			equal( $input.is( ":checked" ), true, "input is checked after refresh");
+			equal( $first_input.jqmData("cells").eq(1).data("test"), "abc",
+				"cell reference in popup is to cell currently in table");
+			equal( $visibleCells.length, $visibleHeaders.length, "same number of headers and rows visible" );
+			start();
+		}, 800);
 	});
 	asyncTest( "The dialog should become visible when button is clicked" , function(){
 		expect( 2 );
@@ -209,16 +195,16 @@
 				}, 800);
 			},
 			function() {
-				$input = $( ".ui-popup-container" ).find( "input:first" );
+				$input = $( "#movie-table-column-popup-popup" ).find( "input:first" );
 				$input.click();
 			},
 			function(){
 				setTimeout(function(){
-					var headers = $( "#column-table-test table tr" ).find( "th:first" );
+					var headers = $( "#column-table-test table thead tr" ).find( "th:first" );
 					if( $input.is( ":checked" ) ){
-						ok( headers.is( ":hidden" )  );
+						ok( headers.is( ":visible" )  );
 					} else {
-						ok( headers.is( ":visible" ) );
+						ok( headers.is( ":hidden" ) );
 					}
 				}, 800);
 			},


### PR DESCRIPTION
This should fix #5839 - columns stay hidden when shrinking and resizing the browser window. 

With the fix, showing and hiding of columns is purely done based on priority-CSS. Only when the user manually toggles a column it's `jqmData(cells)` which now also includes the header cell itself will be locked to `show()/hide()`. 

With the fix, there is also no more need for `ui-table-cell-hidden` and `ui-table-cell-visible`.

Hope this is the correct branch...

[Sample page with fix](http://bit.ly/17WKxop)
