### PR TITLE
Move Rebasing section from README.md to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,15 @@ Combined into one, here's a full example:
         "Dialog: modified the foo to no longer bar. Fixed #1234 - dialog: IE6 crashed when foo is set to bar"
         \WHERE/:\------------- WHAT -------------/.\  WHY #Num /-\---------------- WHY Name ----------------/
 
+### Rebasing
+
+Often times when working on a feature or bug fix branch it's useful to pull in the latest from the parent branch. If you're doing this _before_ submitting a pull request it's best to use git's rebase to apply your commits onto the latest from the parent branch. For example, working on `new-feature` branch where `upstream` is the remote at `git://github.com/jquery/jquery-mobile.git`:
+
+    git checkout new-feature
+    git pull --rebase upstream master
+    ## ... here you may have to resolve some conflicts ... ##
+
+You can now push to your own fork and submit the pull request. Keep in mind that it's only a good idea to do this if you _haven't_ already submitted a pull request unless you want to create a new one because your origin remote (your fork) will report a discrepancy. Again, please refer to the [chapter](http://git-scm.com/book/ch3-6.html) in Pro Git on rebasing if you're new to it.
 
 ------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -126,14 +126,3 @@ Additionally, jQuery Mobile's test suite is split between integration and unit t
     grunt test --types=unit
     grunt test --types=integration
     grunt test --types=unit,integration # default, equivalent to 'grunt test'
-
-
-### Rebasing
-
-Often times when working on a feature or bug fix branch it's useful to pull in the latest from the parent branch. If you're doing this _before_ submitting a pull request it's best to use git's rebase to apply your commits onto the latest from the parent branch. For example, working on `new-feature` branch where `upstream` is the remote at `git://github.com/jquery/jquery-mobile.git`:
-
-    git checkout new-feature
-    git pull --rebase upstream master
-    ## ... here you may have to resolve some conflicts ... ##
-
-You can now push to your own fork and submit the pull request. Keep in mind that it's only a good idea to do this if you _haven't_ already submitted a pull request unless you want to create a new one because your origin remote (your fork) will report a discrepancy. Again, please refer to the [chapter](http://git-scm.com/book/ch3-6.html) in Pro Git on rebasing if you're new to it.


### PR DESCRIPTION
Moved the **Rebasing** section from README.md to CONTRIBUTING.md as it was being wrongly referred to in CONTRIBUTING.md and is more appropriate there. Also fixed a typo in the docs.
