### PR TITLE
Panel: Do not close in response to a default-prevented swipe event

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -233,19 +233,24 @@ $.widget( "mobile.panel", {
 		}
 	},
 
-	_bindSwipeEvents: function() {
-		var self = this,
-			area = self._modal ? self.element.add( self._modal ) : self.element;
+	_handleSwipe: function( event ) {
+		if ( !event.isDefaultPrevented() ) {
+			this.close();
+		}
+	},
 
-		// on swipe, close the panel
-		if ( !!self.options.swipeClose ) {
-			if ( self.options.position === "left" ) {
-				area.on( "swipeleft.panel", function(/* e */) {
-					self.close();
+	_bindSwipeEvents: function() {
+		var area = this._modal ? this.element.add( this._modal ) : this.element;
+
+		// Close the panel on swipe if the swipe event's default is not prevented
+		if ( this.options.swipeClose ) {
+			if ( this.options.position === "left" ) {
+				this._on( area, {
+					swipeleft: "_handleSwipe"
 				});
 			} else {
-				area.on( "swiperight.panel", function(/* e */) {
-					self.close();
+				this._on( area, {
+					swiperight: "_handleSwipe"
 				});
 			}
 		}
@@ -487,7 +492,6 @@ $.widget( "mobile.panel", {
 
 		this.element
 			.removeClass( [ this._getPanelClasses(), o.classes.panelOpen, o.classes.animate ].join( " " ) )
-			.off( "swipeleft.panel swiperight.panel" )
 			.off( "panelbeforeopen" )
 			.off( "panelhide" )
 			.off( "keyup.panel" )

--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -240,19 +240,12 @@ $.widget( "mobile.panel", {
 	},
 
 	_bindSwipeEvents: function() {
-		var area = this._modal ? this.element.add( this._modal ) : this.element;
+		var handler = {};
 
 		// Close the panel on swipe if the swipe event's default is not prevented
 		if ( this.options.swipeClose ) {
-			if ( this.options.position === "left" ) {
-				this._on( area, {
-					swipeleft: "_handleSwipe"
-				});
-			} else {
-				this._on( area, {
-					swiperight: "_handleSwipe"
-				});
-			}
+			handler[ "swipe" + this.options.position ] = "_handleSwipe";
+			this._on( ( this._modal ? this.element.add( this._modal ) : this.element ), handler );
 		}
 	},
 

--- a/tests/unit/panel/index.html
+++ b/tests/unit/panel/index.html
@@ -55,6 +55,7 @@
 			<p>Contents of a panel.</p>
 		</div>
 		<div data-nstest-role="panel" id="panel-test-dismiss">
+			<input id="dismiss-input"></input>
 			<p>Contents of a panel.</p>
 		</div>
 		<div data-nstest-role="panel" id="panel-test-destroy">

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -264,7 +264,48 @@
 
 	});
 
-	asyncTest( "swipe on dismissable modal closes panel", function() {
+	asyncTest( "swipe on dismissible panel does not close panel if the default is prevented",
+		function() {
+			var panel = $( "#panel-test-dismiss" ),
+				eventNs = ".swipeDoesNotClosePanel",
+				input = $( "#dismiss-input" ).one( "swipeleft", function( event ) {
+					event.preventDefault();
+				});
+
+			expect( 1 );
+
+			$.testHelper.detailedEventCascade([
+				function() {
+					panel.panel( "open" );
+				},
+
+				{
+					panelopen: { src: panel, event: "panelopen" + eventNs + "1" }
+				},
+
+				function() {
+					input.trigger( "swipeleft" );
+				},
+
+				{
+					panelclose: { src: panel, event: "panelclose" + eventNs + "2" }
+				},
+
+				function( result ) {
+					deepEqual( result.panelclose.timedOut, true,
+						"panelclose event did not happen in response to swipe on child input" );
+					panel.panel( "close" );
+				},
+
+				{
+					panelclose: { src: panel, event: "panelclose" + eventNs + "3" }
+				},
+
+				start
+			]);
+		});
+
+	asyncTest( "swipe on dismissible modal closes panel", function() {
 
 		expect( 1 );
 


### PR DESCRIPTION
Fixes gh-6925

Note: This fix requires https://github.com/jquery/jquery-mobile/pull/6946 even though the automated tests pass, because in the automated tests I trigger swipe manually, with .trigger( "swipeleft" ) instead of calculating it from mouse events using the swipe special event. https://github.com/jquery/jquery-mobile/pull/6946 ensures that the swipe special event triggers correctly.
