### PR TITLE
fix #6650: panel (external) remove panel classes/properties correctly

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -52,6 +52,7 @@ $.widget( "mobile.panel", {
 			_panelID: el.attr( "id" ),
 			_closeLink: el.find( ":jqmData(rel='close')" ),
 			_parentPage: ( parentPage.length > 0 ) ? parentPage : false,
+			_openedPage: null,
 			_page: this._getPage,
 			_panelInner: this._getPanelInner(),
 			_wrapper: this._getWrapper,
@@ -99,7 +100,7 @@ $.widget( "mobile.panel", {
 	},
 
 	_getPage: function() {
-		var page = this._parentPage ? this._parentPage : $( "." + $.mobile.activePageClass );
+		var page = this._openedPage || (this._parentPage ? this._parentPage : $( "." + $.mobile.activePageClass ));
 
 		return page;
 	},
@@ -339,6 +340,8 @@ $.widget( "mobile.panel", {
 					self._bindFixListener();
 
 					self._trigger( "open" );
+
+					self._openedPage = self._page();
 				};
 
 			self._trigger( "beforeopen" );
@@ -405,6 +408,8 @@ $.widget( "mobile.panel", {
 					self._page().jqmRemoveData( "panel" );
 
 					self._trigger( "close" );
+
+					self._openedPage = null;
 				};
 
 			self._trigger( "beforeclose" );


### PR DESCRIPTION
Fix #6650:

When a panel is outside of a page and is opened while page A is being viewed, the panel-necessary markup is added to page A. 

Clicking on a link on a panel to transition to page B will correctly trigger the panel close methods and cleanup, however for external panels, this line:

```
 var page = this._parentPage ? this._parentPage : $( "." + $.mobile.activePageClass );
```

inside panel widget `_getPage()` will set page to the page with active class, which switches from A to B before the panel cleanup is done. So some properties are still left on page A (e.g. `panel=open`). When going back to this page, the panel cannot be opened anymore (because it's still set to open).

To fix, I added the `_openedPage` property, which is set to the page that was viewed when the panel opened. This page needs to be cleaned up instead of the active page (so actually the active page selector could go altogether).
