### PR TITLE
Build: Use short syntax for RequireJS' shims

### DIFF
--- a/js/requirejs.config.js
+++ b/js/requirejs.config.js
@@ -5,19 +5,9 @@ requirejs.config({
 		"json": "../external/requirejs/plugins/json"
 	},
 	"shim": {
-		"jquery.hashchange": {
-			deps: [ "jquery" ]
-		},
-		"jquery.ui.widget": {
-			deps: [ "jquery" ],
-			exports: "$.widget"
-		},
-		"widgets/jquery.ui.tabs": {
-			deps: [ "jquery.ui.widget" ]
-		},
-		"widgets/jquery.ui.core": {
-			deps: [ "jquery" ],
-			exports: [ "$.ui" ]
-		}
+		"jquery.hashchange": [ "jquery" ],
+		"jquery.ui.widget": [ "jquery" ],
+		"widgets/jquery.ui.tabs": [ "jquery.ui.widget" ],
+		"widgets/jquery.ui.core": [ "jquery" ]
 	}
 });


### PR DESCRIPTION
We don't need to export anything, just express dependencies of the non-AMD modules.
