### PR TITLE
Table Toggle/Reflow: added rebuild method

### DIFF
--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -77,10 +77,13 @@ $.widget( "mobile.table", $.mobile.table, {
 		});
 	},
 
-	_addToggles: function( menu ) {
+	_addToggles: function( menu, keep ) {
 		var opts = this.options;
+
 		// allow update of menu on refresh (fixes #5880)
-		menu.empty();
+		if ( !keep ) {
+			menu.empty();
+		}
 
 		// create the hide/show toggles
 		this.headers.not( "td" ).each( function() {
@@ -92,13 +95,15 @@ $.widget( "mobile.table", $.mobile.table, {
 			if( priority ) {
 				$cells.addClass( opts.classes.priorityPrefix + priority );
 
-				$("<label><input type='checkbox' checked />" + $this.text() + "</label>" )
-					.appendTo( menu )
-					.children( 0 )
-					.data( "cells", $cells )
-					.checkboxradio( {
-						theme: opts.columnPopupTheme
-					});
+				if ( !keep ) {
+					$("<label><input type='checkbox' checked />" + $this.text() + "</label>" )
+						.appendTo( menu )
+						.children( 0 )
+						.data( "cells", $cells )
+						.checkboxradio( {
+							theme: opts.columnPopupTheme
+						});
+				}
 			}
 
 		});
@@ -146,8 +151,8 @@ $.widget( "mobile.table", $.mobile.table, {
 		$popup = $( "<div data-" + ns + "role='popup' data-" + ns + "role='fieldcontain' class='" + opts.classes.popup + "' id='" + id + "'></div>" );
 		$menu = $( "<fieldset data-" + ns + "role='controlgroup'></fieldset>" );
 
-		// set extension here
-		this._addToggles( $menu );
+		// set extension here, send "false" to trigger build/rebuild
+		this._addToggles( $menu, false );
 
 		$menu.appendTo( $popup );
 
@@ -160,6 +165,13 @@ $.widget( "mobile.table", $.mobile.table, {
 		return $menu;
 	},
 
+	rebuild: function() {
+		// NOTE: rebuild passes "false", while refresh passes "undefined"
+		// both refresh the table, but inside addToggles, !false will be true,
+		// so a rebuild call can be indentified
+		this.refresh( false );
+	},
+
 	refresh: function( create ) {
 		this._super( create );
 
@@ -168,7 +180,7 @@ $.widget( "mobile.table", $.mobile.table, {
 			this._unlockCells( this.allHeaders );
 
 			// update columntoggles and $cells
-			this._addToggles( this._menu );
+			this._addToggles( this._menu, create );
 
 			// check/uncheck
 			this._setToggleState();

--- a/js/widgets/table.reflow.js
+++ b/js/widgets/table.reflow.js
@@ -35,6 +35,10 @@ $.widget( "mobile.table", $.mobile.table, {
 		}
 	},
 
+	rebuild: function() {
+		this.refresh( false );
+	},
+
 	refresh: function( create ) {
 		this._super( create );
 		if ( !create && this.options.mode === "reflow" ) {

--- a/tests/unit/table/index.html
+++ b/tests/unit/table/index.html
@@ -35,18 +35,33 @@
 	<script src="../../swarminject.js"></script>
 	<script type="text/javascript">
 	// basic
-	var count = 0;
+	var xcount = 0;
+	var ycount = 0;
 	$(window).on('refresh_test_table', function (e, data) {
 		var tb = $(data).find('tbody'),
 				numbers = [1,2,3,4,5,6,7,8,9],
 				chars = ["a","b","c","d","e","f","g","h","i"],
-				use = count % 2 === 1 ? numbers : chars,
+				use = xcount % 2 === 1 ? numbers : chars,
 				newRow = '<tr><th data-test="abc">'+use[0]+'</th><td>'+use[1]+'</td><td data-test="foo">'+use[2]+'</td><td data-col="3">'+use[3]+'</td><td>'+use[4]+'</td></tr>';
 		tb.empty()
 			.append(newRow)
 			.closest('table')
 			.table('refresh');
-		count += 1;
+		xcount += 1;
+	})
+	.on('refresh_col_table', function (e, data) {
+		var tb = $(data).find('tbody'),
+			th = $(data).find('thead tr'),
+			numbers = [1,2,3,4,5,6,7,8,9],
+			chars = ["z","y","x","w","v","u","t","s","t"],
+			use = xcount % 2 === 1 ? numbers : chars,
+			newRow = '<tr><th>'+use[0]+'</th><td>'+use[1]+'</td><td data-test="foo">'+use[2]+'</td><td data-col="3">'+use[3]+'</td><td>'+use[4]+'</td><td>'+use[5]+'</td><td data-test="xyz">'+use[6]+'</td></tr>';
+		th.append('<th data-nstest-priority="3">New_A</th><th data-nstest-priority="5">New_B</th>');
+		tb.empty()
+			.append(newRow)
+			.closest('table')
+			.table('rebuild');
+		ycount += 1;
 	});
 </script>
 

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -209,6 +209,46 @@
 			start();
 		}, 1200);
 	});
+
+	asyncTest( "Column toggle table rebuild" , function(){
+
+		var $last_input, $visibleCells, $visibleHeaders,
+			$input = $( ".ui-popup-container" ).find( "input" ).eq(2),
+			$table = $('#movie-table-column');
+
+		$input.trigger('click');
+
+		setTimeout(function () {
+
+			$(window).trigger("refresh_col_table", ["#column-table-test"]);
+
+			$last_input = $( ".ui-popup-container" ).find( "input" ).last(),
+			$visibleCells = $table.find("tbody tr").first().find("th, td").not('.ui-table-cell-hidden'),
+			$visibleHeaders = $table.find("thead tr").first().find("th, td").not('.ui-table-cell-hidden');
+
+			ok( $table.length, "Table still enhanced after rebuild");
+			equal(
+				$table.find('tbody tr').eq(1).find("th, td").eq(2).hasClass('ui-table-cell-hidden'),
+				false,
+				"Rebuilding a table clears all ui-table-cell-hidden/show classes"
+			);
+			ok( $input.is( ":checked" ), false, "Input still not checked after rebuild" );
+
+			equal(
+				$last_input.data("cells").last().attr("data-test"),
+				"xyz",
+				"Cell referenced in popup is in table after rebuild (new column and toggle button), columns without data-priority don't break table on rebuild");
+
+			equal(
+				$visibleCells.length,
+				$visibleHeaders.length,
+				"same number of headers and rows visible"
+			);
+
+			start();
+		}, 1200);
+	});
+
 	asyncTest( "The dialog should become visible when button is clicked" , function(){
 		expect( 2 );
 		var $input;


### PR DESCRIPTION
@gabrielschulhof, @uGoMobi:

I added the rebuild method to both reflow and columntoggle.

Notes:
- in reflow it doesn't really do anything so we might leave it away, too. Right now it just calls `refresh`
- in colToggle **rebuild**  calls `refresh` and passes `create=false` while in plain **refresh** `create=undefined`
- for both variants, `!create=true`, so both trigger a refresh. 
- inside `addToggles` however, I can now seperate **rebuild** from **refresh** by testing for `!create` (which I named `!keep` ... to make some sense).
- Tests are passing. I will add a test for refreshing a table with new columns, too.
