### PR TITLE
3803 taphold not to emit tap event option

### DIFF
--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -76,13 +76,14 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 	// also handles taphold
 	$.event.special.tap = {
 		tapholdThreshold: 750,
-
+		emitTapOnTaphold: true,
 		setup: function() {
 			var thisObject = this,
-				$this = $( thisObject );
+				$this = $( thisObject ),
+				isTaphold = false;
 
 			$this.bind( "vmousedown", function( event ) {
-
+				isTaphold = false;
 				if ( event.which && event.which !== 1 ) {
 					return false;
 				}
@@ -107,7 +108,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 
 					// ONLY trigger a 'tap' event if the start target is
 					// the same as the stop target.
-					if ( origTarget === event.target ) {
+					if ( $.event.special.tap.emitTapOnTaphold && !isTaphold && origTarget === event.target ) {
 						triggerCustomEvent( thisObject, "tap", event );
 					}
 				}
@@ -117,6 +118,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 				$document.bind( "vmousecancel", clearTapHandlers );
 
 				timer = setTimeout( function() {
+					isTaphold = true;
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold", { target: origTarget } ) );
 				}, $.event.special.tap.tapholdThreshold );
 			});

--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -108,7 +108,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 
 					// ONLY trigger a 'tap' event if the start target is
 					// the same as the stop target.
-					if ( $.event.special.tap.emitTapOnTaphold && !isTaphold && origTarget === event.target ) {
+					if ( !isTaphold && origTarget === event.target ) {
 						triggerCustomEvent( thisObject, "tap", event );
 					}
 				}
@@ -118,7 +118,9 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 				$document.bind( "vmousecancel", clearTapHandlers );
 
 				timer = setTimeout( function() {
-					isTaphold = true;
+					if ( !$.event.special.tap.emitTapOnTaphold ) {
+						isTaphold = true;
+					}
 					triggerCustomEvent( thisObject, "taphold", $.Event( "taphold", { target: origTarget } ) );
 				}, $.event.special.tap.tapholdThreshold );
 			});

--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -110,6 +110,8 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 					// the same as the stop target.
 					if ( !isTaphold && origTarget === event.target ) {
 						triggerCustomEvent( thisObject, "tap", event );
+					}  else if ( isTaphold ) {
+						event.stopPropagation();
 					}
 				}
 


### PR DESCRIPTION
As explained in [the previous PR discussion](https://github.com/jquery/jquery-mobile/pull/5980), there is an issue with how the option has been implemented where it will be bypassed and the taphold will not emit a tap when the option is set to true and if option is set to false, then tap will never be triggered which would be a bigger issue. 
This PR also fixes an edge case when the taphold event is bound to a link, a mouseup event will still be triggered by propagation and will lead to the link being opened after the taphold is triggered. This is avoided by using  `event.stopPropagation()` in case of `taphold`.

Thanks.
-Jerome
