### PR TITLE
Demos: highlight is now correctly removed on cancelation. Fixed #6892 - ...

### DIFF
--- a/demos/swipe-list/index.php
+++ b/demos/swipe-list/index.php
@@ -75,7 +75,7 @@
 				});
 				// Remove active state and unbind when the cancel button is clicked
 				$( "#confirm #cancel" ).on( "click", function() {
-					listitem.removeClass( "ui-btn-active" );
+					listitem.children( ".ui-btn" ).removeClass( "ui-btn-active" );
 					$( "#confirm #yes" ).off();
 				});
 			}


### PR DESCRIPTION
...Demos - Swipe to delete list item | Highlight isn't correctly removed

Highlight is now correctly removed, if you cancel the deletion of a listitem in swipe to delete demo.

Tests ran fine:

> > 2329 assertions passed (1027483ms)

Done, without errors.
