### PR TITLE
Checkboxradio: Clicking on an unnamed radio button must also work

### DIFF
--- a/tests/unit/checkboxradio/input-set-tests.html
+++ b/tests/unit/checkboxradio/input-set-tests.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Checkboxradio Input Set Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[
+				"widgets/forms/checkboxradio",
+			],
+			[
+				"input_set_tests_core.js"
+			]
+		]);
+	</script>
+
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+
+	<div id="qunit"></div>
+
+	<div data-nstest-role="page">
+		<label>Radio<input id="radio:1" type="radio" name="group1"></label>
+		<form id="the-[form]">
+			<label>Radio<input id="radio:2" type="radio" name="group1"></label>
+			<label>Radio<input id="radio:7" type="radio" name="group1" form="the-'other'-form"></label>
+		</form>
+		<label>Radio<input id="radio:3" type="radio" name="group1" form="the-[form]"></label>
+		<form id="the-'other'-form">
+			<label>Radio<input id="radio:6" type="radio" name="group1" form="the-[form]"></label>
+			<label>Radio<input id="radio:4" type="radio" name="group1"></label>
+		</form>
+
+		<!-- radio5 (below) is not supposed to have a name -->
+		<label>Radio<input id="radio:5" type="radio"></label>
+	</div>
+
+	<label>Radio<input id="radio:8" type="radio" name="group1"></label>
+</body>
+</html>

--- a/tests/unit/checkboxradio/input_set_tests_core.js
+++ b/tests/unit/checkboxradio/input_set_tests_core.js
@@ -1,0 +1,36 @@
+( function( $, undefined ) {
+
+test( "Radio groups are correctly identified", function() {
+	var detached = $( "<input type='radio' name='group1' id='detached'>" ),
+		groups = {
+			"#radio\\:1": "#radio\\:1,#radio\\:8",
+			"#radio\\:2": "#radio\\:2,#radio\\:3,#radio\\:6",
+			"#radio\\:3": "#radio\\:2,#radio\\:3,#radio\\:6",
+			"#radio\\:6": "#radio\\:2,#radio\\:3,#radio\\:6",
+			"#radio\\:4": "#radio\\:4,#radio\\:7",
+			"#radio\\:7": "#radio\\:4,#radio\\:7",
+			"#radio\\:5": "#radio\\:5",
+			"#radio\\:8": "#radio\\:1,#radio\\:8"
+		},
+		checkGroup = function( radio, group ) {
+			var prefix = radio.attr( "id" ) + ": ",
+				result = $.mobile.checkboxradio.prototype._getInputSet.call({
+					element: radio,
+					inputtype: "radio"
+				});
+
+			deepEqual( group.length, result.length, prefix + "length of group is correct" );
+			group.each( function() {
+				deepEqual( result.filter( this ).length, 1,
+					prefix + $( this ).attr( "id" ) + " is correctly present in the result" );
+			});
+		};
+
+	$.each( groups, function( index, value ) {
+		checkGroup( $( index ), $( value ) );
+	});
+
+	checkGroup( detached, detached );
+});
+
+})( jQuery );


### PR DESCRIPTION
Original commit message: Fixed a bug that the input type="radio" button without
the name attribute is not changed to the checked status when it is clicked.
