### PR TITLE
Panels: Correctly set panel classes on pages with external panels

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -52,6 +52,7 @@ $.widget( "mobile.panel", {
 			_panelID: el.attr( "id" ),
 			_closeLink: el.find( ":jqmData(rel='close')" ),
 			_parentPage: ( parentPage.length > 0 ) ? parentPage : false,
+			_openedPage: null,
 			_page: this._getPage,
 			_panelInner: this._getPanelInner(),
 			_wrapper: this._getWrapper,
@@ -99,7 +100,7 @@ $.widget( "mobile.panel", {
 	},
 
 	_getPage: function() {
-		var page = this._parentPage ? this._parentPage : $( "." + $.mobile.activePageClass );
+		var page = this._openedPage || this._parentPage || $( "." + $.mobile.activePageClass );
 
 		return page;
 	},
@@ -339,6 +340,8 @@ $.widget( "mobile.panel", {
 					self._bindFixListener();
 
 					self._trigger( "open" );
+
+					self._openedPage = self._page();
 				};
 
 			self._trigger( "beforeopen" );
@@ -405,6 +408,8 @@ $.widget( "mobile.panel", {
 					self._page().jqmRemoveData( "panel" );
 
 					self._trigger( "close" );
+
+					self._openedPage = null;
 				};
 
 			self._trigger( "beforeclose" );

--- a/tests/unit/panel/index.html
+++ b/tests/unit/panel/index.html
@@ -86,7 +86,22 @@
 				<a href="#panel-test-destroy">Open Panel</a>
 				<a href="#panel-test-non-default-theme">Open Panel</a>
 				<a href="#panel-test-with-close">Open Panel</a>
+				<a href="#panel-test-external">Open Panel</a>
 			</div>
+		</div>
+
+		<div data-nstest-role="page" id="multipage">
+			<div data-nstest-role="header">
+				<h1>Multipage</h1>
+			</div>
+			<div data-nstest-role="content">
+				<p>Contents of a page.</p>
+			</div>
+		</div>
+
+		<div data-nstest-role="panel" id="panel-test-external">
+			<a href="#multipage">Multipage</a>
+			<a href="#" data-nstest-rel="back">Back</a>
 		</div>
 
 	</body>

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -284,4 +284,65 @@
 		$panel.panel( "open" );
 	});
 
+
+	asyncTest( "external panel: test classes during A>B>A transition", function() {
+		expect( 16 );
+
+		var $panel = $( "#panel-test-external" ).panel(),
+			$firstPage = $( ":jqmData(role='page')" ).first(),
+			$secondPage = $( ":jqmData(role='page')" ).last(),
+			$openButton = $firstPage.find( "a[href='\\#panel-test-external']" ),
+			$link = $panel.find( "a[href='\\#multipage']" ),
+			$back = $panel.find( "a[data-nstest-rel='back']" );
+
+		$panel.one( "panelopen", function( event ) {
+
+			ok( !$panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
+			ok( $panel.hasClass( defaults.classes.panelOpen ), "open class added" );
+			ok( $firstPage.data("nstestPanel") === "open", "open flag set on first page" );
+			equal( $firstPage.find(".ui-panel-wrapper").length, 1, "wrapper exists." );
+
+			$link.trigger( "click" );
+
+		}).one( "panelclose", function( event ) {
+
+			ok( $panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
+			ok( !$panel.hasClass( defaults.classes.panelOpen ), "open class added" );
+			ok( $firstPage.data("nstestPanel") === undefined, "no open flag on first" );
+
+			$panel.trigger( "continue" );
+
+		}).one( "continue", function( event ) {
+
+			setTimeout(function() {
+				$panel.panel( "open" );
+
+				ok( !$panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
+				ok( $panel.hasClass( defaults.classes.panelOpen ), "open class added" );
+				ok( $secondPage.data("nstestPanel") === "open", "open flag set on 2nd page" );
+				equal( $secondPage.find(".ui-panel-wrapper").length, 1, "wrapper exists." );
+
+				$back.trigger( "click" );
+
+			},500);
+
+		}).panel( "open" );
+
+		$back.one( "click", function( event ) {
+
+			ok( $firstPage.data("nstestPanel") === undefined, "no open flag on first page on backwards transition" );
+			equal( $firstPage.find(".ui-panel-wrapper").length, 1, "wrapper exists." );
+
+			setTimeout(function() {
+				$panel.panel( "open" );
+
+				ok( $firstPage.data("nstestPanel") === "open", "open flag set on first page" );
+				ok( !$panel.hasClass( defaults.classes.panelClosed ), "closed class removed" );
+				ok( $panel.hasClass( defaults.classes.panelOpen ), "open class added" );
+
+				start();
+			},500);
+		});
+	});
+
 }( jQuery ));


### PR DESCRIPTION
This is an update to #6658

When using external panels, classes set on a page/content wrapper are 
set inside `getPage` with:

`this._parentPage || $( "." + $.mobile.activePageClass )`

If a transition to a new page is triggered from an open, **external** panel, 
**active page changes while the panel plugin still updates element 
classes**, which results in part of the classes being assigned to the page 
being left and part of the classes being set on the new page (log active 
page id inside `getPage` to see).

This PR adds a new parameter `_openedPage`, which if set overrides both 
parent and active page and points to the correct page in need of panel-related 
updating.

Fixes: #6650
Closes: #6658
