### PR TITLE
table widget review

### DIFF
--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -16,6 +16,7 @@ define( [
 (function( $, undefined ) {
 
 $.widget( "mobile.table", $.mobile.table, {
+
 	options: {
 		mode: "columntoggle",
 		columnBtnTheme: null,
@@ -30,16 +31,8 @@ $.widget( "mobile.table", $.mobile.table, {
 	},
 
 	_create: function() {
-		var id, $menuButton, $popup, $menu,
-			$table = this.element,
-			o = this.options,
-			ns = $.mobile.ns,
-			menuInputChange = function(/* e */) {
-				var checked = this.checked;
-				$( this ).jqmData( "cells" )
-					.toggleClass( "ui-table-cell-hidden", !checked )
-					.toggleClass( "ui-table-cell-visible", checked );
-			};
+		var o = this.options,
+			$menu;
 
 		this._super();
 
@@ -47,68 +40,149 @@ $.widget( "mobile.table", $.mobile.table, {
 			return;
 		}
 
-		this.element.addClass( o.classes.columnToggleTable );
+		$.extend( this, {
+			// will be set inside _enhance() or by referenceClass
+			_menu: undefined
+		});
+
+		if( !o.enhanced ) {
+
+			this.element.addClass( o.classes.columnToggleTable );
+
+			this._enhanceColToggle();
+
+		} else {
+			// NOTE: need a better way to access elements pre-enhanced by the user
+			this._menu = $( "." + o.referenceClass );
+		}
+
+		this._setupEvents();
+
+		this._setToggleState();
+	},
+
+	_setupEvents: function () {
+		//NOTE: inputs are bound in bindToggles,
+		// so it can be called on refresh, too
+
+		// update column toggles on resize
+		this._on( $.mobile.window, {
+			throttledresize: "_setToggleState"
+		});
+
+		// bind to refresh call of table
+		this._on( this.element, {
+			refresh: "_refreshColToggle"
+		});
+	},
+
+	_bindToggles: function() {
+		var inputs = this._menu.find( "input" );
+
+		this._on( inputs, {
+			change: "_menuInputChange"
+		});
+	},
+
+	_addToggles: function( menu ) {
+		var o = this.options;
+		// allow update of menu on refresh (fixes #5880)
+		menu.empty();
+
+		// create the hide/show toggles
+		this.headers.not( "td" ).each( function() {
+			var $this = $( this ),
+				priority = $.mobile.getAttribute( this, "priority", true ),
+				$cells = $this.add( $this.data( "cells" ) );
+
+			if( priority ) {
+				$cells.addClass( o.classes.priorityPrefix + priority );
+
+				$("<label><input type='checkbox' checked />" + $this.text() + "</label>" )
+					.appendTo( menu )
+					.children( 0 )
+					.data( "cells", $cells )
+					.checkboxradio( {
+						theme: o.columnPopupTheme
+					});
+			}
+
+		});
+
+		// set bindings here
+		this._bindToggles();
+	},
+
+	_menuInputChange: function( e ) {
+		var that = e.target,
+			$that = $( that ),
+			checked = that.checked,
+			locked = that.getAttribute("locked");
+
+		$that.data( "cells" )
+			.toggleClass( "ui-table-cell-hidden", !checked )
+			.toggleClass( "ui-table-cell-visible", checked );
+
+		if ( locked ) {
+			$that.removeAttr( "locked" );
+
+			this._unlockCells( $that.data( "cells" ) );
+		} else {
+			$that.attr( "locked" , true);
+		}
+	},
+
+	_unlockCells: function( cells ) {
+		// allow hide/show via CSS only = remove all toggle-locks
+		cells.removeClass( "ui-table-cell-hidden ui-table-cell-visible");
+	},
+
+	_enhanceColToggle: function() {
+		var id , $menuButton, $popup, $menu,
+			$table = this.element,
+			o = this.options,
+			ns = $.mobile.ns;
 
 		id = ( $table.attr( "id" ) || o.classes.popup ) + "-popup"; //TODO BETTER FALLBACK ID HERE
 		$menuButton = $( "<a href='#" + id + "' class='" + o.classes.columnBtn + "' data-" + ns + "rel='popup' data-" + ns + "mini='true'>" + o.columnBtnText + "</a>" );
 		$popup = $( "<div data-" + ns + "role='popup' data-" + ns + "role='fieldcontain' class='" + o.classes.popup + "' id='" + id + "'></div>" );
 		$menu = $( "<fieldset data-" + ns + "role='controlgroup'></fieldset>" );
 
-		// create the hide/show toggles
-		this.headers.not( "td" ).each( function() {
-			var $this = $( this ),
-				priority = $this.jqmData( "priority" ),
-				$cells = $this.add( $this.jqmData( "cells" ) );
+		this._menu = $menu;
 
-			if( priority ) {
-				$cells.addClass( o.classes.priorityPrefix + priority );
+		// set extension here
+		this._addToggles( this._menu );
 
-				$("<label><input type='checkbox' checked />" + $this.text() + "</label>" )
-					.appendTo( $menu )
-					.children( 0 )
-					.jqmData( "cells", $cells )
-					.checkboxradio( {
-						theme: o.columnPopupTheme
-					});
-			}
-		});
-		$menu.appendTo( $popup );
-
-		// bind change event listeners to inputs - TODO: move to a private method?
-		$menu.on( "change", "input", menuInputChange );
+		this._menu.appendTo( $popup );
 
 		$menuButton
-			.insertBefore( $table )
-			.addClass( "ui-btn ui-btn-" + ( o.columnBtnTheme || "a" ) + " ui-corner-all ui-shadow ui-mini" );
+			.addClass( "ui-btn ui-btn-" + ( o.columnBtnTheme || "a" ) + " ui-corner-all ui-shadow ui-mini" )
+			.insertBefore( $table );
 
 		$popup
 			.insertBefore( $table )
 			.popup();
-
-		// refresh method
-
-		this._on( $.mobile.window, { "throttledresize": "refresh" } );
-
-		$.extend( this, {
-			_menu: $menu,
-			_menuInputChange: menuInputChange
-		});
-
-		this.refresh();
 	},
 
-	_destroy: function() {
-		this._menu.off( "change", "input", this._menuInputChange );
-		this._super();
+	_refreshColToggle: function () {
+		// columns not being replaced must be cleared from input toggle-locks
+		this._unlockCells( this.allHeaders );
+
+		// update columntoggles and $cells
+		this._addToggles( this._menu );
 	},
 
-	refresh: function() {
+	_setToggleState: function() {
 		this._menu.find( "input" ).each( function() {
 			var $this = $( this );
 
-			this.checked = $this.jqmData( "cells" ).eq( 0 ).css( "display" ) === "table-cell";
+			this.checked = $this.data( "cells" ).eq( 0 ).css( "display" ) === "table-cell";
 			$this.checkboxradio( "refresh" );
 		});
+	},
+
+	_destroy: function() {
+		this._super();
 	}
 });
 

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -91,6 +91,7 @@ $.widget( "mobile.table", $.mobile.table, {
 
 		// create the hide/show toggles
 		this.headers.not( "td" ).each( function() {
+
 			var $this = $( this ),
 				priority = $.mobile.getAttribute( this, "priority", true ),
 				$cells = $this.add( $this.data( "cells" ) );
@@ -155,13 +156,13 @@ $.widget( "mobile.table", $.mobile.table, {
 
 		this._menu.appendTo( $popup );
 
-		$menuButton
-			.addClass( "ui-btn ui-btn-" + ( o.columnBtnTheme || "a" ) + " ui-corner-all ui-shadow ui-mini" )
-			.insertBefore( $table );
-
 		$popup
 			.insertBefore( $table )
 			.popup();
+
+		$menuButton
+			.addClass( "ui-btn ui-btn-" + ( o.columnBtnTheme || "a" ) + " ui-corner-all ui-shadow ui-mini" )
+			.insertBefore( $table );
 	},
 
 	_refreshColToggle: function () {
@@ -170,6 +171,9 @@ $.widget( "mobile.table", $.mobile.table, {
 
 		// update columntoggles and $cells
 		this._addToggles( this._menu );
+
+		// check/uncheck
+		this._setToggleState();
 	},
 
 	_setToggleState: function() {

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -31,8 +31,7 @@ $.widget( "mobile.table", $.mobile.table, {
 	},
 
 	_create: function() {
-		var o = this.options,
-			$menu;
+		var o = this.options;
 
 		this._super();
 

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -10,41 +10,61 @@ define( [ "jquery", "../jquery.mobile.widget", "./page", "../jquery.mobile.regis
 (function( $, undefined ) {
 
 $.widget( "mobile.table", {
+
 	options: {
 		classes: {
 			table: "ui-table"
-		}
+		},
+		referenceClass: "",
+		enhanced: false
 	},
 
 	_create: function() {
-		var $el = this.element,
-			trs = this.element.find( "thead tr" ),
-			headers = this.element.find( "tr:eq(0)" ).children(),
-			allHeaders = headers.add( trs.children() );
+		var o = this.options;
 
-		this.element.addClass( this.options.classes.table );
+		if ( !o.enhanced ) {
+			this.element.addClass( this.options.classes.table );
+		}
 
+		// extend here, assign on refresh > _setHeaders
 		$.extend( this, {
 
 			// Expose headers and allHeaders properties on the widget
 			// headers references the THs within the first TR in the table
-			headers: headers,
+			headers: undefined,
 
 			// allHeaders references headers, plus all THs in the thead, which may include several rows, or not
-			allHeaders: allHeaders
+			allHeaders: undefined
 		});
+
+		this.refresh( true );
+	},
+
+	_setHeaders: function() {
+		var trs = this.element.find( "thead tr" );
+
+		this.headers = this.element.find( "tr:eq(0)" ).children();
+		this.allHeaders = this.headers.add( trs.children() );
+	},
+
+	refresh: function( create ) {
+		var $el = this.element,
+			trs = $el.find( "thead tr" );
+
+		// updating headers on refresh (fixes #5880)
+		this._setHeaders();
 
 		trs.each( function() {
 			var coltally = 0,
 				$this = $( this );
 
 			$this.children().each( function() {
-				var $this = $( this ),
-					span = parseInt( $this.attr( "colspan" ), 10 ),
+				var that = this,
+					span = parseInt( $.mobile.getAttribute( that, "colspan", true), 10 ),
 					sel = ":nth-child(" + ( coltally + 1 ) + ")",
 					j;
 
-				$this.jqmData( "colstart", coltally + 1 );
+				that.setAttribute( "data-colstart", coltally + 1 );
 
 				if( span ) {
 					for( j = 0; j < span - 1; j++ ) {
@@ -53,14 +73,20 @@ $.widget( "mobile.table", {
 					}
 				}
 
-				// Store "cells" data on header as a reference to all cells in the same column as this TH
-				$this
-					.jqmData( "cells", $el.find( "tr" ).not( trs.eq( 0 ) ).not( this ).children( sel ) );
+				// Store "cells" data on header as a reference to all cells in the 
+				// same column as this TH
+				$( that ).data( "cells", $el.find( "tr" ).not( trs.eq( 0 ) ).not( that ).children( sel ) );
 
 				coltally++;
 			});
 		});
-	}
+
+		// propagate refresh on reflow/columntoggle
+		if ( create === undefined ) {
+			this.element.trigger( 'refresh' );
+		}
+}
+
 });
 
 $.mobile.table.initSelector = ":jqmData(role='table')";

--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -83,7 +83,7 @@ $.widget( "mobile.table", {
 
 		// propagate refresh on reflow/columntoggle
 		if ( create === undefined ) {
-			this.element.trigger( 'refresh' );
+			this.element.trigger( "refresh" );
 		}
 }
 

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -28,34 +28,61 @@ $.widget( "mobile.table", $.mobile.table, {
 			return;
 		}
 
-		this.element.addClass( o.classes.reflowTable );
+		if( !o.enhanced ) {
+			this.element.addClass( o.classes.reflowTable );
+
+			this._enhanceReflow();
+		}
+
+		// bind to refresh call of table
+		this._on( this.element, {
+			refresh: "_refreshReflow"
+		});
+	},
+
+	_enhanceReflow: function () {
+		this._updateReflow();
+	},
+
+	_refreshReflow: function () {
+		this._updateReflow( );
+	},
+
+	_updateReflow: function () {
+		var $el = this,
+			o = this.options;
 
 		// get headers in reverse order so that top-level headers are appended last
-		$( this.allHeaders.get().reverse() ).each( function() {
-			// create the hide/show toggles
-			var $cells = $( this ).jqmData( "cells" ),
-				colstart = $( this ).jqmData( "colstart" ),
-				hierarchyClass = $cells.not( this ).filter( "thead th" ).length && " ui-table-cell-label-top",
-				text = $(this).text(),
+		$( $el.allHeaders.get().reverse() ).each( function() {
+			var that = this,
+				$cells = $( that ).data( "cells" ),
+				colstart = $.mobile.getAttribute( this, "colstart", true ),
+				hierarchyClass = $cells.not( that ).filter( "thead th" ).length && " ui-table-cell-label-top",
+				text = $( that ).text(),
 				iteration, filter;
 
 				if( text !== ""  ) {
 
 					if( hierarchyClass ) {
-						iteration = parseInt( $( this ).attr( "colspan" ), 10 );
+						iteration = parseInt( that.getAttribute( "colspan" ), 10 );
 						filter = "";
 
 						if( iteration ){
 							filter = "td:nth-child("+ iteration +"n + " + ( colstart ) +")";
 						}
-						$cells.filter( filter ).prepend( "<b class='" + o.classes.cellLabels + hierarchyClass + "'>" + text + "</b>"  );
-					}
-					else {
-						$cells.prepend( "<b class='" + o.classes.cellLabels + "'>" + text + "</b>"  );
+
+						$el._addLabels( $cells.filter( filter ), o.classes.cellLabels + hierarchyClass, text );
+					} else {
+						$el._addLabels( $cells, o.classes.cellLabels, text );
 					}
 
 				}
 		});
+	},
+
+	_addLabels: function ( cells, label, text ) {
+		// .not fixes #6006
+		cells.not( ":has(b." + label + ")").prepend( "<b class='" + label + "'>" + text + "</b>"  );
 	}
 });
 

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -29,10 +29,27 @@
 		]);
 	</script>
 
-	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css" />
+	<link rel="stylesheet"	href="../../../css/themes/default/jquery.mobile.css" />
 	<link rel="stylesheet" href="../../../external/qunit.css"/>
 
 	<script src="../../swarminject.js"></script>
+	<script type="text/javascript">
+	// basic
+	var count = 0;
+	$(window).on('refresh_test_table', function (e, data) {
+		var tb = $(data).find('tbody'),
+				numbers = [1,2,3,4,5,6,7,8,9],
+				chars = ["a","b","c","d","e","f","g","h","i"],
+				use = count % 2 === 1 ? numbers : chars,
+				newRow = '<tr><th data-test="abc">'+use[0]+'</th><td>'+use[1]+'</td><td data-test="foo">'+use[2]+'</td><td data-col="3">'+use[3]+'</td><td>'+use[4]+'</td></tr>';
+		tb.empty()
+			.append(newRow)
+			.closest('table')
+			.table('refresh');
+		count += 1;
+	});
+</script>
+
 </head>
 <body>
 


### PR DESCRIPTION
@arschmitz: @uGoMobi: 

Little bit late, but let's see if we can everything fixed. The `master` code was pretty different from when I did the 1.4 table refresh, so no quick-copy-paste... I updated the current code in master and tried to stick to the suggestions you made on the filter widget. Plus it took me a while to realize that creating a `refresh` or `enhance` method in both `reflow/columntoggle` does not work, because the second one will always overwrite the first...

Anyway. 
- This commit passes the current Qunit tests on my machine.
- I'm now trying to pass the refresh tests I did for 1.4. Will commit asap
- Demo [Reflow](http://www.franckreich.de/jqm/table/reflow.html) and [Toggle](http://www.franckreich.de/jqm/table/toggle.html)
- This should fix:  
  #5856 New refresh method for table widget and extentions (tested)  
  #5839 Table column toggle breaks table priority hiding  (tested)  
  #5880 Refresh method from tables doesn´t update recently added columns (test still missing)  
  #6006 Refresh method on reflow-table duplicate label  (tested)  
  #6129 Table cells not hiding on smaller screen widths when headers and rows are dynamically injected (test still missing)  

I will try to add tests which add columns to confirm, the issues are fixed.

I'm also still wondering about #5630 and will try to take a look at #6121.

Questionable:
#6095 - error if no tbody is specified on a table. The docs say to use a JQM table requires the `tbody` tag to be set, so I would close this.
#6008 - display: table-frow-group makes table hard to center - I'd just recommend wrapping the table in that case
