### PR TITLE
Helpers: For each widget type, record those elements that will become wi...

### DIFF
--- a/js/jquery.mobile.helpers.js
+++ b/js/jquery.mobile.helpers.js
@@ -173,7 +173,8 @@ define( [ "jquery", "./jquery.mobile.ns", "./jquery.ui.core" ], function( jQuery
 
 		// Enhance child elements
 		enhanceWithin: function() {
-			var widgetElements,
+			var widgetElements, idx,
+				enhanceables = {},
 				that = this;
 
 			// Add no js class to elements
@@ -218,10 +219,15 @@ define( [ "jquery", "./jquery.mobile.ns", "./jquery.ui.core" ], function( jQuery
 						widgetElements = widgetElements.not( $.mobile.page.prototype.keepNativeSelector() );
 					}
 
-					// Enhance whatever is left
-					widgetElements[ constructor.prototype.widgetName ]();
+					// Record whatever is left for enhancement
+					enhanceables[ constructor.prototype.widgetName ] = widgetElements;
 				}
 			});
+
+			// Enhance widgets recorded previously
+			for ( idx in enhanceables ) {
+				enhanceables[ idx ][ idx ]();
+			}
 
 			return this;
 		},


### PR DESCRIPTION
...dgets of that type before actually instantiating the widgets. Fixes #6621 - Dynamically injected popup with header/footer not enhanced properly.

The problem in #6621 was that the popup gets instantiated before the toolbar (which takes care of the header and the footer). .enhanceWithin() was getting called on a div inside the page. Since the popup relocates its payload such that it is an immediate child of the page, it was relocating the as-yet-unenhanced toolbars outside the scope of the .enhanceWithin() call, so when, later on, .enhanceWithin() started looking for toolbars, it missed the header and the footer.

By breaking the enhancement into two passes, we can capture, for each widget type, all elements that will become widgets of that type, before any other widget type has the opportunity to relocate anything.
