### PR TITLE
Fix for Issue 7115

### DIFF
--- a/demos/flipswitch/index.php
+++ b/demos/flipswitch/index.php
@@ -40,7 +40,7 @@
 	width: 1.875em;
 }
 @media (min-width: 28em) {
-	// Repeated from rule .ui-flipswitch above
+	/*Repeated from rule .ui-flipswitch above*/
 	.ui-field-contain > label + .custom-size-flipswitch.ui-flipswitch {
 		width: 1.875em;
 	}


### PR DESCRIPTION
In the second example for Custom-Labels.At line 9,the commenting is
done using "//".This has been replaced by a "/\*  */" style comment.
