### PR TITLE
fixing vmouse start/stop events to use clientX/clientY rather than pageX/pageY

### DIFF
--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -150,7 +150,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 					event.originalEvent.touches[ 0 ] : event;
 			return {
 						time: ( new Date() ).getTime(),
-						coords: [ data.pageX, data.pageY ],
+						coords: [ data.clientX, data.clientY ],
 						origin: $( event.target )
 					};
 		},
@@ -160,7 +160,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 					event.originalEvent.touches[ 0 ] : event;
 			return {
 						time: ( new Date() ).getTime(),
-						coords: [ data.pageX, data.pageY ]
+						coords: [ data.clientX, data.clientY ]
 					};
 		},
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "async": "latest",
-    "grunt": "~0.4.1",
+    "grunt": "0.4.x",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-compress": "~0.4.1",
     "grunt-contrib-concat": "~0.1.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "async": "latest",
-    "grunt": "0.4.x",
+    "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-compress": "~0.4.1",
     "grunt-contrib-concat": "~0.1.3",

--- a/tests/unit/event/event_core.js
+++ b/tests/unit/event/event_core.js
@@ -411,8 +411,8 @@
 		//NOTE bypass the trigger source check
 		$.Event.prototype.originalEvent = {
 			touches: [{
-				pageX: 0,
-				pageY: 0
+				clientX: 0,
+				clientY: 0
 			}]
 		};
 
@@ -421,8 +421,8 @@
 		//NOTE bypass the trigger source check
 		$.Event.prototype.originalEvent = {
 			touches: [{
-				pageX: 200,
-				pageY: 0
+				clientX: 200,
+				clientY: 0
 			}]
 		};
 


### PR DESCRIPTION
swipeleft and swiperight events were being triggered when scrolling up and down large documents.

the vmouse start and stop events were using pageX and pageY, causing the delta Y to only register a few pixels. This causes the swipeleft/swiperight vertical threshold to never be met, and these events would be triggered even on swipes that were mostly in the up or down direction.

As an extra precaution, a ratio of horizontal to vertical distance could be added in the handleSwipe function, so that threshold values don't have to be hardcoded. 
