### PR TITLE
$.find: added indexOf checking for jqmData selector to improve speed on non-jqm selectors

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -14,6 +14,7 @@ define( [ "jquery", "./jquery.mobile.ns", "json!../package.json" ], function( jQ
 	var nsNormalizeDict = {},
 		// Monkey-patching Sizzle to filter the :jqmData selector
 		oldFind = $.find,
+		jqmSelector = ":jqmData",
 		jqmDataRE = /:jqmData\(([^)]*)\)/g;
 
 	// jQuery.mobile configurable options
@@ -327,7 +328,9 @@ define( [ "jquery", "./jquery.mobile.ns", "json!../package.json" ], function( jQ
 	};
 
 	$.find = function( selector, context, ret, extra ) {
-		selector = selector.replace( jqmDataRE, "[data-" + ( $.mobile.ns || "" ) + "$1]" );
+		if ( selector.indexOf( jqmSelector ) > -1 ) {
+			selector = selector.replace( jqmDataRE, "[data-" + ( $.mobile.ns || "" ) + "$1]" );
+		}
 
 		return oldFind.call( this, selector, context, ret, extra );
 	};


### PR DESCRIPTION
$.find always runs regexp on given selector string. The problem is, that some apps (and even some widgets) do more normal selector searching than :jqmData searching. 

I added checking for :jqmData keyword in selector by simple indexOf method, which is faster, not that it makes a huge difference, but still.

Please refer to the test on [http://jsperf.com/jquery-mobile-find-patch-performance-fix](http://jsperf.com/jquery-mobile-find-patch-performance-fix)

Note that the

``` js
jqmSelector = ":jqmData",
jqmDataRE = /:jqmData\(([^)]*)\)/g;
```

duplication could be changed also
