### PR TITLE
Correct orientationchange when iphones starting app via launcher icon while being held in landscape orientation

### DIFF
--- a/js/events/orientationchange.js
+++ b/js/events/orientationchange.js
@@ -14,34 +14,34 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 		initial_map = { "0": true, "180": true },
 		portrait_map = initial_map;
 
-	function setOrientationMap() {
-	// It seems that some device/browser vendors use window.orientation values 0 and 180 to
-	// denote the "default" orientation. For iOS devices, and most other smart-phones tested,
-	// the default orientation is always "portrait", but in some Android and RIM based tablets,
-	// the default orientation is "landscape". The following code attempts to use the window
-	// dimensions to figure out what the current orientation is, and then makes adjustments
-	// to the to the portrait_map if necessary, so that we can properly decode the
-	// window.orientation value whenever get_orientation() is called.
-	//
-	// Note that we used to use a media query to figure out what the orientation the browser
-	// thinks it is in:
-	//
-	//     initial_orientation_is_landscape = $.mobile.media("all and (orientation: landscape)");
-	//
-	// but there was an iPhone/iPod Touch bug beginning with iOS 4.2, up through iOS 5.1,
-	// where the browser *ALWAYS* applied the landscape media query. This bug does not
-	// happen on iPad.
+    function setOrientationMap() {
+		// It seems that some device/browser vendors use window.orientation values 0 and 180 to
+		// denote the "default" orientation. For iOS devices, and most other smart-phones tested,
+		// the default orientation is always "portrait", but in some Android and RIM based tablets,
+		// the default orientation is "landscape". The following code attempts to use the window
+		// dimensions to figure out what the current orientation is, and then makes adjustments
+		// to the to the portrait_map if necessary, so that we can properly decode the
+		// window.orientation value whenever get_orientation() is called.
+		//
+		// Note that we used to use a media query to figure out what the orientation the browser
+		// thinks it is in:
+		//
+		//     initial_orientation_is_landscape = $.mobile.media("all and (orientation: landscape)");
+		//
+		// but there was an iPhone/iPod Touch bug beginning with iOS 4.2, up through iOS 5.1,
+		// where the browser *ALWAYS* applied the landscape media query. This bug does not
+		// happen on iPad.
 
-	if ( $.support.orientation ) {
+		if ( $.support.orientation ) {
 
-		// Check the window width and height to figure out what the current orientation
-		// of the device is at this moment. Note that we've initialized the portrait map
-		// values to 0 and 180, *AND* we purposely check for landscape so that if we guess
-		// wrong, , we default to the assumption that portrait is the default orientation.
-		// We use a threshold check below because on some platforms like iOS, the iPhone
-		// form-factor can report a larger width than height if the user turns on the
-		// developer console. The actual threshold value is somewhat arbitrary, we just
-		// need to make sure it is large enough to exclude the developer console case.
+			// Check the window width and height to figure out what the current orientation
+			// of the device is at this moment. Note that we've initialized the portrait map
+			// values to 0 and 180, *AND* we purposely check for landscape so that if we guess
+			// wrong, , we default to the assumption that portrait is the default orientation.
+			// We use a threshold check below because on some platforms like iOS, the iPhone
+			// form-factor can report a larger width than height if the user turns on the
+			// developer console. The actual threshold value is somewhat arbitrary, we just
+			// need to make sure it is large enough to exclude the developer console case.
 
 			var ww = window.innerWidth || win.width(),
 				wh = window.innerHeight || win.height(),
@@ -49,21 +49,21 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 				initial_orientation_is_landscape,
 				initial_orientation_is_default;
 
-		initial_orientation_is_landscape = ww > wh && ( ww - wh ) > landscape_threshold;
+			initial_orientation_is_landscape = ww > wh && ( ww - wh ) > landscape_threshold;
 
-		// Now check to see if the current window.orientation is 0 or 180.
-		initial_orientation_is_default = initial_map[ window.orientation ];
+			// Now check to see if the current window.orientation is 0 or 180.
+			initial_orientation_is_default = initial_map[ window.orientation ];
 
-		// If the initial orientation is landscape, but window.orientation reports 0 or 180, *OR*
-		// if the initial orientation is portrait, but window.orientation reports 90 or -90, we
-		// need to flip our portrait_map values because landscape is the default orientation for
-		// this device/browser.
-		if ( ( initial_orientation_is_landscape && initial_orientation_is_default ) || ( !initial_orientation_is_landscape && !initial_orientation_is_default ) ) {
-			portrait_map = { "-90": true, "90": true };
+			// If the initial orientation is landscape, but window.orientation reports 0 or 180, *OR*
+			// if the initial orientation is portrait, but window.orientation reports 90 or -90, we
+			// need to flip our portrait_map values because landscape is the default orientation for
+			// this device/browser.
+			if ( ( initial_orientation_is_landscape && initial_orientation_is_default ) || ( !initial_orientation_is_landscape && !initial_orientation_is_default ) ) {
+				portrait_map = { "-90": true, "90": true };
 			} else {
 				portrait_map = initial_map;
 			}
-	}
+		}
 	}
 
 	setOrientationMap();

--- a/js/events/orientationchange.js
+++ b/js/events/orientationchange.js
@@ -11,11 +11,10 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 		event_name = "orientationchange",
 		get_orientation,
 		last_orientation,
-		initial_orientation_is_landscape,
-		initial_orientation_is_default,
-		portrait_map = { "0": true, "180": true },
-		ww, wh, landscape_threshold;
+		initial_map = { "0": true, "180": true },
+		portrait_map = initial_map;
 
+	function setOrientationMap() {
 	// It seems that some device/browser vendors use window.orientation values 0 and 180 to
 	// denote the "default" orientation. For iOS devices, and most other smart-phones tested,
 	// the default orientation is always "portrait", but in some Android and RIM based tablets,
@@ -44,14 +43,16 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 		// developer console. The actual threshold value is somewhat arbitrary, we just
 		// need to make sure it is large enough to exclude the developer console case.
 
-		ww = window.innerWidth || win.width();
-		wh = window.innerHeight || win.height();
-		landscape_threshold = 50;
+			var ww = window.innerWidth || win.width(),
+				wh = window.innerHeight || win.height(),
+				landscape_threshold = 50,
+				initial_orientation_is_landscape,
+				initial_orientation_is_default;
 
 		initial_orientation_is_landscape = ww > wh && ( ww - wh ) > landscape_threshold;
 
 		// Now check to see if the current window.orientation is 0 or 180.
-		initial_orientation_is_default = portrait_map[ window.orientation ];
+		initial_orientation_is_default = initial_map[ window.orientation ];
 
 		// If the initial orientation is landscape, but window.orientation reports 0 or 180, *OR*
 		// if the initial orientation is portrait, but window.orientation reports 90 or -90, we
@@ -59,7 +60,21 @@ define( [ "jquery", "../jquery.mobile.support.orientation", "./throttledresize" 
 		// this device/browser.
 		if ( ( initial_orientation_is_landscape && initial_orientation_is_default ) || ( !initial_orientation_is_landscape && !initial_orientation_is_default ) ) {
 			portrait_map = { "-90": true, "90": true };
-		}
+			} else {
+				portrait_map = initial_map;
+			}
+	}
+	}
+
+	setOrientationMap();
+
+	// On iPhones, when a webapp is started in full screen mode (via a launcher icon, not via Safari) *while* device is
+	// held in landscape orientation, then the initial value of window.orientation may be incorrect, stating that
+	// device is still in portrait mode while innerHeight and innerWidth are already set to landscape dimensions. It
+	// seems that window.orientation is delivered correctly on ready event. This is why we need to trigger our decision
+	// logic once again on document ready if we previously had to flip portrait_map values.
+	if ( initial_map !== portrait_map ) {
+		$( window.document ).ready( setOrientationMap );
 	}
 
 	$.event.special.orientationchange = $.extend( {}, $.event.special.orientationchange, {


### PR DESCRIPTION
Currently, when an app is stored as an app launcher icon on iPhone's home screen and app is being started while the device is held in landscape orientation, jQuery mobile flips the orientation events i.e. it reports "landscape"
when device is held in portrait mode and vice versa.

Test page is available [here](http://jsbin.com/ofuhaw/945/edit).

Steps to reproduce:
1. Open app with the iPhone's Safari browser.
2. Tap on Safari's bottom bar on the icon to add the app to home screen and select "Add to home screen".
3. Close Safari, go to screen where app launcher was created.
4. **While holding device in landscape orientation** start the app by tapping the launcher.

Expected outcome: The test page should display the text `landscape`.

Actual outcome: The test page displays the text `portrait`.

Tested on: iPhone 5 with iOS 6 and iPhone 4 with iOS 7.0.3. This bug is **not reproducible** on iPads; tested with iPad 2 with iOS 7.0.3 and iPad mini with iOS 6.

Bug could be reproduced with jQuery mobile 1.3.2 and current master.

Description for the pull request:
The problem is that the initial value of `window.orientation` may be incorrect while starting app and holding device in landscape orientation. Upon start on iPhones while holding them in landscape orientation, this variable states that device is still in portrait mode while `window.innerHeight` and `window.innerWidth` are already set to landscape dimensions. It seems that `window.orientation` is only corrected when the `ready` event is fired.

This commit fixes the problem by triggering the decision logic once again on document ready if orientation values had to be flipped previously to normalize output for other devices.

Edit: signed the CLA
