### PR TITLE
Do not unconditionally add "//" to absolute URLs and handle authority-less URLs

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -57,6 +57,7 @@ define([
 			var path = $.mobile.path,
 				$pages = $( ":jqmData(role='page'), :jqmData(role='dialog')" ),
 				hash = path.stripHash( path.stripQueryParams(path.parseLocation().hash) ),
+				theLocation = $.mobile.path.parseLocation(),
 				hashPage = document.getElementById( hash );
 
 			// if no pages are found, create one with body's inner html
@@ -70,7 +71,8 @@ define([
 
 				// unless the data url is already set set it to the pathname
 				if ( !$this[ 0 ].getAttribute( "data-" + $.mobile.ns + "url" ) ) {
-					$this.attr( "data-" + $.mobile.ns + "url", $this.attr( "id" ) || location.pathname + location.search );
+					$this.attr( "data-" + $.mobile.ns + "url", $this.attr( "id" ) ||
+						theLocation.pathname + theLocation.search );
 				}
 			});
 

--- a/js/navigation/base.js
+++ b/js/navigation/base.js
@@ -46,13 +46,14 @@ define([
 			page.find( base.linkSelector ).each(function( i, link ) {
 				var thisAttr = $( link ).is( "[href]" ) ? "href" :
 					$( link ).is( "[src]" ) ? "src" : "action",
+				theLocation = $.mobile.path.parseLocation(),
 				thisUrl = $( link ).attr( thisAttr );
 
 				// XXX_jblas: We need to fix this so that it removes the document
 				//            base URL, and then prepends with the new page URL.
 				// if full path exists and is same, chop it - helps IE out
-				thisUrl = thisUrl.replace( location.protocol + "//" +
-					location.host + location.pathname, "" );
+				thisUrl = thisUrl.replace( theLocation.protocol + theLocation.doubleSlash +
+					theLocation.host + theLocation.pathname, "" );
 
 				if ( !/^(\w+:|#|\/)/.test( thisUrl ) ) {
 					$( link ).attr( thisAttr, newPath + thisUrl );

--- a/js/navigation/path.js
+++ b/js/navigation/path.js
@@ -41,19 +41,31 @@ define([
 			urlParseRE: /^\s*(((([^:\/#\?]+:)?(?:(\/\/)((?:(([^:@\/#\?]+)(?:\:([^:@\/#\?]+))?)@)?(([^:\/#\?\]\[]+|\[[^\/\]@#?]+\])(?:\:([0-9]+))?))?)?)?((\/?(?:[^\/\?#]+\/+)*)([^\?#]*)))?(\?[^#]+)?)(#.*)?/,
 
 			// Abstraction to address xss (Issue #4787) by removing the authority in
-			// browsers that auto	decode it. All references to location.href should be
+			// browsers that auto-decode it. All references to location.href should be
 			// replaced with a call to this method so that it can be dealt with properly here
 			getLocation: function( url ) {
-				var uri = url ? this.parseUrl( url ) : location,
-					hash = this.parseUrl( url || location.href ).hash;
+
+				// Always use our own URL parser, even though location potentially provides all the
+				// fields we may need later on. This way, URL parsing is consistent, and we only
+				// grab location.href from the browser.
+				var uri = this.parseUrl( url || location.href ),
+					hash = uri.hash;
 
 				// mimic the browser with an empty string when the hash is empty
 				hash = hash === "#" ? "" : hash;
 
+				// The pathname must start with a slash if there's a protocol, because you can't
+				// have a protocol followed by a relative path. Also, it's impossible to calculate
+				// absolute URLs from relative ones if the absolute one doesn't have a leading "/".
+				if ( uri.protocol !== "" && uri.pathname.substring( 0, 1 ) !== "/" ) {
+					uri.pathname = "/" + uri.pathname;
+					uri.directory = "/" + uri.directory;
+				}
+
 				// Make sure to parse the url or the location object for the hash because using location.hash
 				// is autodecoded in firefox, the rest of the url should be from the object (location unless
 				// we're testing) to avoid the inclusion of the authority
-				return uri.protocol + "//" + uri.host + uri.pathname + uri.search + hash;
+				return uri.protocol + uri.doubleSlash + uri.host + uri.pathname + uri.search + hash;
 			},
 
 			//return the original document url
@@ -323,7 +335,7 @@ define([
 
 					// reconstruct each of the pieces with the new search string and hash
 					href = path.parseUrl( href );
-					href = href.protocol + "//" + href.host + href.pathname + search + preservedHash;
+					href = href.protocol + href.doubleSlash + href.host + href.pathname + search + preservedHash;
 				} else {
 					href += href.indexOf( "#" ) > -1 ? uiState : "#" + uiState;
 				}

--- a/js/navigation/path.js
+++ b/js/navigation/path.js
@@ -44,10 +44,6 @@ define([
 			// browsers that auto-decode it. All references to location.href should be
 			// replaced with a call to this method so that it can be dealt with properly here
 			getLocation: function( url ) {
-
-				// Always use our own URL parser, even though location potentially provides all the
-				// fields we may need later on. This way, URL parsing is consistent, and we only
-				// grab location.href from the browser.
 				var uri = this.parseUrl( url || location.href ),
 					hash = uri.hash;
 

--- a/js/navigation/path.js
+++ b/js/navigation/path.js
@@ -47,9 +47,10 @@ define([
 				var parsedUrl = this.parseUrl( url || location.href ),
 					uri = url ? parsedUrl : location,
 
-					// Make sure to parse the url or the location object for the hash because using location.hash
-					// is autodecoded in firefox, the rest of the url should be from the object (location unless
-					// we're testing) to avoid the inclusion of the authority
+					// Make sure to parse the url or the location object for the hash because using
+					// location.hash is autodecoded in firefox, the rest of the url should be from
+					// the object (location unless we're testing) to avoid the inclusion of the
+					// authority
 					hash = parsedUrl.hash;
 
 				// mimic the browser with an empty string when the hash is empty
@@ -59,10 +60,12 @@ define([
 					parsedUrl.doubleSlash +
 					uri.host +
 
-					// The pathname must start with a slash if there's a protocol, because you can't
-					// have a protocol followed by a relative path. Also, it's impossible to calculate
-					// absolute URLs from relative ones if the absolute one doesn't have a leading "/".
-					( ( uri.protocol !== "" && uri.pathname.substring( 0, 1 ) !== "/" ) ? "/" : "" ) +
+					// The pathname must start with a slash if there's a protocol, because you
+					// can't have a protocol followed by a relative path. Also, it's impossible to
+					// calculate absolute URLs from relative ones if the absolute one doesn't have
+					// a leading "/".
+					( ( uri.protocol !== "" && uri.pathname.substring( 0, 1 ) !== "/" ) ?
+						"/" : "" ) +
 					uri.pathname +
 					uri.search +
 					hash;
@@ -335,7 +338,8 @@ define([
 
 					// reconstruct each of the pieces with the new search string and hash
 					href = path.parseUrl( href );
-					href = href.protocol + href.doubleSlash + href.host + href.pathname + search + preservedHash;
+					href = href.protocol + href.doubleSlash + href.host + href.pathname + search +
+						preservedHash;
 				} else {
 					href += href.indexOf( "#" ) > -1 ? uiState : "#" + uiState;
 				}

--- a/js/navigation/path.js
+++ b/js/navigation/path.js
@@ -44,24 +44,28 @@ define([
 			// browsers that auto-decode it. All references to location.href should be
 			// replaced with a call to this method so that it can be dealt with properly here
 			getLocation: function( url ) {
-				var uri = this.parseUrl( url || location.href ),
-					hash = uri.hash;
+				var parsedUrl = this.parseUrl( url || location.href ),
+					uri = url ? parsedUrl : location,
+
+					// Make sure to parse the url or the location object for the hash because using location.hash
+					// is autodecoded in firefox, the rest of the url should be from the object (location unless
+					// we're testing) to avoid the inclusion of the authority
+					hash = parsedUrl.hash;
 
 				// mimic the browser with an empty string when the hash is empty
 				hash = hash === "#" ? "" : hash;
 
-				// The pathname must start with a slash if there's a protocol, because you can't
-				// have a protocol followed by a relative path. Also, it's impossible to calculate
-				// absolute URLs from relative ones if the absolute one doesn't have a leading "/".
-				if ( uri.protocol !== "" && uri.pathname.substring( 0, 1 ) !== "/" ) {
-					uri.pathname = "/" + uri.pathname;
-					uri.directory = "/" + uri.directory;
-				}
+				return uri.protocol +
+					parsedUrl.doubleSlash +
+					uri.host +
 
-				// Make sure to parse the url or the location object for the hash because using location.hash
-				// is autodecoded in firefox, the rest of the url should be from the object (location unless
-				// we're testing) to avoid the inclusion of the authority
-				return uri.protocol + uri.doubleSlash + uri.host + uri.pathname + uri.search + hash;
+					// The pathname must start with a slash if there's a protocol, because you can't
+					// have a protocol followed by a relative path. Also, it's impossible to calculate
+					// absolute URLs from relative ones if the absolute one doesn't have a leading "/".
+					( ( uri.protocol !== "" && uri.pathname.substring( 0, 1 ) !== "/" ) ? "/" : "" ) +
+					uri.pathname +
+					uri.search +
+					hash;
 			},
 
 			//return the original document url

--- a/tests/unit/path/path_core.js
+++ b/tests/unit/path/path_core.js
@@ -239,9 +239,9 @@
 
 	test( "path.getLocation works properly", function() {
 		equal( $.mobile.path.getLocation("http://example.com/"), "http://example.com/" );
-		equal( $.mobile.path.getLocation("http://foo@example.com"), "http://example.com" );
-		equal( $.mobile.path.getLocation("http://foo:bar@example.com"), "http://example.com" );
-		equal( $.mobile.path.getLocation("http://<foo<:bar@example.com"), "http://example.com" );
+		equal( $.mobile.path.getLocation("http://foo@example.com/"), "http://example.com/" );
+		equal( $.mobile.path.getLocation("http://foo:bar@example.com/"), "http://example.com/" );
+		equal( $.mobile.path.getLocation("http://<foo<:bar@example.com/"), "http://example.com/" );
 
 		var allUriParts = "http://jblas:password@mycompany.com:8080/mail/inbox?msg=1234&type=unread#msg-content";
 

--- a/tests/unit/path/path_core.js
+++ b/tests/unit/path/path_core.js
@@ -242,6 +242,8 @@
 		equal( $.mobile.path.getLocation("http://foo@example.com/"), "http://example.com/" );
 		equal( $.mobile.path.getLocation("http://foo:bar@example.com/"), "http://example.com/" );
 		equal( $.mobile.path.getLocation("http://<foo<:bar@example.com/"), "http://example.com/" );
+		equal( $.mobile.path.getLocation("x-wmapp0:www/index.html" ), "x-wmapp0:/www/index.html" );
+		equal( $.mobile.path.getLocation("qrc:/index.html" ), "qrc:/index.html" );
 
 		var allUriParts = "http://jblas:password@mycompany.com:8080/mail/inbox?msg=1234&type=unread#msg-content";
 


### PR DESCRIPTION
Navigation: Test authority-less protocols with path.getLocation()
Navigation: Do not assume "//" is always part of an absolute URL
Navigation: Expect a trailing slash when testing path.getLocation()

Note: this does indeed represent a fix for gh-6574, but only once a version of
Cordova sporting https://github.com/apache/cordova-wp8/pull/30 is released.

Closes gh-6597
Fixes gh-6574
Fixes gh-6599
