### PR TITLE
Navigation: Only bind to browser's AnimationEnd event. Fixes #5156.

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -111,11 +111,11 @@ define( [
 	/* exposed $.mobile methods */
 
 	//animation complete callback
+	var animationEndEvent = "WebKitTransitionEvent" in window ? "webkitAnimationEnd" : "animationend";
 	$.fn.animationComplete = function( callback ) {
 		if ( $.support.cssTransitions ) {
-			return $( this ).one( "webkitAnimationEnd animationend", callback );
-		}
-		else{
+			return $( this ).one( animationEndEvent, callback );
+		} else {
 			// defer execution for consistency between webkit/non webkit
 			setTimeout( callback, 0 );
 			return $( this );


### PR DESCRIPTION
This fixes the leak for applications that dynamically create pages. See #5156 for more info about the problem.
