### PR TITLE
Navigation: Added support for authority-less URI schemes.

### DIFF
--- a/js/navigation/path.js
+++ b/js/navigation/path.js
@@ -50,10 +50,15 @@ define([
 				// mimic the browser with an empty string when the hash is empty
 				hash = hash === "#" ? "" : hash;
 
-				// Make sure to parse the url or the location object for the hash because using location.hash
-				// is autodecoded in firefox, the rest of the url should be from the object (location unless
-				// we're testing) to avoid the inclusion of the authority
-				return uri.protocol + "//" + uri.host + uri.pathname + uri.search + hash;
+				if (!uri.doubleSlash) {
+					// Make sure to parse the url or the location object for the hash because using location.hash
+					// is autodecoded in firefox, the rest of the url should be from the object (location unless
+					// we're testing) to avoid the inclusion of the authority
+					return uri.protocol + "//" + uri.host + uri.pathname + uri.search + hash;
+				} else {
+					// support URI schemes which contain only a path and no authority (e.g. "qrc:")
+					return uri.protocol + uri.pathname + uri.search + hash;
+				}
 			},
 
 			//return the original document url


### PR DESCRIPTION
For URI schemes like "qrc:" (Qt resource) which do not include an
authority but only a path the method $.mobile.path.getLocation()
incorrectly returns a URL with a double slash after the scheme name.

In a Qt Webkit ThinClient application this resulted in continuously
adding up slashes in front of the path (e.g. "qrc://////index.html").

---

Remark: Please note that I'm currently unable to test this modification (lack of a Qt ThinClient) and this change is untested in its current state. Just let me know whether you're able to reproduce and test or postpone this change until I'm able to do a final test myself.
