### PR TITLE
Panel: Resize modal overlay to stretch to the height of the document.

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -324,7 +324,9 @@ $.widget( "mobile.panel", {
 
 					self._modalOpenClasses = self._getPosDisplayClasses( o.classes.modal ) + " " + o.classes.modalOpen;
 					if ( self._modal ) {
-						self._modal.addClass( self._modalOpenClasses );
+						self._modal
+							.addClass( self._modalOpenClasses )
+							.height( Math.max( self._modal.height(), self.document.height() ) );
 					}
 				},
 				complete = function() {


### PR DESCRIPTION
Fixes #6466 - Panel: Panel doesn't close by clicking outside if the page is scrolled down.

Basically, assign a height to the panel whenever you open it.
