### PR TITLE
Fix 6320: Table/ColToggle - fieldset in popup not getting enhanced

### DIFF
--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -155,7 +155,7 @@ $.widget( "mobile.table", $.mobile.table, {
 		fragment.appendChild( menuButton[ 0 ] );
 		table.before( fragment );
 
-		popup.popup();
+		popup.popup().enhanceWithin();
 
 		return menu;
 	},


### PR DESCRIPTION
This fixes #6320 - the controlgroup inside the columntoggle popup does not get enhanced by merely calling

`popup.popup()`

Fixed by adding 

`popup.popup().enhanceWithin();`
