### PR TITLE
Filterable events

### DIFF
--- a/js/widgets/filterable.js
+++ b/js/widgets/filterable.js
@@ -62,7 +62,7 @@ $.widget( "mobile.filterable", {
 			}
 
 			this._timer = this._delay( function() {
-				this._trigger( "beforefilter", "beforefilter", { input: search } );
+				this._trigger( "beforefilter", null, { input: search } );
 
 				// Change val as lastval for next execution
 				search[ 0 ].setAttribute( "data-" + $.mobile.ns + "lastval", val );

--- a/js/widgets/filterable.js
+++ b/js/widgets/filterable.js
@@ -117,6 +117,10 @@ $.widget( "mobile.filterable", {
 		}
 
 		this._refreshChildWidget();
+
+		this._trigger( "filter", null, {
+			items: filterItems
+		});
 	},
 
 	// The Default implementation of _refreshChildWidget attempts to call


### PR DESCRIPTION
This includes two fixes for filterable. The first removes the invalid second string argument from the existing `_trigger` call. The second adds a `filter` event, as discussed in #6580. I've named it `filter` instead of `postfilter` to be consistent with other events.

I haven't added any unit tests, since there was nothing to extend. The only filterable unit tests is a trivial assert.
