### PR TITLE
Dialog extension: Remove reference to close() method

### DIFF
--- a/js/widgets/page.dialog.js
+++ b/js/widgets/page.dialog.js
@@ -120,7 +120,6 @@ $.widget( "mobile.page", $.mobile.page, {
 				.attr( "data-" + $.mobile.ns + "rel", "back" )
 				.text( text || this.options.closeBtnText || "" )
 				.prependTo( dst );
-			this._on( btn, { click: "close" } );
 		}
 
 		this._headerCloseButton = btn;


### PR DESCRIPTION
Fixes gh-6968

The alternative here is to implement the close() method on the page extension, but that seems unnecessary, since the close button link should be handled like any other data-rel=back link.
