### PR TITLE
Unprefixed transition property for .ui-slider-handle-snapping

### DIFF
--- a/css/structure/jquery.mobile.forms.slider.css
+++ b/css/structure/jquery.mobile.forms.slider.css
@@ -116,6 +116,7 @@ div.ui-slider-switch.ui-mini {
 .ui-slider-handle-snapping {
 	-webkit-transition: left 70ms linear;
 	-moz-transition: left 70ms linear;
+	transition: left 70ms linear;
 }
 .ui-slider-switch .ui-slider-label {
 	position: absolute;


### PR DESCRIPTION
Realistically you don't need the `-moz` prefix anymore according to [CanIUse](http://caniuse.com/css-transitions), but I left it in.
