### PR TITLE
buttonMarkup: Fix bugs that buttonMarkup doesn't set options properly and doesn't get a value of options.

### DIFF
--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -217,7 +217,7 @@ $.fn.buttonMarkup = function( options, overwriteClasses ) {
 			return ( optionValue !== undefined ) ? optionValue : defaults[ optionKey ];
 		}
 
-		eval( "retrievedOptions." + optionKey + " = arguments[2]" );
+		retrievedOptions[ optionKey ] = arguments[2];
 		el.className = optionsToClasses( $.extend( {}, defaults, retrievedOptions ) ).join( " " );
 		return this;
 	}

--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -171,6 +171,10 @@ function camelCase2Hyphenated( c ) {
 	return "-" + c.toLowerCase();
 }
 
+function isAlreadyEnhanced( classes ) {
+	return ( /(^|\s)ui-btn(?=\s|$)/g ).test( classes );
+}
+
 // $.fn.buttonMarkup:
 // DOM: gets/sets .className
 //
@@ -188,7 +192,35 @@ function camelCase2Hyphenated( c ) {
 // then you should omit @overwriteClasses or set it to false.
 $.fn.buttonMarkup = function( options, overwriteClasses ) {
 	var idx, data, el, retrievedOptions, optionKey,
-		defaults = $.fn.buttonMarkup.defaults;
+		defaults = $.fn.buttonMarkup.defaults,
+		argc = arguments.length,
+		optionValue;
+
+	if ( typeof options === "string" && options === "option" ) {
+		if ( argc !== 2 && argc !== 3 ) {
+			return;
+		}
+
+		el = this[ 0 ];
+		if ( !overwriteClasses || !isAlreadyEnhanced( el.className ) ) {
+			return;
+		}
+
+		optionKey = overwriteClasses.trim();
+		if ( !optionKey.length ) {
+			return;
+		}
+
+		retrievedOptions = classNameToOptions( el.className ).options;
+		if ( argc === 2 ) {
+			optionValue = retrievedOptions[ optionKey ];
+			return ( optionValue !== undefined ) ? optionValue : defaults[ optionKey ];
+		}
+
+		eval( "retrievedOptions." + optionKey + " = arguments[2]" );
+		el.className = optionsToClasses( $.extend( {}, defaults, retrievedOptions ) ).join( " " );
+		return this;
+	}
 
 	for ( idx = 0 ; idx < this.length ; idx++ ) {
 		el = this[ idx ];

--- a/js/jquery.mobile.buttonMarkup.js
+++ b/js/jquery.mobile.buttonMarkup.js
@@ -206,7 +206,7 @@ $.fn.buttonMarkup = function( options, overwriteClasses ) {
 			return;
 		}
 
-		optionKey = overwriteClasses.trim();
+		optionKey = $.trim( overwriteClasses );
 		if ( !optionKey.length ) {
 			return;
 		}


### PR DESCRIPTION
Hi All,

I know that it will be deprecated, but I hope that my PR can help you improve/stabilize current ButtonMarkup.

**Tests :**
You can check issues to click three test buttons of bottom on the following test page:
- Origin(master): http://hyunsook.github.io/jqm-debug/latest/buttons-buttonMarkup_getter-setter_origin.html 
  
  Here are issues which were checked on that origin test page.
  - Getter: 
    - Sample Code: `btn_corners.buttonMarkup( "option", "corners" );`
    - Expected outcome: Retutn _true_ or _false_.
    - Actual coutcome: No return _true_ or _false_, but return _buttonMarkup own object_.
  - Setter: 
    - Sample Code: `btn_corners.buttonMarkup( "option", "corners", false );`
    - Expected outcome: Buttons is changed to square off corners.
    - Actual coutcome: Buttons is still round.
  
  The other options are same result with that.

**Solution :**
To fix the issues, my team modified jquery.mobile.buttonMarkup.js as follows:
1) Add isAlreadyEnhanced method to check if a button is enhanced.
2) Add codes to be able to function as setter or getter in according to options on buttonMarkup upper part.

You can see that the bugs are fixed on the following page:
- Modified: http://hyunsook.github.io/jqm-debug/latest/buttons-buttonMarkup_getter-setter_after.html 

If there are any problems or mistakes to go over it, please let me know.
