### PR TITLE
fix #6656 pageContainer: dynamic injected pages missing remove bindings

### DIFF
--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -650,6 +650,7 @@ define( [
 			// users can bind to .done on the promise
 			if ( content.length && !settings.reload ) {
 				this._enhance( content, settings.role );
+				content.page( "bindRemove" );
 				deferred.resolve( absUrl, settings, content );
 
 				//if we are reloading the content make sure we update


### PR DESCRIPTION
Fixes #6656

This will allow JQM to remove dynamically injected pages from the DOM.

When dynamically injecting a page, inside `pageContainer` widget, the `page` to transition to is injected into the DOM, thus JQM will not fire an ajax request to fetch it. This will prevent `_loadSuccess()` from being called, which prevents `_include()` from being called, which sets the `remove` binding on the page being loaded. 

Same as inside `_include()` the new page is enhanced first and then bound to.
