### PR TITLE
Page: Fixed the abnormal operating of _setOptions() for the domCache option.

### DIFF
--- a/js/widgets/page.js
+++ b/js/widgets/page.js
@@ -138,6 +138,17 @@ $.widget( "mobile.page", {
 			this.element.find( "[data-" + $.mobile.ns + "='content']" ).removeClass( "ui-body-" + this.options.contentTheme )
 				.addClass( "ui-body-" + o.contentTheme );
 		}
+
+		if ( o.domCache !== undefined && this.options.domCache !== o.domCache ) {
+			this.options.domCache = o.domCache;
+			this.element.attr( "data-dom-cache", o.domCache );
+
+			if ( o.domCache ) {
+				this.element.unbind( "pagehide.remove" );
+			} else {
+				this.element.page( "bindRemove" );
+			}
+		}
 	},
 
 	_handlePageBeforeShow: function(/* e */) {


### PR DESCRIPTION
Hi all~!

Currently, the <code>domCache</code> option of Page widget is not set properly on runtime.
So, to fix this bug, I submit PR.
- origin: You can see the bug of _setOptions() for the domCache option through the following sample page.
  http://hyunsook.github.io/jqm-debug/latest/page-domCache.html.
  Step 1. Go to that page.
  Step 2. Click "set domCache option" button in that page.
  Step 3. Test _setOptions() for the domCache option by following the steps to reproduce of the loaded page, [page-caching-switch.html](http://hyunsook.github.io/jqm-debug/latest/page-caching-switch.html).
- modified: You can see that the bug is fixed on the following page.
  http://hyunsook.github.io/jqm-debug/latest/page-domCache_after.html

If there are any problems or mistakes on that PR, please let me know. 
Thanks in advance. :)
