### PR TITLE
Allow using data-enhance="true" to override a previous false.

### DIFF
--- a/js/jquery.mobile.helpers.js
+++ b/js/jquery.mobile.helpers.js
@@ -87,8 +87,14 @@ define( [ "jquery", "./jquery.mobile.ns", "./jquery.ui.core" ], function( jQuery
 				excluded = false;
 				e = elements[ i ];
 
+				// The first value encountered while descending the ancestors tree is the official one
 				while ( e ) {
 					c = e.getAttribute ? e.getAttribute( "data-" + $.mobile.ns + attr ) : "";
+
+					if ( c === "true" ) {
+						excluded = false;
+						break;
+					}
 
 					if ( c === "false" ) {
 						excluded = true;


### PR DESCRIPTION
While importing some legacy pages into the jqm framework I had to switch off the auto-enhancing on some set of pages. Later when I started to migrate some of them I wanted to turn on the enhancing on them, but only on them, by using data-enhance="true" on a child of the included html, but jqm didn't support this.
This patch adds the support for this feature.
