### PR TITLE
Toolbar: $.mobile.navigate should trigger the back button

### DIFF
--- a/js/widgets/toolbar.js
+++ b/js/widgets/toolbar.js
@@ -50,7 +50,7 @@ define( [
 				if ( this.options.addBackBtn &&
 					this.role === "header" &&
 					$( ".ui-page" ).length > 1 &&
-					this.page[ 0 ].getAttribute( "data-" + $.mobile.ns + "url" ) !== $.mobile.path.stripHash( location.hash ) &&
+					this.page[ 0 ] !== $.mobile.pageContainer.pagecontainer("getActivePage")[ 0 ] &&
 					!this.leftbtn ) {
 						this._addBackButton();
 				} else {

--- a/tests/integration/toolbar/index.html
+++ b/tests/integration/toolbar/index.html
@@ -42,7 +42,15 @@
 		</div>
 	</div>
 	<div data-nstest-role="page" id="page2">
-		<div id="header" data-nstest-role="header" data-nstest-add-back-btn="true">
+		<div id="page-2-header" data-nstest-role="header" data-nstest-add-back-btn="true">
+			<h1>Header</h1>
+		</div>
+		<div data-nstest-role="content">
+			<p>Content</p>
+		</div>
+	</div>
+	<div data-nstest-role="page" id="page3">
+		<div id="page-3-header" data-nstest-role="header" data-nstest-add-back-btn="true">
 			<h1>Header</h1>
 		</div>
 		<div data-nstest-role="content">

--- a/tests/integration/toolbar/toolbar_core.js
+++ b/tests/integration/toolbar/toolbar_core.js
@@ -20,7 +20,7 @@ asyncTest( "Back button appears correctly", function() {
 		},
 
 		function() {
-			var backBtn = $( "#header a:first" );
+			var backBtn = $( "#page-2-header a:first" );
 
 			deepEqual( backBtn.length, 1, "A 'Back' button was added to the header." );
 			deepEqual( backBtn.attr( "role" ), "button", "The 'Back' button has the attribute " + '"' + "data-role='button'" + '"' );
@@ -30,5 +30,29 @@ asyncTest( "Back button appears correctly", function() {
 		start
 	]);
 });
+
+// Test the order of history update and page transition to guarantee that
+// the back button properly displays.
+asyncTest( "navigating with $.mobile.navigate should trigger the back button", function() {
+
+	expect( 2 );
+
+	$.testHelper.pageSequence([
+		function() {
+			$.mobile.navigate("#page3");
+		},
+
+		function() {
+			var backBtn = $( "#page-3-header a:first" );
+
+			deepEqual( backBtn.length, 1, "A 'Back' button was added to the header." );
+			deepEqual( backBtn.attr( "role" ), "button", "The 'Back' button has the attribute " + '"' + "data-role='button'" + '"' );
+			$.mobile.back();
+		},
+
+		start
+	]);
+});
+
 
 })( jQuery );


### PR DESCRIPTION
I encountered this issue when using $.mobile.navigate() to programmatically navigate to another page. I noticed that the data-add-back-btn attribute on the header widget did not work.

The back button shows up when I use $("body").pagecontainer("change", "#foo").

The affected line dates back to commit b3a8230 by @scottjehl

This commit adds a toolbar integration test that fails without the fix in place.
