### PR TITLE
Autogrow: Wedge open vertical space while recalculating textarea height

### DIFF
--- a/js/widgets/forms/autogrow.js
+++ b/js/widgets/forms/autogrow.js
@@ -26,6 +26,19 @@ define( [
 		},
 
 		_autogrow: function() {
+
+			// This div is added right after the textarea. It vertically wedges open
+			// the space occupied by the textarea while its height is being
+			// recalculated, because in the process of recalculating its height the
+			// height has to be set to 0, and doing that can cause the page to jump
+			// https://github.com/jquery/jquery-mobile/issues/6898
+			this._shadow = $( "<div>" )
+				.css({
+					"visibility": "none"
+				})
+				.hide()
+				.insertAfter( this.element );
+
 			this._on({
 				"keyup": "_timeout",
 				"change": "_timeout",
@@ -70,6 +83,8 @@ define( [
 		},
 
 		_unbindAutogrow: function() {
+			this._shadow.remove();
+			this._shadow = null;
 			this._off( this.element, "keyup change input paste" );
 			this._off( this.document,
 				"pageshow popupbeforeposition updatelayout panelopen" );
@@ -95,6 +110,10 @@ define( [
 		_updateHeight: function() {
 
 			this.keyupTimeout = 0;
+
+			this._shadow
+				.show()
+				.css( "height", this.element.outerHeight() );
 
 			this.element.css({
 				"height": 0,
@@ -129,6 +148,8 @@ define( [
 				"min-height": "",
 				"max-height": ""
 			});
+
+			this._shadow.hide();
 		},
 
 		refresh: function() {

--- a/tests/functional/large-autogrow-textarea.html
+++ b/tests/functional/large-autogrow-textarea.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>JQM latest - issue template</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" href="../../css/themes/default/jquery.mobile.css"/>
+	<script src="../../external/jquery/jquery.js"></script>
+	<script src="../../external/jquery-ui/jquery.ui.widget.js"></script>
+	<script src="../../external/jquery-ui/jquery.ui.core.js"></script>
+	<script src="../../js/"></script>
+</head>
+<body>
+
+	<div data-role="page">
+
+		<div data-role="header">
+			<h1>Issue template</h1>
+		</div><!-- /header -->
+
+		<div class="ui-content">
+			<form>
+				<label for="textarea2">Textarea:</label>
+				<textarea cols="40" rows="8" name="textarea2" id="textarea2">
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed posuere blandit enim et tempus. Morbi sit amet lacinia nulla, facilisis bibendum nisl. In eu elementum lorem. In volutpat venenatis nisi, sed suscipit nisl eleifend ac. Duis placerat, felis eu sagittis lacinia, enim diam commodo augue, at eleifend purus diam sit amet felis. Nunc at venenatis nibh, sed tempor felis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam egestas cursus dolor ac pulvinar. Nulla facilisi.
+
+Cras at arcu commodo, varius turpis egestas, interdum urna. Nam et rutrum est, id rhoncus sem. Phasellus semper tempor vulputate. Nullam vehicula lorem nisl, sit amet fermentum dolor molestie et. Vivamus vestibulum nec neque suscipit euismod. Fusce posuere est et posuere molestie. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer vel tellus euismod orci elementum fringilla at a lacus. Vivamus libero dui, bibendum vel turpis nec, elementum tincidunt turpis. Fusce ut dolor gravida, vulputate erat in, faucibus enim. Donec posuere lectus at semper varius. Morbi consequat metus at urna sodales, et semper justo egestas. Sed ultrices congue mi non malesuada. In hac habitasse platea dictumst. Suspendisse sed cursus quam.
+
+Aenean at neque luctus, congue nulla eu, euismod lectus. Donec libero neque, tempor sodales tortor non, commodo aliquet risus. Suspendisse in iaculis enim. Integer eleifend commodo erat a pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae quam in lectus pellentesque gravida vel et lacus. Etiam vel massa tempus, commodo ante tempus, dignissim sapien. Vestibulum quis enim bibendum, pharetra nisi eget, rutrum lectus. In cursus euismod nunc at blandit. Duis ultricies ut turpis et rutrum. Sed suscipit leo diam, eget sodales quam blandit ut.
+
+Sed viverra fermentum dapibus. Aliquam erat volutpat. Praesent quam turpis, rhoncus sit amet lectus eget, bibendum imperdiet urna. Cras eget risus sit amet lectus ullamcorper convallis eget imperdiet risus. Nam volutpat cursus metus hendrerit volutpat. Proin eget sagittis augue. Aenean vitae libero id ipsum egestas aliquam. Integer tempor elementum magna condimentum sodales. Proin convallis eu arcu eget facilisis. Ut placerat, lacus ac ornare pellentesque, eros lacus accumsan libero, vel feugiat dolor est at purus. Integer placerat elit elit, ut condimentum nisi ultrices ut. Duis placerat rutrum blandit. Nunc dignissim et odio a tristique.
+
+Suspendisse viverra id nisi eu laoreet. Phasellus eu dolor euismod, venenatis diam a, malesuada velit. Phasellus ut tortor at nibh consectetur rhoncus ac sed orci. Integer id nisi et tortor sagittis cursus nec at lorem. Donec pulvinar consequat volutpat. Quisque non orci fringilla, egestas massa at, sodales lacus. Sed vehicula aliquet est. Donec id turpis nec orci consequat fringilla. Etiam a odio sed orci posuere vehicula quis id enim. In lorem ipsum, ultrices et cursus ut, tempor eget nulla. Sed sollicitudin tristique diam tempus vestibulum. Curabitur faucibus lorem sed sem eleifend vestibulum. Nam posuere egestas lectus eu mattis. Nam blandit auctor libero non sagittis.
+
+In tortor tellus, luctus et pellentesque sit amet, tincidunt ut enim. Nam sit amet lacus id lectus dapibus aliquet. Mauris nisi elit, malesuada eu turpis in, consequat aliquam lorem. Proin commodo egestas lectus facilisis tristique. Duis ligula orci, semper eget mi quis, pretium blandit risus. Pellentesque tristique odio sit amet ante tincidunt fermentum. Curabitur ultricies erat id tincidunt convallis. Aenean sed velit adipiscing, aliquet risus quis, hendrerit tortor. In eget metus non orci convallis bibendum a ut nunc. Integer vel nunc vitae lorem mollis eleifend. In elementum dignissim erat vitae rutrum. Etiam neque dui, pulvinar a est placerat, tempus pretium nibh. Donec placerat magna id leo interdum, eget euismod elit luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis vitae arcu suscipit, ullamcorper turpis a, sodales nisi. Ut venenatis dictum dui, in pulvinar justo gravida non.
+
+Vivamus varius aliquet rhoncus. Proin sit amet eleifend quam. Donec ultrices elit eu elit consequat, quis tincidunt dolor convallis. Nulla consectetur erat quis leo rhoncus auctor non tempus odio. Curabitur nec dolor vitae nisl ornare faucibus in ut tortor. Cras eu rhoncus sapien. Praesent semper nulla ut metus eleifend fermentum vitae ac justo. Donec volutpat dictum eros vel mattis. Aenean lobortis nulla quis risus ornare mattis. Maecenas gravida at odio vitae sagittis. Cras consequat egestas dictum. Cras nec erat in sem dignissim fringilla eget eget turpis. Pellentesque in gravida urna.
+
+Nam dolor leo, tristique tristique dignissim sed, adipiscing quis dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec hendrerit elit lacus, in pretium nibh accumsan id. Cras pharetra nisi enim, a dapibus leo auctor vitae. Quisque felis dui, vestibulum ac pharetra ac, aliquam at libero. Suspendisse ullamcorper luctus tellus quis ornare. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Donec aliquet varius est nec rhoncus. Curabitur velit risus, commodo sit amet libero a, scelerisque sagittis magna. Cras ullamcorper fringilla risus nec ultricies. Aenean placerat id velit in posuere. Etiam pretium aliquam elit at ornare. Nunc diam nunc, ultricies vitae sagittis convallis, volutpat nec diam. Nullam sed facilisis dui, ac placerat sapien.
+
+Donec dolor neque, congue mattis malesuada id, semper a arcu. Etiam scelerisque nisl neque, eu imperdiet libero venenatis nec. Pellentesque vitae sem quis eros accumsan luctus. Praesent volutpat sagittis sagittis. Donec ante dolor, aliquet ut blandit quis, viverra nec justo. Nulla facilisi. Morbi sit amet neque lobortis, vulputate quam eget, euismod nunc. Proin porttitor interdum orci eu feugiat. Fusce sed ipsum odio. Nullam vitae sapien nunc. Maecenas consectetur quam vel tempor interdum. Nulla a magna convallis, sollicitudin lorem a, vulputate eros. Pellentesque lobortis, nisl sit amet gravida cursus, quam nisi mollis leo, sit amet imperdiet urna odio nec ligula. Donec enim nunc, porttitor vel rhoncus quis, gravida posuere sapien.
+
+Vestibulum sit amet tortor libero. Donec vel purus sed velit porttitor adipiscing. Mauris tempus convallis sapien eu sodales. Nam adipiscing odio ac dolor placerat, vel ultrices felis posuere. Pellentesque mattis dolor vel vestibulum rhoncus. Nunc eleifend est leo, id interdum nunc tincidunt ac. Nulla dignissim felis quis vehicula blandit. Aliquam erat volutpat. In ultrices vitae arcu ut pellentesque. Nunc ac laoreet ante. Cras semper leo turpis, in vulputate nisl tempus at. Donec in eros nec sem accumsan convallis id a urna. Pellentesque posuere dictum turpis eu adipiscing.
+
+Cras tempor, quam id porttitor pulvinar, est ligula consequat turpis, a venenatis ipsum nulla ac lectus. Donec at urna vitae sem ultrices adipiscing. Aenean porta lectus vitae augue lobortis pharetra. Mauris in lectus diam. Cras faucibus non urna a viverra. Nullam mattis, massa at adipiscing venenatis, odio ligula adipiscing magna, sed luctus magna magna vitae elit. Aliquam hendrerit, dui eget tristique feugiat, mi massa fermentum nulla, ut placerat libero nisi eu sapien. Suspendisse mattis dui at nisi sodales sollicitudin. Etiam feugiat suscipit lectus, vel aliquam velit iaculis semper. Vestibulum condimentum, velit nec hendrerit varius, mi risus consequat purus, quis vulputate tellus nisi venenatis erat. Cras id bibendum lectus, eu rutrum turpis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Proin quis justo sapien. Sed dictum enim quam, non blandit diam rutrum pretium.
+				</textarea>
+			</form>
+
+		</div><!-- /content -->
+
+	</div><!-- /page -->
+
+</body>
+</html>


### PR DESCRIPTION
A div is added after the textarea and hidden at all times except during the
textarea height calculation process. During _updateHeight() its height is set to
the current height of the textarea before the textarea height is set to 0. This
will maintain the height of the document while the textarea is being resized and
seems to successfully prevent the browser from scrolling the document -
everywhere except on Android 2.3.5, where this change makes things no worse.

We should test this change extensively.

Fixes gh-6898
