### PR TITLE
Allow using data-enhance="true" to override a previous false

### DIFF
--- a/js/jquery.mobile.core.js
+++ b/js/jquery.mobile.core.js
@@ -227,6 +227,11 @@ define( [ "jquery", "./jquery.mobile.ns", "json!../package.json" ], function( jQ
 				while ( e ) {
 					var c = e.getAttribute ? e.getAttribute( "data-" + $.mobile.ns + attr ) : "";
 
+					if ( c === "true" ) {
+						excluded = false;
+						break;
+					}
+
 					if ( c === "false" ) {
 						excluded = true;
 						break;


### PR DESCRIPTION
While importing some legacy pages into the jqm framework I had to switch off the auto-enhancing on some set of pages. Later when I started to migrate some of them I wanted to turn on the enhancing on them, but only on them, by using data-enhance="true" on a child <div> of the included html, but jqm didn't support this.

This patch adds the support for this feature.
