### PR TITLE
Button: Fixed the bugs of _setOptions - The button widget doesn't set the iconshadow option.

### DIFF
--- a/js/widgets/forms/button.js
+++ b/js/widgets/forms/button.js
@@ -71,6 +71,8 @@ $.widget( "mobile.button", {
 			( ( options.iconpos && options.icon ) ?
 				" ui-btn-icon-" + options.iconpos :
 				( options.icon ? " ui-btn-icon-left" : "" ) ) +
+			( ( options.iconshadow && options.icon ) ?	/* TODO: Deprecated in 1.4, remove in 1.5. */
+				" ui-shadow-icon" : "" ) +
 			( options.icon ? " ui-icon-" + options.icon : "" ) +
 			"' >" + this.element.val() + "</div>");
 	},
@@ -106,6 +108,9 @@ $.widget( "mobile.button", {
 		}
 		if ( options.iconpos !== undefined ) {
 			outer.removeClass( "ui-btn-icon-" + options.iconpos );
+		}
+		if ( options.iconshadow !== undefined ) {	/* TODO: Deprecated in 1.4, remove in 1.5. */
+			outer.toggleClass( "ui-shadow-icon", options.iconshadow );
 		}
 		if ( options.icon !== undefined ) {
 			if ( !this.options.iconpos && !options.iconpos ) {


### PR DESCRIPTION
The button widget doesn't set the iconshadow option, like the bugs of the icon option (#6625) and the iconpos option (#6626).

Here are test pages.
- origin: http://hyunsook.github.io/jqm-debug/latest/buttons-button_setoptions_iconshadow_origin.html
- modified: http://hyunsook.github.io/jqm-debug/latest/buttons-button_setoptions_iconshadow_after.html

NOTE: The codes were modified by basing on the c28c02c commit of master, not the commits for #6625 or #6626. 

I already know that the iconshadow option is deprecated in 1.4., so I don't know whether that PR will be helpful for you, or not. I hope that my PR can help you, but if the PR will not be helpful, you can close.
