### PR TITLE
When options of collapsibleset is changed in runtime, it should not affect to collapsibles.

### DIFF
--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -220,8 +220,8 @@ $.widget( "mobile.collapsible", {
 		}
 
 		if ( opts.iconpos !== undefined ) {
-			anchor.removeClass( "ui-btn-icon-" + ( currentOpts.iconPos === "right" ? "right" : "left" ) );
-			anchor.addClass( "ui-btn-icon-" + ( opts.iconPos === "right" ? "right" : "left" ) );
+			anchor.removeClass( "ui-btn-icon-" + ( currentOpts.iconpos === "right" ? "right" : "left" ) );
+			anchor.addClass( "ui-btn-icon-" + ( opts.iconpos === "right" ? "right" : "left" ) );
 		}
 
 		if ( opts.theme !== undefined ) {
@@ -231,8 +231,8 @@ $.widget( "mobile.collapsible", {
 		}
 
 		if ( opts.contentTheme !== undefined ) {
-			oldTheme = this._themeClassFromOption( "ui-body-", currentOpts.theme );
-			newTheme = this._themeClassFromOption( "ui-body-", opts.theme );
+			oldTheme = this._themeClassFromOption( "ui-body-", currentOpts.contentTheme );
+			newTheme = this._themeClassFromOption( "ui-body-", opts.contentTheme );
 			ui.content.removeClass( oldTheme ).addClass( newTheme );
 		}
 

--- a/js/widgets/collapsible.js
+++ b/js/widgets/collapsible.js
@@ -163,14 +163,27 @@ $.widget( "mobile.collapsible", {
 		return ui;
 	},
 
-	refresh: function() {
-		var key, options = {};
+	refresh: function( collapsibleSetOptions ) {
+		var key, options = {}, opts = {};
 
-		for ( key in $.mobile.collapsible.defaults ) {
-			options[ key ] = this.options[ key ];
+		if ( collapsibleSetOptions && typeof collapsibleSetOptions  === "object" ) {
+			// if refreshed by collapsibleset.
+			for ( key in collapsibleSetOptions ) {
+				if ( this.options[ key ] == null ) {
+					options[ key ] = collapsibleSetOptions[ key ];
+					opts[ key ] = null;
+				}
+			}
+		} else {
+			for ( key in $.mobile.collapsible.defaults ) {
+					options[ key ] = this.options[ key ];
+			}
 		}
-
 		this._setOptions( options );
+		// recover options.
+		for ( key in opts ) {
+			this.options[ key ] = opts[ key ];
+		}
 	},
 
 	_setOptions: function( options ) {

--- a/js/widgets/collapsibleSet.js
+++ b/js/widgets/collapsibleSet.js
@@ -92,8 +92,8 @@ $.widget( "mobile.collapsibleset", $.extend( {
 			elem.toggleClass( "ui-corner-all", hasCorners );
 		}
 
+		this.element.children( ":mobile-collapsible" ).collapsible( "refresh" , options );
 		ret = this._super( options );
-		this.element.children( ":mobile-collapsible" ).collapsible( "refresh" );
 		return ret;
 	},
 

--- a/tests/unit/individual-modules/collapsibleset-tests.html
+++ b/tests/unit/individual-modules/collapsibleset-tests.html
@@ -42,7 +42,7 @@
 			<h1>Collapsible 1</h1>
 			<p>Content of collapsible 1</p>
 		</div>
-		<div data-nstest-role="collapsible">
+		<div data-nstest-role="collapsible" data-nstest-collapsed="false">
 			<h1>Collapsible 2</h1>
 			<p>Content of collapsible 2</p>
 		</div>

--- a/tests/unit/individual-modules/collapsibleset_core.js
+++ b/tests/unit/individual-modules/collapsibleset_core.js
@@ -3,4 +3,40 @@ test( "Collapsible set widget works correctly", function() {
 
 	deepEqual( collapsibleset.hasClass( "ui-collapsible-set" ), true, "Collapsible set has class ui-collapsible-set" );
 	deepEqual( collapsibleset.children( ".ui-collapsible" ).length, 2, "Collapsible set correctly enhances its children" );
+
+	collapsibleset.collapsibleset( "option", "mini", "true" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-mini" ).length, 2, "Collapsible set correctly apply option(mini='true') to children" );
+
+	collapsibleset.collapsibleset( "option", "mini", "false" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-mini" ).length, 0, "Collapsible set correctly apply option(mini='false') to children" );
+
+	collapsibleset.collapsibleset( "option", "inset", "false" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-collapsible-inset" ).length, 0, "Collapsible set correctly apply option(inset='false') to children" );
+
+	collapsibleset.collapsibleset( "option", "inset", "true" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-collapsible-inset" ).length, 2, "Collapsible set correctly apply option(inset='true') to children" );
+
+	collapsibleset.collapsibleset( "option", "iconpos", "right" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-btn-icon-right" ).length, 2, "Collapsible set correctly apply option(iconpos='right') to children" );
+
+	collapsibleset.collapsibleset( "option", "iconpos", "left" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-btn-icon-left" ).length, 2, "Collapsible set correctly apply option(iconpos='left') to children" );
+
+	collapsibleset.collapsibleset( "option", "collapsedIcon", "arrow-r" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-icon-arrow-r" ).length, 1, "Collapsible set correctly apply option(collapsedIcon='arrow-r') to children" );
+
+	collapsibleset.collapsibleset( "option", "collapsedIcon", "plus" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-icon-plus" ).length, 1, "Collapsible set correctly apply option(collapsedIcon='plus') to children" );
+
+	collapsibleset.collapsibleset( "option", "expandedIcon", "arrow-r" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-icon-arrow-r" ).length, 1, "Collapsible set correctly apply option(expandedIcon='arrow-r') to children" );
+
+	collapsibleset.collapsibleset( "option", "expandedIcon", "minus" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-icon-plus" ).length, 1, "Collapsible set correctly apply option(expandedIcon='minus') to children" );
+
+	collapsibleset.collapsibleset( "option", "theme", "b" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-btn-b" ).length, 2, "Collapsible set correctly apply option(theme='b') to children" );
+
+	collapsibleset.collapsibleset( "option", "theme", "a" ).collapsibleset( "refresh" );
+	deepEqual( collapsibleset.find( ".ui-btn-a" ).length, 2, "Collapsible set correctly apply option(theme='a') to children" );
 });


### PR DESCRIPTION
Hi all.

When options of collapsibleset are changed in runtime, it should not affect to child collapsibles.

If you visit below URL, you should see the malfunction
URL : http://hyunsook.github.io/jqm-debug/latest/collapsibleset-setoptions-refresh-origin.html

This bug is caused that collapsible could not get a old value about options of collapsibleset.

When 'refresh' of Collapsible executes, this widget gets options from collapsibleset.
But collapsible can not know old options of collapsibleset.
Because, Options of collapsibleset is changed before  'refresh' of collapsible method executes.
Variables, currentOpts and opts, have same values.(_setOptions in collapsible.js)

This PR contain the solution.

If you visit here, you would see the normal operation.
URL : http://hyunsook.github.io/jqm-debug/latest/collapsibleset-setoptions-refresh.html

If there are any problems or mistakes on that PR, please let me know.
Thanks in advance.
