### PR TITLE
Transitions: delay  transition to avoid  transition stuck, and keep them...

### DIFF
--- a/demos/examples/backbone-require/js/libs/jquerymobile.js
+++ b/demos/examples/backbone-require/js/libs/jquerymobile.js
@@ -3703,9 +3703,11 @@ var createHandler = function( sequential ) {
 					$to.animationComplete( doneIn );
 				}
 
-				$to
-					.removeClass( toPreClass )
-					.addClass( name + " in" + reverseClass );
+				setTimeout(function() {
+					$to
+						.removeClass( toPreClass )
+						.addClass( name + " in" + reverseClass );
+				},1);		
 
 				if ( none ) {
 					doneIn();


### PR DESCRIPTION
Transitions: delay $to transition to avoid $from transition stuck, and keep them slide at same time. Fix for iOS 5. Adresses #5764.
