### PR TITLE
Collapsible: toggle ui-btn-active class on vmouse events

### DIFF
--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -53,10 +53,16 @@ $.widget( "mobile.collapsible", {
 			this._enhance( elem, ui );
 		}
 
+		function cancelActiveState() {
+			ui.heading.find( "a" ).first().removeClass( $.mobile.activeBtnClass );
+		}
+
 		this._on( ui.heading, {
-			"tap": function() {
+			"vmousedown": function() {
 				ui.heading.find( "a" ).first().addClass( $.mobile.activeBtnClass );
 			},
+			"vmouseup": cancelActiveState,
+			"vmousecancel": cancelActiveState,
 
 			"click": function( event ) {
 				this._handleExpandCollapse( !ui.heading.hasClass( "ui-collapsible-heading-collapsed" ) );


### PR DESCRIPTION
Hi. This issue (https://github.com/jquery/jquery-mobile/pull/6096) still exists.
You can check it here on mobile devices:
http://jsbin.com/ujudog/2/

I updated PR.
