### PR TITLE
Fix 6319: Table/ColToggle - setting display:block to override offset on fieldset

### DIFF
--- a/css/structure/jquery.mobile.table.columntoggle.css
+++ b/css/structure/jquery.mobile.table.columntoggle.css
@@ -9,6 +9,7 @@
 /* Remove top/bottom margins around the fieldcontain on check list */
 .ui-table-columntoggle-popup fieldset {
 	margin:0;
+	display: block;
 }
 
 /* Hide all prioritized columns by default */

--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -155,7 +155,7 @@ $.widget( "mobile.table", $.mobile.table, {
 		fragment.appendChild( menuButton[ 0 ] );
 		table.before( fragment );
 
-		popup.popup();
+		popup.popup().enhanceWithin();
 
 		return menu;
 	},


### PR DESCRIPTION
@uGoMobi:

This fixes #6319.

The fieldset inside the popup columntoggle already has: `margin: 0` set, but it also gets

```
.ui-mobile fieldset {
    display: table-column;
}
```

which causes a few pixels offset on the bottom of the popup.

Setting `display: block` in addition to margin fixes this.
