### PR TITLE
Button: Fixed the bugs of _setOptions - The button widget doesn't set the iconpos option.

### DIFF
--- a/js/widgets/forms/button.js
+++ b/js/widgets/forms/button.js
@@ -105,7 +105,9 @@ $.widget( "mobile.button", {
 			outer.toggleClass( "ui-mini", options.mini );
 		}
 		if ( options.iconpos !== undefined ) {
-			outer.removeClass( "ui-btn-icon-" + options.iconpos );
+			outer
+				.removeClass( "ui-btn-icon-" + this.options.iconpos )
+				.addClass( "ui-btn-icon-" + options.iconpos );
 		}
 		if ( options.icon !== undefined ) {
 			if ( !this.options.iconpos && !options.iconpos ) {


### PR DESCRIPTION
The button widget doesn't set the iconpos option, like the bug of the icon option (#6625).

Here are test pages.
- origin: http://hyunsook.github.io/jqm-debug/latest/buttons-button_setoptions_iconpos_origin.html
- modified: http://hyunsook.github.io/jqm-debug/latest/buttons-button_setoptions_iconpos_after.html

NOTE: The codes were modified by basing on the c28c02cc6b commit of master, not the commit for #6625.
