### PR TITLE
Tabs: Alternative based on collapsibleset

### DIFF
--- a/css/structure/jquery.mobile.collapsible.css
+++ b/css/structure/jquery.mobile.collapsible.css
@@ -101,3 +101,102 @@
 .ui-collapsible-set .ui-collapsible.ui-first-child {
 	margin-top: 0;
 }
+/* ui-collapsible-tabs - above 40em */
+@media (min-width: 40em) {
+	.ui-collapsible-tabs {
+		display: table;
+		table-layout: fixed;
+		width: 100%;
+	}
+	.ui-collapsible-tabs .ui-collapsible {
+		display: table-cell;
+	}
+	.ui-collapsible-tabs .ui-collapsible-content {
+		margin: 0;
+		padding: 0;
+		position: relative;
+	}
+	/* content - IE8 ignores this and falls back to regular collapsible-set */
+	.ui-collapsible-tabs[data-tabs="10"] .ui-collapsible .ui-collapsible-content {width: 1000%; }
+	.ui-collapsible-tabs[data-tabs="9"] .ui-collapsible .ui-collapsible-content {width: 900%; }
+	.ui-collapsible-tabs[data-tabs="8"] .ui-collapsible .ui-collapsible-content {width: 800%;}
+	.ui-collapsible-tabs[data-tabs="7"] .ui-collapsible .ui-collapsible-content {width: 700%;}
+	.ui-collapsible-tabs[data-tabs="6"] .ui-collapsible .ui-collapsible-content {width: 600%;}
+	.ui-collapsible-tabs[data-tabs="5"] .ui-collapsible .ui-collapsible-content {width: 500%;}
+	.ui-collapsible-tabs[data-tabs="4"] .ui-collapsible .ui-collapsible-content {width: 400%;}
+	.ui-collapsible-tabs[data-tabs="3"] .ui-collapsible .ui-collapsible-content {width: 300%;}
+	.ui-collapsible-tabs[data-tabs="2"] .ui-collapsible .ui-collapsible-content {width: 200%;}
+	.ui-collapsible-tabs[data-tabs="1"] .ui-collapsible .ui-collapsible-content {width: 100%;}
+
+	/* positioning (can use nth-child because IE8 does not care for the above */
+	.ui-collapsible-tabs .ui-collapsible:nth-child(1) .ui-collapsible-content {left: 0;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(2) .ui-collapsible-content {left: -100%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(3) .ui-collapsible-content {left: -200%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(4) .ui-collapsible-content {left: -300%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(5) .ui-collapsible-content {left: -400%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(6) .ui-collapsible-content {left: -500%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(7) .ui-collapsible-content {left: -600%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(8) .ui-collapsible-content {left: -700%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(9) .ui-collapsible-content {left: -800%;}
+	.ui-collapsible-tabs .ui-collapsible:nth-child(10) .ui-collapsible-content {left: -900%;}
+
+	/* corners */
+	/* hardcode inset content-theme bottom corners, because can't inherit 0 on bottom left/right first/last tab */
+	.ui-collapsible-tabs .ui-collapsible-inset.ui-collapsible-themed-content:not(.ui-collapsible-collapsed) .ui-collapsible-content {
+		-webkit-border-bottom-left-radius: .6em;
+		border-bottom-left-radius: .6em;
+		-webkit-border-bottom-right-radius: .6em;
+		border-bottom-right-radius: .6em;
+	}
+	.ui-collapsible-tabs .ui-collapsible.ui-first-child {
+		-webkit-border-top-left-radius: inherit;
+		border-top-left-radius: inherit;
+		-webkit-border-top-right-radius: 0;
+		border-top-right-radius: 0;
+		-webkit-border-bottom-right-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+	.ui-collapsible-tabs .ui-collapsible.ui-last-child {
+		-webkit-border-top-right-radius: inherit;
+		border-top-right-radius: inherit;
+		-webkit-border-top-left-radius: 0;
+		border-top-left-radius: 0;
+		-webkit-border-bottom-left-radius: 0;
+		border-bottom-left-radius: 0;
+	}
+	/* straight corner last-tab if one tab is open */
+	.ui-collapsible-tabs .ui-collapsible:not(.ui-collapsible-collapsed) ~ .ui-collapsible.ui-last-child {
+		-webkit-border-bottom-right-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+	/* straight corner first-tab... this needs another JS-class */
+	.ui-collapsible-tabs .ui-collapsible.ui-first-child.ui-collapsible-collapsed {
+		-webkit-border-bottom-left-radius: inherit;
+		border-bottom-left-radius: inherit;
+	}
+	/* because this does not work with preceeding siblings */
+	.ui-collapsible-tabs .ui-collapsible:not(.ui-collapsible-collapsed)  ~ .ui-collapsible.ui-first-child {
+		-webkit-border-bottom-left-radius: inherit;
+		border-bottom-left-radius: inherit;
+	}
+	.ui-collapsible-tabs .ui-collapsible.ui-collapsible-collapsed.ui-first-child,
+	.ui-collapsible-tabs .ui-collapsible.ui-first-child {
+		border-bottom-left-radius: 0;
+		-webkit-border-bottom-left-radius: 0;
+	}
+	/* hide status text */
+	.ui-collapsible-tabs {
+		position: absolute !important;
+		left: -9999px;
+		clip: rect(1px 1px 1px 1px);
+		clip: rect(1px,1px,1px,1px);
+	}
+	/* borders */
+	.ui-collapsible-tabs .ui-collapsible:not(.ui-collapsible-collapsed) h1 a {
+		border-bottom-color: transparent;
+	}
+	.ui-collapsible-tabs .ui-collapsible .ui-collapsible-content {
+		border-top-color: transparent;
+		border-top-width: 1px; /* magic */
+	}
+}

--- a/css/structure/jquery.mobile.collapsible.css
+++ b/css/structure/jquery.mobile.collapsible.css
@@ -199,4 +199,7 @@
 		border-top-color: transparent;
 		border-top-width: 1px; /* magic */
 	}
+	.ui-collapsible-tabs .ui-collapsible + .ui-collapsible h1 a {
+		border-left-color: transparent;
+	}
 }

--- a/js/widgets/collapsibleSet.js
+++ b/js/widgets/collapsibleSet.js
@@ -31,6 +31,7 @@ $.widget( "mobile.collapsibleset", $.extend( {
 
 	options: $.extend( {
 		enhanced: false,
+		type: null
 	}, $.mobile.collapsible.defaults ),
 
 	_handleCollapsibleExpand: function( event ) {
@@ -55,6 +56,9 @@ $.widget( "mobile.collapsibleset", $.extend( {
 			elem.addClass( "ui-collapsible-set " +
 				this._themeClassFromOption( "ui-group-theme-", opts.theme ) + " " +
 				( opts.corners && opts.inset ? "ui-corner-all " : "" ) );
+			if (opts.type) {
+				elem.addClass( "ui-collapsible-tabs" );
+			}
 			this.element.find( $.mobile.collapsible.initSelector ).collapsible();
 		}
 


### PR DESCRIPTION
@uGoMobi: @arschmitz:

I know you are sticking with UI tabs, but I still wanted to contribute my latest version of collapsible tabs, which is down to a single option in JS, class and respective CSS. I like it because it's easy to extend and I can fallback to a regular collapsible-set on small screens. Plus it saves a widget :-)

Demo [here](http://www.franckreich.de/jqm/tabview/demo.html)

It's still raw, I'm still playing with transparent borders and inheriting the correct border color to the `h1 a` plus I'm afraid I need another class `ui-collapsible-tabs-all-closed` to fix the bottom-left corner on the first tab. 

Still maybe some stuff you can use (UI tabs seems to be without CSS in latest JQM). Otherwise close as you see fit.
