### PR TITLE
$.mobile.getAttribute : Add a validation logic into getAttribute function to prevent errors.

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -121,13 +121,15 @@ define( [ "jquery", "./jquery.mobile.ns", "json!../package.json" ], function( jQ
 
 		// Retrieve an attribute from an element and perform some massaging of the value
 		getAttribute: function( e, key, dns ) {
-			var value;
+			var elem = e.get ? e[ 0 ] : e,
+				value;
 
-			if ( dns ) {
-				key = "data-" + $.mobile.ns + key;
+			if ( elem && elem.getAttribute ) {
+				if ( dns ) {
+					key = "data-" + $.mobile.ns + key;
+				}
+				value = e.getAttribute( key );
 			}
-
-			value = e.getAttribute( key );
 
 			return value === "true" ? true :
 				value === "false" ? false :


### PR DESCRIPTION
Hi all.

I’d like to propose to improve ‘$.mobile.getAttribute’ method in jquery.mobile.core.js.
I know that @gabrielschulhof made the method to improve performance.

@gabrielschulhof, I found a problem in the method  while I use it on Tizen Web UIFW.

If an element of argument is null or it does not support native function(getAttribute), That method will make errors.

So  we’d better to add validation logics into the function to prevent the errors.

As you guys can see my PR codes, I added some validation logics in the getAttribute.
Please check it.
