### PR TITLE
Textarea: Turn off overflow for autogrow textarea widgets

### DIFF
--- a/css/structure/jquery.mobile.forms.textinput.autogrow.css
+++ b/css/structure/jquery.mobile.forms.textinput.autogrow.css
@@ -1,3 +1,7 @@
+textarea.ui-input-text.ui-textinput-autogrow {
+	overflow: hidden;
+}
+
 .ui-textinput-autogrow-resize {
 	-webkit-transition: height 0.25s;
 	-o-transition: height 0.25s;

--- a/js/widgets/forms/autogrow.js
+++ b/js/widgets/forms/autogrow.js
@@ -26,6 +26,8 @@ define( [
 		},
 
 		_autogrow: function() {
+			this.element.addClass( "ui-textinput-autogrow" );
+
 			this._on({
 				"keyup": "_timeout",
 				"change": "_timeout",
@@ -70,6 +72,7 @@ define( [
 		},
 
 		_unbindAutogrow: function() {
+			this.element.removeClass( "ui-textinput-autogrow" );
 			this._off( this.element, "keyup change input paste" );
 			this._off( this.document,
 				"pageshow popupbeforeposition updatelayout panelopen" );


### PR DESCRIPTION
This has two benefits:
1. Scrollbars will not affect the reported initial height
2. The scrollbar will not be displayed during the initial animation, only to
   disappear during the final animation frame

Fixes gh-6996
