### PR TITLE
Flipswitch: Transfer tabindex to "on" button and make input unfocusable

### DIFF
--- a/js/widgets/forms/flipswitch.js
+++ b/js/widgets/forms/flipswitch.js
@@ -71,7 +71,7 @@ $.widget( "mobile.flipswitch", $.extend({
 			});
 	},
 
-	_handleInputFocus: function( event ) {
+	_handleInputFocus: function() {
 		this.on.focus();
 	},
 

--- a/js/widgets/forms/flipswitch.js
+++ b/js/widgets/forms/flipswitch.js
@@ -40,6 +40,18 @@ $.widget( "mobile.flipswitch", $.extend({
 
 			this._handleFormReset();
 
+			// Transfer tabindex to "on" element and make input unfocusable
+			$.extend( this, {
+				_originalTabIndex: this.element.attr( "tabindex" )
+			});
+			if ( this._originalTabIndex != null ) {
+				this.on.attr( "tabindex", this._originalTabIndex );
+			}
+			this.element.attr( "tabindex", "-1" );
+			this._on({
+				"focus" : "_handleInputFocus"
+			});
+
 			if ( this.element.is( ":disabled" ) ) {
 				this._setOptions({
 					"disabled": true
@@ -59,6 +71,11 @@ $.widget( "mobile.flipswitch", $.extend({
 			this._on( {
 				"change": "refresh"
 			});
+	},
+
+	_handleInputFocus: function( event ) {
+		$( event.target ).blur();
+		this.on.focus();
 	},
 
 	widget: function() {
@@ -90,7 +107,11 @@ $.widget( "mobile.flipswitch", $.extend({
 			options = this.options,
 			element = this.element,
 			theme = options.theme ? options.theme : "inherit",
-			on = $( "<span></span>", { tabindex: 1 } ),
+
+			// The "on" button is an anchor so it's focusable
+			on = $( "<a></a>", {
+				"href": "#"
+			}),
 			off = $( "<span></span>" ),
 			type = element.get( 0 ).tagName,
 			onText = ( type === "INPUT" ) ?
@@ -199,6 +220,11 @@ $.widget( "mobile.flipswitch", $.extend({
 	_destroy: function() {
 		if ( this.options.enhanced ) {
 			return;
+		}
+		if ( this._originalTabIndex != null ) {
+			this.element.attr( "tabindex", this._originalTabIndex );
+		} else {
+			this.element.removeAttr( "tabindex" );
 		}
 		this.on.remove();
 		this.off.remove();

--- a/js/widgets/forms/flipswitch.js
+++ b/js/widgets/forms/flipswitch.js
@@ -41,9 +41,7 @@ $.widget( "mobile.flipswitch", $.extend({
 			this._handleFormReset();
 
 			// Transfer tabindex to "on" element and make input unfocusable
-			$.extend( this, {
-				_originalTabIndex: this.element.attr( "tabindex" )
-			});
+			this._originalTabIndex = this.element.attr( "tabindex" );
 			if ( this._originalTabIndex != null ) {
 				this.on.attr( "tabindex", this._originalTabIndex );
 			}
@@ -74,7 +72,6 @@ $.widget( "mobile.flipswitch", $.extend({
 	},
 
 	_handleInputFocus: function( event ) {
-		$( event.target ).blur();
 		this.on.focus();
 	},
 

--- a/tests/integration/flipswitch/flipswitch_core.js
+++ b/tests/integration/flipswitch/flipswitch_core.js
@@ -1,0 +1,30 @@
+/*
+ * mobile flipswitch unit tests
+ */
+(function($){
+
+	var testFocusTransfer = function( el ) {
+		expect( 1 );
+		$.testHelper.detailedEventCascade([
+			function() {
+				el.focus();
+			},
+			{
+				focus: { src: el.siblings( "a" ), event: "focus.TransfersFocus1" }
+			},
+			function( result ) {
+				deepEqual( result.focus.timedOut, false, "'on' button received focus event" );
+				start();
+			}
+		]);
+	};
+
+	asyncTest( "select based flipswitch transfers focus to 'on' button", function() {
+		testFocusTransfer( $( "#flip-select" ) );
+	});
+
+	asyncTest( "checkbox based flipswitch transfers focus to 'on' button", function() {
+		testFocusTransfer( $( "#flip-checkbox" ) );
+	});
+
+})( jQuery );

--- a/tests/integration/flipswitch/flipswitch_core.js
+++ b/tests/integration/flipswitch/flipswitch_core.js
@@ -3,14 +3,14 @@
  */
 (function($){
 
-	var testFocusTransfer = function( el ) {
+	var testFocusTransfer = function( element ) {
 		expect( 1 );
 		$.testHelper.detailedEventCascade([
 			function() {
-				el.focus();
+				element.focus();
 			},
 			{
-				focus: { src: el.siblings( "a" ), event: "focus.TransfersFocus1" }
+				focus: { src: element.siblings( "a" ), event: "focus.TransfersFocus1" }
 			},
 			function( result ) {
 				deepEqual( result.focus.timedOut, false, "'on' button received focus event" );

--- a/tests/integration/flipswitch/index.html
+++ b/tests/integration/flipswitch/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Button Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+
+
+	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css"/>
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[ "widgets/page" ],
+      [
+				"widgets/forms/flipswitch",
+			],
+			[ "jquery.mobile.init" ],
+			[
+				"flipswitch_core.js"
+			]
+		]);
+	</script>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+  <h1 id="qunit-header">jQuery Mobile Flipswitch Test Suite</h1>
+  <h2 id="qunit-banner"></h2>
+  <h2 id="qunit-userAgent"></h2>
+  <ol id="qunit-tests">
+  </ol>
+
+  <div data-nstest-role="page" data-nstest-theme="a">
+    <div data-nstest-role="content" data-nstest-theme="b">
+      	<input type="checkbox" data-nstest-role="flipswitch" name="flip-checkbox" id="flip-checkbox"/>
+      	<select id="flip-select" name="flip-select" data-nstest-role="flipswitch">
+            <option>On</option>
+            <option>Off</option>
+        </select>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/integration/flipswitch/index.html
+++ b/tests/integration/flipswitch/index.html
@@ -31,11 +31,7 @@
 	<script src="../../swarminject.js"></script>
 </head>
 <body>
-  <h1 id="qunit-header">jQuery Mobile Flipswitch Test Suite</h1>
-  <h2 id="qunit-banner"></h2>
-  <h2 id="qunit-userAgent"></h2>
-  <ol id="qunit-tests">
-  </ol>
+	<div id="qunit"></div>
 
   <div data-nstest-role="page" data-nstest-theme="a">
     <div data-nstest-role="content" data-nstest-theme="b">

--- a/tests/unit/flipswitch/flipswitch_core.js
+++ b/tests/unit/flipswitch/flipswitch_core.js
@@ -58,5 +58,11 @@
 		$("#flip-select").trigger("swiperight");
 		ok( $("#flip-select").parent().hasClass("ui-flipswitch-active"), "should not be active" );
 	});
+	test( "checkbox based flipswitch is untabbable", function() {
+		deepEqual( parseInt( $( "#flip-checkbox" ).attr( "tabindex" ) ), -1, "tabindex is set to -1" );
+	});
+	test( "select based flipswitch is untabbable", function() {
+		deepEqual( parseInt( $( "#flip-select" ).attr( "tabindex" ) ), -1, "tabindex is set to -1" );
+	});
 
 })( jQuery );


### PR DESCRIPTION
The "on" button must be an anchor for it to be focusable just like an input even
when it does not have an explicitly set tabindex. Although the input becomes
unfocusable, a focus handler that transfers focus to the "on" button is
nevertheless attached to it in case third-party code focuses the input manually.

Fixes gh-6955
