### PR TITLE
'Collapsible' is not working well when the widget inherits options from collapsibleset.

### DIFF
--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -42,7 +42,8 @@ $.widget( "mobile.collapsible", {
 		var elem = this.element,
 			ui = {
 				accordion: elem
-					.closest( ":jqmData(role='collapsible-set'), :jqmData(role='collapsibleset')" )
+					.closest( ":jqmData(role='collapsible-set'), :jqmData(role='collapsibleset')" +
+						( $.mobile.collapsibleset ? ", :mobile-collapsibleset" : "" ) )
 					.addClass( "ui-collapsible-set" )
 			};
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -42,8 +42,7 @@ $.widget( "mobile.collapsible", {
 		var elem = this.element,
 			ui = {
 				accordion: elem
-					.closest( ":jqmData(role='collapsible-set')" +
-						( $.mobile.collapsibleset ? ", :mobile-collapsibleset" : "" ) )
+					.closest( ":jqmData(role='collapsible-set'), :jqmData(role='collapsibleset')" )
 					.addClass( "ui-collapsible-set" )
 			};
 


### PR DESCRIPTION
Hi all.

I find a bug in collapsible.
'Collapsible' is not working well when the widget inherits options from collapsibleset.

If you visit below URL, you should see the malfunction.
http://hyunsook.github.io/jqm-debug/latest/collapsibleset-inset_origin.html

The selector, :mobile-collapsibleset, can not find the collapsibleset within running _create().
Because this selector only can find the DOM after collapsibleset is created.

I think, we have two solutions.
First is to change widget creation order.
Second is to use a legacy selector (:jqmData(role='collapsibleset') ).
This PR contain second solution.

If you visit here, you would see the normal operation.
http://hyunsook.github.io/jqm-debug/latest/collapsibleset-inset_after.html

If there are any problems or mistakes on that PR, please let me know.
Thanks in advance.
