### PR TITLE
Add flag for taphold to avoid firing a tap event after the taphold event.

### DIFF
--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -79,9 +79,11 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 
 		setup: function() {
 			var thisObject = this,
-				$this = $( thisObject );
+				$this = $( thisObject ),
+				isTapHold = false;
 
 			$this.bind( "vmousedown", function( event ) {
+				isTapHold = false;
 
 				if ( event.which && event.which !== 1 ) {
 					return false;
@@ -107,7 +109,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 
 					// ONLY trigger a 'tap' event if the start target is
 					// the same as the stop target.
-					if ( origTarget === event.target ) {
+					if ( !isTapHold && origTarget === event.target ) {
 						triggerCustomEvent( thisObject, "tap", event );
 					}
 				}
@@ -117,6 +119,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 				$document.bind( "vmousecancel", clearTapHandlers );
 
 				timer = setTimeout( function() {
+					isTapHold = true;
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold", { target: origTarget } ) );
 				}, $.event.special.tap.tapholdThreshold );
 			});


### PR DESCRIPTION
Fix [issue 3803](https://github.com/jquery/jquery-mobile/issues/3803) by setting up a flag for taphold and avoid triggering the tap event if the flag is set to true (the flag is set to false at the start of mousedown event handler and only set to true when the taphold event is triggered). This doesn't involve delaying the tap event. All tests run without errors.
