### PR TITLE
 A user should not change  the value of clearBtn option in runtime.

### DIFF
--- a/js/widgets/forms/clearButton.js
+++ b/js/widgets/forms/clearButton.js
@@ -91,7 +91,7 @@ define( [
 		_setOptions: function( options ) {
 			this._super( options );
 
-			if ( options.clearbtn !== undefined && !this.element.is( "textarea, :jqmData(type='range')" ) ) {
+			if ( options.clearBtn !== undefined && !this.element.is( "textarea, :jqmData(type='range')" ) ) {
 				if ( options.clearBtn ) {
 					this._addClearBtn();
 				} else {
@@ -100,7 +100,7 @@ define( [
 			}
 
 			if ( options.clearBtnText !== undefined && this._clearBtn !== undefined ) {
-				this._clearBtn.text( options.clearBtnText );
+				this._clearBtn.text( options.clearBtnText ).attr("title", options.clearBtnText);
 			}
 		},
 
@@ -114,7 +114,8 @@ define( [
 
 		_destroyClear: function() {
 			this.element.removeClass( "ui-input-has-clear" );
-			this._unbindClear()._clearBtn.remove();
+			this._unbindClear();
+			this._clearBtn.remove();
 		},
 
 		_destroy: function() {


### PR DESCRIPTION
Hi all ~ :-)
API Doc informs to user that the value of clearBtn option can be changed  in runtime. But it does not work properly due to two problems.

So, This PR is containing modified codes about those.

If you want to see demos, please visit below URLs.
Origin : http://hyunsook.github.io/jqm-debug/latest/textinput-clearbtn-origin.html
Patch applied : http://hyunsook.github.io/jqm-debug/latest/textinput-clearbtn-after.html

First is that clearbtn should be changed clearBtn.

```
    _setOptions: function( options ) {
        this._super( options );

        if ( options.clearbtn !== undefined && !this.element.is( "textarea, :jqmData(type='range')" ) ) { 
            if ( options.clearBtn ) {
                this._addClearBtn();
            } else {
                this._destroyClear();
            }
        }

        if ( options.clearBtnText !== undefined && this._clearBtn !== undefined ) {
            this._clearBtn.text( options.clearBtnText );
        }
    },
```

Second  is that  'unbindClear' returns undefined value. So we can not use chaining at this point.

```
    _destroyClear: function() {
        this.element.removeClass( "ui-input-has-clear" );
        this._unbindClear()._clearBtn.remove(); 
    },
```

If there are any problems or mistakes on that PR, please let me know. 
Thanks in advance.
