### PR TITLE
fixed broken link from single page template to multi-page template

### DIFF
--- a/demos/pages-single-page/index.html
+++ b/demos/pages-single-page/index.html
@@ -24,7 +24,7 @@
 	<div data-role="content">	
 		<p>This is a single page boilerplate template that you can copy to build your first jQuery Mobile page. Each link or form from here will pull a new page in via Ajax to support the animated page transitions.</p>		
 		<p>Just view the source and copy the code to get started. All the CSS and JS is linked to the jQuery CDN versions so this is super easy to set up. Remember to include a meta viewport tag in the head to set the zoom level.</p>
-		<p>This template is standard HTML document with a single "page" container inside, unlike a <a href="multipage-template.html" data-ajax="false">multi-page template</a> that has multiple pages within it. We strongly recommend building your site or app as a series of separate pages like this because it's cleaner, more lightweight and works better without JavaScript.</p>
+		<p>This template is standard HTML document with a single "page" container inside, unlike a <a href="../pages-multi-page/" data-ajax="false">multi-page template</a> that has multiple pages within it. We strongly recommend building your site or app as a series of separate pages like this because it's cleaner, more lightweight and works better without JavaScript.</p>
 	</div><!-- /content -->
 	
 	<div data-role="footer">


### PR DESCRIPTION
just a href change so the link from single page template to multi-page template in demos works

this is another try for https://github.com/jquery/jquery-mobile/pull/6589
CLA signed too ;)
