### PR TITLE
Fix for placeholder text not being grayed out in IE10

### DIFF
--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -23,6 +23,9 @@ textarea.ui-mini { height: 45px; }
 /* Resolves issue #5166: Added to support issue introduced in Firefox 15. We can likely remove this in the future. */
 input::-moz-placeholder, textarea::-moz-placeholder { color: #aaa; }
 
+/* For IE10 */
+:-ms-input-placeholder { color: #aaa; }
+
 /* Resolves issue #5131: Width of textinput depends on its type, for Android 4.1 */
 input[type=number]::-webkit-outer-spin-button { margin: 0; }
 


### PR DESCRIPTION
looks like a similar issue to #5166
