### PR TITLE
tables/fix 6255: getAttribute colspan vs. data-colspan

### DIFF
--- a/js/widgets/table.js
+++ b/js/widgets/table.js
@@ -63,7 +63,7 @@ $.widget( "mobile.table", {
 
 			// Iterate over the children of the tr
 			$( this ).children().each( function() {
-				var span = parseInt( $.mobile.getAttribute( this, "colspan", true), 10 ),
+				var span = parseInt( $.mobile.getAttribute( this, "colspan" ), 10 ),
 					selector = ":nth-child(" + ( columnCount + 1 ) + ")",
 					j;
 


### PR DESCRIPTION
@gabrielschulhof, @uGoMobi, @MythosVylok:

Fix for #6255. 

Setting `true` in **table.js** on this line:

```
var span = parseInt( $.mobile.getAttribute( this, "colspan" ), 10 ),
```

will try to get `data-colspan` vs. `colspan` on the header rows, which returns NaN, so therefore only the first grouped row was in `$cells`. Removing `true` fixes this. 

Demo: [here](http://www.franckreich.de/jqm/bugs/6255/index.html)
