### PR TITLE
Refresh method in table widget is not working well.

### DIFF
--- a/js/widgets/table.columntoggle.js
+++ b/js/widgets/table.columntoggle.js
@@ -185,7 +185,7 @@ $.widget( "mobile.table", $.mobile.table, {
 
 		if ( !create && this.options.mode === "columntoggle" ) {
 			// columns not being replaced must be cleared from input toggle-locks
-			this._unlockCells( this.allHeaders );
+			this._unlockCells( this.element.find( ".ui-table-cell-hidden, .ui-table-cell-visible" ) );
 
 			// update columntoggles and cells
 			this._addToggles( this._menu, create );


### PR DESCRIPTION
Hi all.

I found an abnormal operation of refresh method in Table widget.

This bug can be reproduced through the following scenario.
Step 1. The mode of table is ‘columnToggle’.
Step 2. Hide columns in the table via click event.
Step 3. Call Refresh method.
Step 4. Only title column is displayed. (Data columns are never displayed.)

If you visit here and then click ‘execute macro’, you would see the malfunction.
URL : http://hyunsook.github.io/jqm-debug/latest/table_refresh_columntoggle_bug.html

This PR contain the solution and modified codes.

If you visit here, you would see the normal operation.
URL : http://hyunsook.github.io/jqm-debug/latest/table_refresh_columntoggle_fix.html

If there are any problems or mistakes on that PR, please let me know.
Thanks in advance.
