### PR TITLE
Collapsible vmousecancel

### DIFF
--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -134,6 +134,9 @@ $.widget( "mobile.collapsible", $.mobile.widget, {
 			"tap": function(/* event */) {
 				collapsibleHeading.find( "a" ).first().addClass( $.mobile.activeBtnClass );
 			},
+			"vmousecancel": function(/* event */) {
+				collapsibleHeading.find( "a" ).first().removeClass( $.mobile.activeBtnClass );
+			},
 
 			"click": function( event ) {
 

--- a/tests/integration/collapsible/collapsible_core.js
+++ b/tests/integration/collapsible/collapsible_core.js
@@ -302,5 +302,27 @@
 			}
 		]);
 	});
+
+	asyncTest( "Collapsible vmousecancel", function(){
+		expect( 2 );
+		$.testHelper.pageSequence([
+			function(){
+				$.mobile.changePage( $( "#collapsible-vmousecancel" ) );
+			},
+
+			function() {
+				var collapsible = $.mobile.activePage.find( ".ui-collapsible" ),
+					collapsibleHeading = collapsible.find("h4"),
+					event = jQuery.Event("tap");
+				event = jQuery.Event("tap");
+				collapsibleHeading.trigger(event);
+				equal(collapsible.find("a.ui-btn-active").length, 1, "Heading is active after tap");
+				event = jQuery.Event("vmousecancel");
+				collapsibleHeading.trigger(event);
+				equal(collapsible.find("a.ui-btn-active").length, 0, "Heading is not active when collapse/expand is cancelled");
+				start();
+			}
+		]);
+	});
 	
 })( jQuery );

--- a/tests/integration/collapsible/index.html
+++ b/tests/integration/collapsible/index.html
@@ -344,5 +344,21 @@
 	</div>
 </div>
 
+<div data-nstest-role="page" id="collapsible-vmousecancel">
+	<div data-nstest-role="header">
+		<h1>Collapsible vmousecancel</h1>
+	</div>
+	<div data-nstest-role="content">
+		<div data-nstest-role="collapsible">
+			<h4>Heading</h4>
+			<ul data-nstest-role="listview">
+				<li><a href="#">List item 1</a></li>
+				<li><a href="#">List item 2</a></li>
+				<li><a href="#">List item 3</a></li>
+			</ul>
+		</div>
+	</div>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Hi. This is not easy to reproduce bug but when you check this code, it makes more sense :)

It works only on mobile browsers, where tap event is called.
Test page: http://jsbin.com/ujudog/1/
Code: http://jsbin.com/ujudog/1/edit
Before: 
![merge0](https://f.cloud.github.com/assets/411343/642073/0f84467c-d34c-11e2-9e28-266b7d94190e.png)
1. Double tap  on "Heading"
2. Make sure your second tap is finished (move your finger) outside "Heading".
3. If collapsible didn't expand, it worked.
4. "Heading" should have ui-btn-active class (blue):

![merge2](https://f.cloud.github.com/assets/411343/642070/ea3a19b4-d34b-11e2-8def-c28a0ba3e73f.png)

This happens, because ui-btn-active class is removed only on expand/collapse event. When user triggers only tap and mousecancel, this class is not removed.
I added test case but it just tests that vmousecancel removes this class.
