### PR TITLE
Toolbar: Remove call to _setOptions from inside _makeFixed

### DIFF
--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -46,7 +46,6 @@ define( [ "jquery", "../jquery.mobile.widget", "../jquery.mobile.core", "../jque
 			this._addTransitionClass();
 			this._bindPageEvents();
 			this._bindToggleHandlers();
-			this._setOptions( this.options );
 		},
 
 		_setOptions: function( o ) {

--- a/js/widgets/toolbar.js
+++ b/js/widgets/toolbar.js
@@ -38,8 +38,7 @@ define( [
 				role: role,
 				page: page,
 				leftbtn: leftbtn,
-				rightbtn: rightbtn,
-				backBtn: null
+				rightbtn: rightbtn
 			});
 			this.element.attr( "role", role === "header" ? "banner" : "contentinfo" ).addClass( "ui-" + role );
 			this.refresh();
@@ -113,18 +112,15 @@ define( [
 
 		},
 		_addBackButton: function() {
-			var theme,
-				options = this.options;
-
-			if ( !this.backBtn ) {
+			var options = this.options,
 				theme = options.backBtnTheme || options.theme;
-				this.backBtn = $( "<a role='button' href='javascript:void(0);' " +
-					"class='ui-btn ui-corner-all ui-shadow ui-btn-left " +
-						( theme ? "ui-btn-" + theme + " " : "" ) +
-						"ui-toolbar-back-btn ui-icon-carat-l ui-btn-icon-left' " +
-					"data-" + $.mobile.ns + "rel='back'>" + options.backBtnText + "</a>" )
-						.prependTo( this.element );
-			}
+
+			$( "<a role='button' href='javascript:void(0);' " +
+				"class='ui-btn ui-corner-all ui-shadow ui-btn-left " +
+					( theme ? "ui-btn-" + theme + " " : "" ) +
+					"ui-toolbar-back-btn ui-icon-carat-l ui-btn-icon-left' " +
+				"data-" + $.mobile.ns + "rel='back'>" + options.backBtnText + "</a>" )
+					.prependTo( this.element );
 		},
 		_addHeadingClasses: function() {
 			this.element.children( "h1, h2, h3, h4, h5, h6" )

--- a/tests/integration/toolbar/fixed-toolbar-tests.html
+++ b/tests/integration/toolbar/fixed-toolbar-tests.html
@@ -1,0 +1,49 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Toolbar Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[
+				"widgets/fixedToolbar.workarounds",
+				"jquery.mobile.buttonMarkup"
+			],
+			[ "jquery.mobile.init" ],
+			[ "fixed_toolbar_core.js" ]
+		]);
+	</script>
+
+	<link rel="stylesheet" href="../../../css/themes/default/jquery.mobile.css"/>
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+
+	<div id="qunit"></div>
+
+	<div data-nstest-role="page">
+		<div class="ui-content" role="main">
+			<a href="#page2" id="go-to-page-2">Go to page 2</a>
+		</div>
+	</div>
+	<div data-nstest-role="page" id="page2">
+		<div id="header" data-nstest-role="header" data-nstest-position="fixed" data-nstest-add-back-btn="true">
+			<h1>Header</h1>
+		</div>
+		<div data-nstest-role="content">
+			<p>Content</p>
+		</div>
+	</div>
+</body>
+</html>

--- a/tests/integration/toolbar/fixed_toolbar_core.js
+++ b/tests/integration/toolbar/fixed_toolbar_core.js
@@ -1,0 +1,16 @@
+module( "Fixed toolbar" );
+
+asyncTest( "Only a single back button is added to a fixed toolbar", function() {
+	expect( 1 );
+	$.testHelper.pageSequence([
+		function() {
+			$( "#go-to-page-2" ).click();
+		},
+		function() {
+			deepEqual( $( "#header" ).children( "a" ).length, 1,
+				"Fixed header has exactly one back button" );
+			$.mobile.back();
+		},
+		start
+	]);
+});


### PR DESCRIPTION
Note by @gabrielschulhof: Edited commit message to
comply with new style guide and replaced author with real name.

Fixes gh-6567

**Note:**
This PR also reverts the part of 86b70c6510c759ebc8f474a992c8e23b2c33a1c7 that prevents a second button from being added, and includes a test to make sure a second button is not added. IOW, this is the right way to fix #6554.
