### PR TITLE
Select: Add label class correctly when independent from browser DOM.

### DIFF
--- a/js/widgets/forms/select.js
+++ b/js/widgets/forms/select.js
@@ -53,7 +53,13 @@ $.widget( "mobile.selectmenu", $.mobile.widget, $.extend( {
 
 	// setup items that are generally necessary for select menu extension
 	_preExtension: function() {
-		var classes = "";
+		var classes = "",
+			root = this.element.closest( "form, fieldset, :jqmData(role='page'), :jqmData(role='dialog')" );
+
+		if( root.length === 0 ) {
+			root = this.element.parents().last();
+		}
+
 		// TODO: Post 1.1--once we have time to test thoroughly--any classes manually applied to the original element should be carried over to the enhanced element, with an `-enhanced` suffix. See https://github.com/jquery/jquery-mobile/issues/3577
 		/* if ( $el[0].className.length ) {
 			classes = $el[0].className;
@@ -68,7 +74,7 @@ $.widget( "mobile.selectmenu", $.mobile.widget, $.extend( {
 
 		this.select = this.element.removeClass( "ui-btn-left ui-btn-right" ).wrap( "<div class='ui-select" + classes + "'>" );
 		this.selectID  = this.select.attr( "id" );
-		this.label = $( "label[for='"+ this.selectID +"']" ).addClass( "ui-select" );
+		this.label = root.find( "label[for='" + this.selectID + "']" ).addClass( "ui-select" );
 		this.isMultiple = this.select[ 0 ].multiple;
 		if ( !this.options.theme ) {
 			this.options.theme = $.mobile.getInheritedTheme( this.select, "c" );

--- a/tests/unit/select/select_core.js
+++ b/tests/unit/select/select_core.js
@@ -201,6 +201,20 @@
 		ok( $( "#native-select-choice-few-container label" ).hasClass( "ui-select" ), "created label has ui-select class" );
 	});
 
+	test( "make sure the label for the select gets the ui-select class when independent from browser DOM", function(){
+		var unenhancedSelect = $(
+				"<div>" +
+				"  <label for='sample'>Sample</label>" +
+				"  <select id='sample'>" +
+				"    <option>Test</option>" +
+				"  </select>" +
+				"</div>");
+
+		unenhancedSelect.find("select").selectmenu();
+
+		ok( unenhancedSelect.find("label").hasClass( "ui-select" ), "created label has ui-select class" );
+	});
+
 	module("Non native menus", {
 		setup: function() {
 			$.mobile.selectmenu.prototype.options.nativeMenu = false;


### PR DESCRIPTION
I found a issue about `ui-select` class of label with selectmenu in independent DOM tree.
Our project use jQuery mobile with Backbone.js, and create DOM tree independent from browser DOM dynamically.

If browser DOM contains label tag, add `ui-select` class to the label when call `selectmenu()` on select tag correctly.
But, `selectmenu()` doesn't add `ui-select` class when independent DOM contains label tag.

TestPage: http://jsbin.com/asilus/5/edit

I expect to set same class on the label each way.
