### PR TITLE
Custom select: Transfer value of "overlayTheme" option to dialog 

### DIFF
--- a/js/widgets/forms/select.custom.js
+++ b/js/widgets/forms/select.custom.js
@@ -133,7 +133,7 @@ $.widget( "mobile.selectmenu", $.mobile.selectmenu, {
 	},
 
 	build: function() {
-		var selectId, popupId, dialogId, label, thisPage, isMultiple, menuId, themeAttr, overlayThemeAttr,
+		var selectId, popupId, dialogId, label, thisPage, isMultiple, menuId, themeAttr, overlayTheme, overlayThemeAttr,
 			dividerThemeAttr, menuPage, listbox, list, header, headerTitle, menuPageContent, menuPageClose, headerClose, self,
 			o = this.options;
 
@@ -150,7 +150,8 @@ $.widget( "mobile.selectmenu", $.mobile.selectmenu, {
 		isMultiple = this.element[ 0 ].multiple;
 		menuId = selectId + "-menu";
 		themeAttr = o.theme ? ( " data-" + $.mobile.ns + "theme='" + o.theme + "'" ) : "";
-		overlayThemeAttr = o.overlayTheme ? ( " data-" + $.mobile.ns + "theme='" + o.overlayTheme + "'" ) : "";
+		overlayTheme = o.overlayTheme || o.theme || null;
+		overlayThemeAttr = overlayTheme ? ( " data-" + $.mobile.ns + "overlay-theme='" + overlayTheme + "'" ) : "";
 		dividerThemeAttr = ( o.dividerTheme && isMultiple ) ? ( " data-" + $.mobile.ns + "divider-theme='" + o.dividerTheme + "'" ) : "";
 		menuPage = $( "<div data-" + $.mobile.ns + "role='dialog' class='ui-selectmenu' id='" + dialogId + "'" + themeAttr + overlayThemeAttr + ">" +
 			"<div data-" + $.mobile.ns + "role='header'>" +

--- a/tests/integration/select/index.html
+++ b/tests/integration/select/index.html
@@ -146,6 +146,62 @@
 			</select>
 		</div>
 
+		<div data-nstest-role="fieldcontain" id="select-overlay-theme-container">
+			<label for="select-choice-many-overlay-theme-test" class="select">Your state:</label>
+			<select data-nstest-theme="x" data-nstest-overlay-theme="x" name="select-choice-many-overlay-theme-test" id="select-choice-many-overlay-theme-test" data-nstest-native-menu="false">
+				<option value="AL">Alabama</option>
+				<option value="AK">Alaska</option>
+				<option value="AZ">Arizona</option>
+				<option value="AR">Arkansas</option>
+				<option value="CA">California</option>
+				<option value="CO">Colorado</option>
+				<option value="CT">Connecticut</option>
+				<option value="DE">Delaware</option>
+				<option value="FL">Florida</option>
+				<option value="GA">Georgia</option>
+				<option value="HI">Hawaii</option>
+				<option value="ID">Idaho</option>
+				<option value="IL">Illinois</option>
+				<option value="IN">Indiana</option>
+				<option value="IA">Iowa</option>
+				<option value="KS">Kansas</option>
+				<option value="KY">Kentucky</option>
+				<option value="LA">Louisiana</option>
+				<option value="ME">Maine</option>
+				<option value="MD">Maryland</option>
+				<option value="MA">Massachusetts</option>
+				<option value="MI">Michigan</option>
+				<option value="MN">Minnesota</option>
+				<option value="MS">Mississippi</option>
+				<option value="MO">Missouri</option>
+				<option value="MT">Montana</option>
+				<option value="NE">Nebraska</option>
+				<option value="NV">Nevada</option>
+				<option value="NH">New Hampshire</option>
+				<option value="NJ">New Jersey</option>
+				<option value="NM">New Mexico</option>
+				<option value="NY">New York</option>
+				<option value="NC">North Carolina</option>
+				<option value="ND">North Dakota</option>
+				<option value="OH">Ohio</option>
+				<option value="OK">Oklahoma</option>
+				<option value="OR">Oregon</option>
+				<option value="PA">Pennsylvania</option>
+				<option value="RI">Rhode Island</option>
+				<option value="SC">South Carolina</option>
+				<option value="SD">South Dakota</option>
+				<option value="TN">Tennessee</option>
+				<option value="TX">Texas</option>
+				<option value="UT">Utah</option>
+				<option value="VT">Vermont</option>
+				<option value="VA">Virginia</option>
+				<option value="WA">Washington</option>
+				<option value="WV">West Virginia</option>
+				<option value="WI">Wisconsin</option>
+				<option value="WY">Wyoming</option>
+			</select>
+		</div>
+
 		<div data-nstest-role="fieldcontain" id="select-choice-many-container">
 			<label for="select-choice-many" class="select">Your state:</label>
 			<select name="select-choice-many" id="select-choice-many" data-nstest-native-menu="false">

--- a/tests/integration/select/select_core.js
+++ b/tests/integration/select/select_core.js
@@ -492,4 +492,25 @@
 		]);
 	});
 
+	asyncTest( "Custom select passes on overlay theme to its dialog", function() {
+
+		expect( 2 );
+
+		var dialog,
+			eventNs = ".passesOnOverlayThemeToDialog";
+
+		$.testHelper.pageSequence([
+			function() {
+				$( "#select-overlay-theme-container a:first" ).click();
+			},
+			function() {
+				dialog = $( "#select-choice-many-overlay-theme-test-dialog" );
+				deepEqual( $( ":mobile-pagecontainer" ).hasClass( "ui-overlay-x" ), true, "Page container has appropriate theme." );
+				deepEqual( dialog.dialog( "option", "overlayTheme" ), "x", "Dialog widget overlayTheme option is correct." );
+				dialog.dialog( "close" );
+			},
+			start
+		]);
+	});
+
 })(jQuery);


### PR DESCRIPTION
Since 2451b0b both the "overlayTheme" option
and the "theme" option are transferred to the dialog's data-theme attribute,
resulting in two copies of the data-theme attribute being set on the dialog div.

If the "overlayTheme" option is specified, the "theme" option is fanned out to
both the dialog's "theme" option as well as its "overlayTheme" option.

Fixes gh-6975

Edit: Changed title and description to reflect discussion
