### PR TITLE
Touchend (and vmouseup) are not propagated if $.event.special.tap.emitTapOnTaphold is set to false (fixes #5983)

### DIFF
--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -113,7 +113,7 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 					if ( !isTaphold && origTarget === event.target ) {
 						triggerCustomEvent( thisObject, "tap", event );
 					} else if ( isTaphold ) {
-						event.stopPropagation();
+						event.preventDefault();
 					}
 				}
 


### PR DESCRIPTION
Currently, touchend events (and possibly others) are stopped by code handling the "no tap on taphold" feature (#5983). This means that if one wants to detect touchend after a taphold then this is virtually impossible because the propagation is being stopped via `event.stopPropagation()`. The intent of this call (as described by commit #49bb033) is to prevent default action upon tap on an anchor element.

This pull request fixes the problem by calling `event.preventDefault()` instead of `event.stopPropagation()`. This allows touchend (and associated vmouseup) to bubble up and at the same time prevents default action on target element.
