### PR TITLE
Swipe event: Trigger only one event per mouse sequence and let it bubble

### DIFF
--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -186,15 +186,20 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 		// in work at any given time
 		eventInProgress: false,
 
-		// This hash helps teardown remove all the right handlers
-		contexts: {},
-
 		setup: function() {
-			var thisObject = this,
+			var events,
+				thisObject = this,
 				$this = $( thisObject ),
 				context = {};
 
-			$.event.special.swipe.contexts[ this ] = context;
+			// Retrieve the events data for this element and add the swipe context
+			events = $.data( this, "mobile-events" );
+			if ( !events ) {
+				events = { length: 0 };
+				$.data( this, "mobile-events", events );
+			}
+			events.length++;
+			events.swipe = context;
 
 			context.start = function( event ) {
 
@@ -245,7 +250,17 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 		},
 
 		teardown: function() {
-			var context = $.event.special.swipe.contexts[ this ];
+			var events, context;
+
+			events = $.data( this, "mobile-events" );
+			if ( events ) {
+				context = events.swipe;
+				delete events.swipe;
+				events.length--;
+				if ( events.length === 0 ) {
+					$.removeData( this, "mobile-events" );
+				}
+			}
 
 			if ( context ) {
 				if ( context.start ) {
@@ -258,8 +273,6 @@ define( [ "jquery", "../jquery.mobile.vmouse", "../jquery.mobile.support.touch" 
 					$document.off( touchStopEvent, context.stop );
 				}
 			}
-
-			delete $.event.special.swipe.contexts[ this ];
 		}
 	};
 	$.each({

--- a/tests/unit/event/event_core.js
+++ b/tests/unit/event/event_core.js
@@ -6,6 +6,7 @@
 	var libName = "jquery.mobile.events.js",
 	    components = [ "events/touch.js", "events/throttledresize.js", "events/orientationchange.js" ],
 	    absFn = Math.abs,
+			originalPageContainer = $.mobile.pageContainer,
 	    originalEventFn = $.Event.prototype.originalEvent,
 	    preventDefaultFn = $.Event.prototype.preventDefault,
 	    events = ("touchstart touchmove touchend tap taphold " +
@@ -28,7 +29,12 @@
 			// the collections existence in non touch enabled test browsers
 			$.Event.prototype.touches = [{pageX: 1, pageY: 1 }];
 
+			$.mobile.pageContainer = originalPageContainer || $( "body" );
+
 			$($.mobile.pageContainer).unbind( "throttledresize" );
+		},
+		teardown: function() {
+			$.mobile.pageContainer = originalPageContainer;
 		}
 	});
 

--- a/tests/unit/event/index.html
+++ b/tests/unit/event/index.html
@@ -13,12 +13,13 @@
 	</script>
 
 	<script src="../../../js/jquery.mobile.define.js"></script>
+	<script src="../../../js/jquery.mobile.ns.js"></script>
 	<script src="../../../js/jquery.mobile.support.touch.js"></script>
 	<script src="../../../js/jquery.mobile.events.js"></script>
+	<script src="../../../js/jquery.mobile.vmouse.js"></script>
 	<script src="../../../js/events/touch.js"></script>
 	<script src="../../../js/events/throttledresize.js"></script>
 	<script src="../../../js/events/orientationchange.js"></script>
-	<script src="../../../js/"></script>
 
 	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
 	<script src="../../../external/qunit/qunit.js"></script>


### PR DESCRIPTION
The element to which a mousedown handler is attached by the swipe setup() code
takes ownership of the next swipe event. This means that, if the same mousedown
event triggers other swipe setup() -attached mousedown handlers as it bubbles,
the subsequent ones will bail. Thus, if a swipe event results from the mousedown
then such a swipe event will be triggered on the deepest element with an
attached swipe handler, and it will be allowed to bubble from there. This
provides the tools that developers can use to avoid scenarios such as the one
mentioned in the referenced issue.

Fixes gh-6262
