### PR TITLE
Toolbar: Back button correctly appears/disappears on external toolbar

### DIFF
--- a/js/widgets/toolbar.js
+++ b/js/widgets/toolbar.js
@@ -124,7 +124,7 @@ define( [
 					// This must also be a header toolbar
 					this.role === "header" &&
 
-					// There must be multiple pages in the DOMN
+					// There must be multiple pages in the DOM
 					$( ".ui-page" ).length > 1 &&
 					( this.page ?
 

--- a/js/widgets/toolbar.js
+++ b/js/widgets/toolbar.js
@@ -114,9 +114,12 @@ define( [
 			this.rightbtn = this.rightbtn || headerAnchors.eq( 1 ).addClass( "ui-btn-right" ).length;
 		},
 		_updateBackButton: function() {
-			var options = this.options,
-				backButton = this.element.find( ".ui-toolbar-back-btn" ),
+			var backButton,
+				options = this.options,
 				theme = options.backBtnTheme || options.theme;
+
+			// Retrieve the back button or create a new, empty one
+			backButton = this._backButton = ( this._backButton || {} );
 
 			// We add a back button only if the option to do so is on
 			if ( this.options.addBackBtn &&
@@ -141,18 +144,22 @@ define( [
 					!this.leftbtn ) {
 
 				// Skip back button creation if one is already present
-				if ( backButton.length === 0 ) {
-					$( "<a role='button' href='javascript:void(0);' " +
-						"class='ui-btn ui-corner-all ui-shadow ui-btn-left " +
-							( theme ? "ui-btn-" + theme + " " : "" ) +
-							"ui-toolbar-back-btn ui-icon-carat-l ui-btn-icon-left' " +
-						"data-" + $.mobile.ns + "rel='back'>" + options.backBtnText + "</a>" )
+				if ( !backButton.attached ) {
+					backButton.element = ( backButton.element ||
+						$( "<a role='button' href='javascript:void(0);' " +
+							"class='ui-btn ui-corner-all ui-shadow ui-btn-left " +
+								( theme ? "ui-btn-" + theme + " " : "" ) +
+								"ui-toolbar-back-btn ui-icon-carat-l ui-btn-icon-left' " +
+							"data-" + $.mobile.ns + "rel='back'>" + options.backBtnText +
+							"</a>" ) )
 							.prependTo( this.element );
+					backButton.attached = true;
 				}
 
 			// If we are not adding a back button, then remove the one present, if any
-			} else {
-				backButton.remove();
+			} else if ( backButton.element ) {
+				backButton.element.detach();
+				backButton.attached = false;
 			}
 		},
 		_addHeadingClasses: function() {

--- a/js/widgets/toolbar.js
+++ b/js/widgets/toolbar.js
@@ -96,23 +96,22 @@ define( [
 		},
 		// Deprecated in 1.4. As from 1.5 ui-btn-left/right classes have to be present in the markup.
 		_addHeaderButtonClasses: function() {
-			var $headeranchors = this.element.children( "a, button" );
+			var headerAnchors = this.element.children( "a, button" );
 
 			// Do not mistake a back button for a left toolbar button
-			this.leftbtn = $headeranchors.hasClass( "ui-btn-left" ) &&
-				!$headeranchors.hasClass( "ui-toolbar-back-btn" );
+			this.leftbtn = headerAnchors.hasClass( "ui-btn-left" ) &&
+				!headerAnchors.hasClass( "ui-toolbar-back-btn" );
 
-			this.rightbtn = $headeranchors.hasClass( "ui-btn-right" );
+			this.rightbtn = headerAnchors.hasClass( "ui-btn-right" );
 
 			// Filter out right buttons and back buttons
 			this.leftbtn = this.leftbtn ||
-				$headeranchors.eq( 0 )
+				headerAnchors.eq( 0 )
 					.not( ".ui-btn-right,.ui-toolbar-back-btn" )
 					.addClass( "ui-btn-left" )
 					.length;
 
-			this.rightbtn = this.rightbtn || $headeranchors.eq( 1 ).addClass( "ui-btn-right" ).length;
-
+			this.rightbtn = this.rightbtn || headerAnchors.eq( 1 ).addClass( "ui-btn-right" ).length;
 		},
 		_updateBackButton: function() {
 			var options = this.options,

--- a/tests/integration/toolbar/external-toolbar-tests.html
+++ b/tests/integration/toolbar/external-toolbar-tests.html
@@ -1,0 +1,55 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Toolbar Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[
+				"widgets/toolbar",
+				"jquery.mobile.buttonMarkup"
+			],
+			[ "jquery.mobile.init" ],
+			[ "external_toolbar_core.js" ]
+		]);
+	</script>
+
+	<link rel="stylesheet" href="../../../css/themes/default/jquery.mobile.css"/>
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+
+	<div id="qunit"></div>
+
+	<div id="header" data-nstest-role="header" data-nstest-add-back-btn="true">
+		<h1>Header</h1>
+	</div>
+	<div data-nstest-role="page">
+		<div class="ui-content" role="main">
+			<a href="#page2" id="go-to-page-2">Go to page 2</a>
+		</div>
+	</div>
+	<div data-nstest-role="page" id="page2">
+		<div data-nstest-role="content">
+			<a href="#page3" id="go-to-page-3">Go to page 3</a>
+			<p>Content</p>
+		</div>
+	</div>
+	<div data-nstest-role="page" id="page3">
+		<div data-nstest-role="content">
+			<p>Content</p>
+		</div>
+	</div>
+</body>
+</html>

--- a/tests/integration/toolbar/external-toolbar-tests.html
+++ b/tests/integration/toolbar/external-toolbar-tests.html
@@ -15,9 +15,9 @@
 		$.testHelper.asyncLoad([
 			[
 				"widgets/toolbar",
-				"jquery.mobile.buttonMarkup"
+				"buttonMarkup"
 			],
-			[ "jquery.mobile.init" ],
+			[ "init" ],
 			[ "external_toolbar_core.js" ]
 		]);
 	</script>

--- a/tests/integration/toolbar/external_toolbar_core.js
+++ b/tests/integration/toolbar/external_toolbar_core.js
@@ -1,0 +1,43 @@
+asyncTest( "Back button added to external toolbar", function() {
+	$( "#header" ).toolbar();
+	$.testHelper.pageSequence([
+		function() {
+			$( "#go-to-page-2" ).click();
+		},
+		function() {
+			deepEqual( $( "#header" ).find( ".ui-toolbar-back-btn" ).length, 1,
+				"After navigating to page 2 exactly one back button " +
+					"appears on the external toolbar" );
+			$.mobile.back();
+		},
+		function() {
+			deepEqual( $( "#header" ).find( ".ui-toolbar-back-btn" ).length, 0,
+				"After going back from page 2 no back button appears on the external toolbar" );
+			$( "#go-to-page-2" ).click();
+		},
+		function() {
+			deepEqual( $( "#header" ).find( ".ui-toolbar-back-btn" ).length, 1,
+				"After navigating to page 2 again exactly one back button " +
+					"appears on the external toolbar" );
+			$( "#go-to-page-3" ).click();
+		},
+		function() {
+			deepEqual( $( "#header" ).find( ".ui-toolbar-back-btn" ).length, 1,
+				"After navigating to page 3 exactly one back button " +
+					"appears on the external toolbar" );
+			$.mobile.back();
+		},
+		function() {
+			deepEqual( $( "#header" ).find( ".ui-toolbar-back-btn" ).length, 1,
+				"After navigating back to page 2 exactly one back button " +
+					"appears on the external toolbar" );
+			$.mobile.back();
+		},
+		function() {
+			deepEqual( $( "#header" ).find( ".ui-toolbar-back-btn" ).length, 0,
+				"After navigating back from page 2 no back button " +
+					"appears on the external toolbar" );
+			start();
+		},
+	]);
+});


### PR DESCRIPTION
This commit makes the following modifications:
1. Rename _addBackButton() to _updateBackButton() and move the decision making
   as to whether to add or remove a back button from _setOptions() into
   _updateBackButton().
2. Call _updateBackButton() from refresh() as well. This will cause the back
   button to be updated whenever the page changes, because the "pageshow"
   handler is hooked up to refresh().
3. Modify _addHeaderButtonClasses to not recognize the back button as a left
   button.
4. Modify the preconditions for adding a button to include an alternative to
   checking the page's URL for instances where there is no page present - i.e.
   when the toolbar is external. In such cases one must add a back button if
   the active item on the history stack is not the first item.

Fixes gh-7091
