### PR TITLE
navigation: added support for query-params in URLs

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -593,6 +593,12 @@ define( [
 				return;
 			}
 
+			// if it is the first page, allow to override query parameters
+			if ( content.length > 0 &&
+				path.isFirstPageUrl(fileUrl) ) {
+					settings.isFirstPage = true;
+			}
+
 			// Reset base to the default document base
 			// TODO figure out why we doe this
 			this._getBase().reset();
@@ -767,7 +773,7 @@ define( [
 
 				// store the original absolute url so that it can be provided
 				// to events in the triggerData of the subsequent changePage call
-				options.absUrl = triggerData.absUrl;
+				options.absUrl = options.isFirstPage ? url : triggerData.absUrl;
 
 				this.transition( content, triggerData, options );
 			}, this));
@@ -893,7 +899,7 @@ define( [
 			// us to avoid generating a document url with an id hash in the case where the
 			// first-page of the document has an id attribute specified.
 			if ( toPage[ 0 ] === $.mobile.firstPage[ 0 ] && !settings.dataUrl ) {
-				settings.dataUrl = documentUrl.hrefNoHash;
+				settings.dataUrl = settings.isFirstPage ? settings.absUrl : documentUrl.hrefNoHash;
 			}
 
 			// The caller passed us a real page DOM element. Update our
@@ -922,7 +928,7 @@ define( [
 			// It is up to the developer that turns on the allowSamePageTransitiona option
 			// to either turn off transition animations, or make sure that an appropriate
 			// animation transition is used.
-			if ( fromPage && fromPage[0] === toPage[0] && !settings.allowSamePageTransition ) {
+			if ( fromPage && fromPage[0] === toPage[0] && !settings.allowSamePageTransition && !settings.isFirstPage ) {
 				isPageTransitioning = false;
 				this._triggerWithDeprecated( "transition", triggerData );
 				this.element.trigger( "pagechange", triggerData );

--- a/js/transitions/transition.js
+++ b/js/transitions/transition.js
@@ -36,9 +36,16 @@ define( [ "jquery",
 			});
 		},
 
+		isSamePage: function() {
+			// NOTE: no friend of comparing ids here
+			return this.$from !== undefined &&
+				( this.$to[0] === this.$from[0] ||
+					this.$to.attr( "id" ) === this.$from.attr( "id" ) )
+		},
+
 		cleanFrom: function() {
 			this.$from
-				.removeClass( $.mobile.activePageClass + " out in reverse " + this.name )
+				.removeClass( this.isSamePage() ? "" : $.mobile.activePageClass ) + " out in reverse " + this.name )
 				.height( "" );
 		},
 

--- a/js/transitions/transition.js
+++ b/js/transitions/transition.js
@@ -40,12 +40,18 @@ define( [ "jquery",
 			// NOTE: no friend of comparing ids here
 			return this.$from !== undefined &&
 				( this.$to[0] === this.$from[0] ||
-					this.$to.attr( "id" ) === this.$from.attr( "id" ) )
+					this.$to.attr( "id" ) === this.$from.attr( "id" ) );
 		},
 
 		cleanFrom: function() {
+			var samePage = this.isSamePage(),
+				classes = " out in reverse " + this.name;
+
+			if ( samePage ) {
+				classes += $.mobile.activePageClass;
+			}
 			this.$from
-				.removeClass( this.isSamePage() ? "" : $.mobile.activePageClass ) + " out in reverse " + this.name )
+				.removeClass( classes )
 				.height( "" );
 		},
 


### PR DESCRIPTION
@gabrielschulhof:

I have modified the following to enable query parameters in my project ([Demo Page](http://www.franckreich.de/members/export/l/search.html?search=vila) - try searching for "soon" and "paris" and go back/fwd).

Of course to reload an existing page `allowSamePageTransitions` must be set on the changePage call.

I have not done any tests yet, but my it works in my application when 
- starting with a deeplink `foo.html?search=foo`, 
- starting without `foo.html`
- starting another page `bar.html` and then going to the search page `foo.html` either with or without query param.

I'm not sure this is really robust, but if it is, let me know and I will also add some unit tests.
