### PR TITLE
Textinput: automatically shrinks

### DIFF
--- a/css/structure/jquery.mobile.forms.textinput.css
+++ b/css/structure/jquery.mobile.forms.textinput.css
@@ -9,7 +9,6 @@
 .ui-input-search input,
 textarea.ui-input-text {
 	padding: .4em;
-	min-height: 2.2em;
 	line-height: 1.4em;
 	display: block;
 	width: 100%;
@@ -22,6 +21,7 @@ textarea.ui-input-text {
 .ui-input-text input,
 .ui-input-search input {
 	margin: 0;
+	min-height: 2.2em;
 	text-align: left; /* Opera aligns type="date" right by default */
 	border: 0;
 	background: transparent none;
@@ -30,13 +30,8 @@ textarea.ui-input-text {
 	border-radius: inherit;
 }
 textarea.ui-input-text {
-	height: 3.125em;
 	overflow: auto;
 	resize: vertical;
-	-webkit-transition: height 200ms linear;
-	-moz-transition: height 200ms linear;
-	-o-transition: height 200ms linear;
-	transition: height 200ms linear;
 }
 .ui-mini .ui-input-text input,
 .ui-mini .ui-input-search input,

--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -119,7 +119,8 @@ $.widget( "mobile.textinput", {
 			this._keyup = function() {
 				input.css( "height", 0 );
 
-				var scrollHeight = input[ 0 ].scrollHeight,
+				var paddingTop, paddingBottom, paddingHeight,
+					scrollHeight = input[ 0 ].scrollHeight,
 					clientHeight = input[ 0 ].clientHeight,
 					borderTop = parseFloat( input.css( "border-top-width" ) ),
 					borderBottom = parseFloat( input.css( "border-bottom-width" ) ),
@@ -132,9 +133,9 @@ $.widget( "mobile.textinput", {
 				// height. Because the height is set to 0, clientHeight == 0 in Firefox.
 				// Therefore, we can use this to check if padding must be added.
 				if ( clientHeight === 0 ) {
-					var paddingTop = parseFloat( input.css( "padding-top" ) ),
-						paddingBottom = parseFloat( input.css( "padding-bottom" ) ),
-						paddingHeight = paddingTop + paddingBottom;
+					paddingTop = parseFloat( input.css( "padding-top" ) );
+					paddingBottom = parseFloat( input.css( "padding-bottom" ) );
+					paddingHeight = paddingTop + paddingBottom;
 
 					height += paddingHeight;
 				}

--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -117,18 +117,29 @@ $.widget( "mobile.textinput", {
 		// Autogrow
 		if ( isTextarea ) {
 			this._keyup = function() {
+				input.css( "height", 0 );
+
 				var scrollHeight = input[ 0 ].scrollHeight,
 					clientHeight = input[ 0 ].clientHeight,
-					paddingTop, paddingBottom, paddingHeight;
+					borderTop = parseFloat( input.css( "border-top-width" ) ),
+					borderBottom = parseFloat( input.css( "border-bottom-width" ) ),
+					borderHeight = borderTop + borderBottom,
+					height = scrollHeight + borderHeight + extraLineHeight;
 
+				// Padding is not included in scrollHeight and clientHeight by Firefox
+				// if no scrollbar is visible. Because textareas use the border-box
+				// box-sizing model, padding should be included in the new (assigned)
+				// height. Because the height is set to 0, clientHeight == 0 in Firefox.
+				// Therefore, we can use this to check if padding must be added.
+				if ( clientHeight === 0 ) {
+					var paddingTop = parseFloat( input.css( "padding-top" ) ),
+						paddingBottom = parseFloat( input.css( "padding-bottom" ) ),
+						paddingHeight = paddingTop + paddingBottom;
 
-				if ( clientHeight < scrollHeight ) {
-					paddingTop = parseFloat( input.css( "padding-top" ) );
-					paddingBottom = parseFloat( input.css( "padding-bottom" ) );
-					paddingHeight = paddingTop + paddingBottom;
-
-					input.height( scrollHeight - paddingHeight + extraLineHeight );
+					height += paddingHeight;
 				}
+
+				input.css( "height", height );
 			};
 
 			input.on( "keyup change input paste", function() {


### PR DESCRIPTION
Fixes #2719.

I used the method we discussed in #2719. I assume that's clear; if not, please let me know so I can explain things. A few words on some decisions I made:
- I used `.css("height")` instead of `.height()`, as this might work faster. (That is because `.height()` might perform some logic because of the box-model. I've been working on this solution for a while and I've done the logic by thinking and trying, so there's no need to perform extra calculations on this.)
- I removed the min-height from textareas, because this gives trouble while setting the height to 0.
- I removed the height from textareas, it isn't used with this new solution.

The solution has been tested in Safari, Google Chrome, Opera, and Firefox.
