### PR TITLE
fix navbar #6250: classes is a global vs. local for each button

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -593,6 +593,12 @@ define( [
 				return;
 			}
 
+			// if it is the first page, allow to override query parameters
+			if ( content.length > 0 &&
+				path.isFirstPageUrl(fileUrl) ) {
+					settings.isFirstPage = true;
+			}
+
 			// Reset base to the default document base
 			// TODO figure out why we doe this
 			this._getBase().reset();
@@ -767,7 +773,7 @@ define( [
 
 				// store the original absolute url so that it can be provided
 				// to events in the triggerData of the subsequent changePage call
-				options.absUrl = triggerData.absUrl;
+				options.absUrl = options.isFirstPage ? url : triggerData.absUrl;
 
 				this.transition( content, triggerData, options );
 			}, this));
@@ -893,7 +899,7 @@ define( [
 			// us to avoid generating a document url with an id hash in the case where the
 			// first-page of the document has an id attribute specified.
 			if ( toPage[ 0 ] === $.mobile.firstPage[ 0 ] && !settings.dataUrl ) {
-				settings.dataUrl = documentUrl.hrefNoHash;
+				settings.dataUrl = settings.isFirstPage ? settings.absUrl : documentUrl.hrefNoHash;
 			}
 
 			// The caller passed us a real page DOM element. Update our
@@ -922,7 +928,7 @@ define( [
 			// It is up to the developer that turns on the allowSamePageTransitiona option
 			// to either turn off transition animations, or make sure that an appropriate
 			// animation transition is used.
-			if ( fromPage && fromPage[0] === toPage[0] && !settings.allowSamePageTransition ) {
+			if ( fromPage && fromPage[0] === toPage[0] && !settings.allowSamePageTransition && !settings.isFirstPage ) {
 				isPageTransitioning = false;
 				this._triggerWithDeprecated( "transition", triggerData );
 				this.element.trigger( "pagechange", triggerData );

--- a/js/transitions/transition.js
+++ b/js/transitions/transition.js
@@ -36,9 +36,16 @@ define( [ "jquery",
 			});
 		},
 
+		isSamePage: function() {
+			// NOTE: no friend of comparing ids here
+			return this.$from !== undefined &&
+				( this.$to[0] === this.$from[0] ||
+					this.$to.attr( "id" ) === this.$from.attr( "id" ) )
+		},
+
 		cleanFrom: function() {
 			this.$from
-				.removeClass( $.mobile.activePageClass + " out in reverse " + this.name )
+				.removeClass( this.isSamePage() ? "" : $.mobile.activePageClass ) + " out in reverse " + this.name )
 				.height( "" );
 		},
 

--- a/js/transitions/transition.js
+++ b/js/transitions/transition.js
@@ -40,12 +40,18 @@ define( [ "jquery",
 			// NOTE: no friend of comparing ids here
 			return this.$from !== undefined &&
 				( this.$to[0] === this.$from[0] ||
-					this.$to.attr( "id" ) === this.$from.attr( "id" ) )
+					this.$to.attr( "id" ) === this.$from.attr( "id" ) );
 		},
 
 		cleanFrom: function() {
+			var samePage = this.isSamePage(),
+				classes = " out in reverse " + this.name;
+
+			if ( samePage ) {
+				classes += $.mobile.activePageClass;
+			}
 			this.$from
-				.removeClass( this.isSamePage() ? "" : $.mobile.activePageClass ) + " out in reverse " + this.name )
+				.removeClass( classes )
 				.height( "" );
 		},
 

--- a/js/widgets/navbar.js
+++ b/js/widgets/navbar.js
@@ -21,7 +21,7 @@ $.widget( "mobile.navbar", {
 		var $navbar = this.element,
 			$navbtns = $navbar.find( "a" ),
 			iconpos = $navbtns.filter( ":jqmData(icon)" ).length ? this.options.iconpos : undefined,
-			classes = "ui-btn";
+			classes;
 
 		$navbar.addClass( "ui-navbar" )
 			.attr( "role", "navigation" )
@@ -31,7 +31,8 @@ $.widget( "mobile.navbar", {
 
 		$navbtns
 			.each( function() {
-				var icon = $.mobile.getAttribute( this, "icon", true ),
+				var classes = "ui-btn",
+					icon = $.mobile.getAttribute( this, "icon", true ),
 					theme = $.mobile.getAttribute( this, "theme", true );
 
 				if ( theme ) {


### PR DESCRIPTION
The `classes` variable inside the toolbar widget is only declared outside of the loop that assigns classes to each button. When looping over each button, this causes each button to "inherit" the classes assigned to the previous buttons. 

Fixes #6250
