### PR TITLE
jquery.mobile.tabele.reflow.js: removed the display: table-row-group; css. Fixes 6583. This display property causes assistive technology like VoiceOver to no longer detect the table as a table. 

### DIFF
--- a/css/structure/jquery.mobile.table.reflow.css
+++ b/css/structure/jquery.mobile.table.reflow.css
@@ -47,11 +47,6 @@
 /* Breakpoint to show as a standard table at 560px (35em x 16px) or wider */ 
 @media ( min-width: 35em ) {
 
-	/* Fixes table rendering when switching between breakpoints in Safari <= 5. See https://github.com/jquery/jquery-mobile/issues/5380 */
-	.ui-table-reflow.ui-responsive {
-		display: table-row-group;
-	}
-
 	/* Show the table header rows */ 
 	.ui-table-reflow.ui-responsive td,
 	.ui-table-reflow.ui-responsive th,


### PR DESCRIPTION
I apologize in advance for this pull request because I do not have Safari <= 5 and am therefore not able to reproduce bug 5380 - which this code was supposed to fix. However, the fix for 5380 is invalid because it directly causes the issue reported in 6583 in a lot of different browser and AT combinations.
