### PR TITLE
Checkboxradio: Retrieve label correctly

### DIFF
--- a/js/widgets/forms/checkboxradio.js
+++ b/js/widgets/forms/checkboxradio.js
@@ -38,15 +38,7 @@ $.widget( "mobile.checkboxradio", $.extend( {
 				return input.jqmData( dataAttr ) ||
 					input.closest( "form, fieldset" ).jqmData( dataAttr );
 			},
-			// NOTE: Windows Phone could not find the label through a selector
-			// filter works though.
-			parentLabel = input.closest( "label" ),
-			label = parentLabel.length ? parentLabel :
-				input
-					.closest( "form, fieldset, :jqmData(role='page'), :jqmData(role='dialog')" )
-					.find( "label" )
-					.filter( "[for='" + escapeId( input[0].id ) + "']" )
-					.first(),
+			label = this._findLabel(),
 			inputtype = input[0].type,
 			checkedClass = "ui-" + inputtype + "-on",
 			uncheckedClass = "ui-" + inputtype + "-off";
@@ -59,7 +51,8 @@ $.widget( "mobile.checkboxradio", $.extend( {
 			this.options.disabled = true;
 		}
 
-		o.iconpos = inheritAttr( input, "iconpos" ) || label.attr( "data-" + $.mobile.ns + "iconpos" ) || o.iconpos,
+		o.iconpos = inheritAttr( input, "iconpos" ) ||
+			label.element.attr( "data-" + $.mobile.ns + "iconpos" ) || o.iconpos,
 
 		// Establish options
 		o.mini = inheritAttr( input, "mini" ) || o.mini;
@@ -67,8 +60,8 @@ $.widget( "mobile.checkboxradio", $.extend( {
 		// Expose for other methods
 		$.extend( this, {
 			input: input,
-			label: label,
-			parentLabel: parentLabel,
+			label: label.element,
+			labelIsParent: label.isParent,
 			inputtype: inputtype,
 			checkedClass: checkedClass,
 			uncheckedClass: uncheckedClass
@@ -78,7 +71,7 @@ $.widget( "mobile.checkboxradio", $.extend( {
 			this._enhance();
 		}
 
-		this._on( label, {
+		this._on( label.element, {
 			vmouseover: "_handleLabelVMouseOver",
 			vclick: "_handleLabelVClick"
 		});
@@ -94,10 +87,29 @@ $.widget( "mobile.checkboxradio", $.extend( {
 		this.refresh();
 	},
 
+	_findLabel: function() {
+		var input = this.element,
+			parentLabel = input.closest( "label" ),
+
+			// NOTE: Windows Phone could not find the label through a selector
+			// filter works though.
+			label = parentLabel.length ? parentLabel :
+				input
+					.closest( "form, fieldset, :jqmData(role='page'), :jqmData(role='dialog')" )
+					.find( "label" )
+					.filter( "[for='" + escapeId( input[0].id ) + "']" )
+					.first();
+
+		return {
+			element: label,
+			isParent: ( parentLabel.length > 0 )
+		};
+	},
+
 	_enhance: function() {
 		this.label.addClass( "ui-btn ui-corner-all");
 
-		if ( this.parentLabel.length > 0 ) {
+		if ( this.labelIsParent ) {
 			this.input.add( this.label ).wrapAll( this._wrapper() );
 		} else {
 			//this.element.replaceWith( this.input.add( this.label ).wrapAll( this._wrapper() ) );

--- a/js/widgets/forms/checkboxradio.js
+++ b/js/widgets/forms/checkboxradio.js
@@ -88,21 +88,28 @@ $.widget( "mobile.checkboxradio", $.extend( {
 	},
 
 	_findLabel: function() {
-		var input = this.element,
-			parentLabel = input.closest( "label" ),
+		var parentLabel, label, isParent,
+			input = this.element,
+			labelsList = input[ 0 ].labels;
+
+		if( labelsList && labelsList.length > 0 ) {
+			label = $( labelsList[ 0 ] );
+			isParent = $.contains( label[ 0 ], input[ 0 ] );
+		} else {
+			parentLabel = input.closest( "label" );
+			isParent = ( parentLabel.length > 0 );
 
 			// NOTE: Windows Phone could not find the label through a selector
 			// filter works though.
-			label = parentLabel.length ? parentLabel :
-				input
-					.closest( "form, fieldset, :jqmData(role='page'), :jqmData(role='dialog')" )
-					.find( "label" )
-					.filter( "[for='" + escapeId( input[0].id ) + "']" )
+			label = isParent ? parentLabel :
+				$( this.document[ 0 ].getElementsByTagName( "label" ) )
+					.filter( "[for='" + escapeId( input[ 0 ].id ) + "']" )
 					.first();
+		}
 
 		return {
 			element: label,
-			isParent: ( parentLabel.length > 0 )
+			isParent: isParent
 		};
 	},
 

--- a/tests/unit/checkboxradio/find-label-tests.html
+++ b/tests/unit/checkboxradio/find-label-tests.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>jQuery Mobile Checkboxradio Input Set Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[
+				"widgets/forms/checkboxradio",
+			],
+			[
+				"find_label_tests_core.js"
+			]
+		]);
+	</script>
+
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+
+	<div id="qunit"></div>
+
+	<label id="separate-label-outside-form-label" for="separate-label-outside-form">Label</label>
+	<form>
+		<label id="separate-label-in-form-label" for="separate-label-in-form">Label</label>
+		<input type="checkbox" id="separate-label-in-form">
+		<input type="checkbox" id="separate-label-outside-form">
+		<label id="nested-input-inside-form-label">Label<input type="checkbox" id="nested-input-inside-form"></label>
+	</form>
+
+	<label id="separate-label-input-outside-form-label" for="separate-label-input-outside-form">Label</label>
+	<input type="checkbox" id="separate-label-input-outside-form">
+	<label id="nested-input-outside-form-label">Label<input type="checkbox" id="nested-input-outside-form"></label>
+</body>
+</html>

--- a/tests/unit/checkboxradio/find_label_tests_core.js
+++ b/tests/unit/checkboxradio/find_label_tests_core.js
@@ -1,0 +1,51 @@
+var pairs = [
+		{
+			label: "#separate-label-outside-form-label",
+			input: "#separate-label-outside-form",
+			isParent: false
+		},
+		{
+			label: "#separate-label-in-form-label",
+			input: "#separate-label-in-form",
+			isParent: false
+		},
+		{
+			label: "#nested-input-inside-form-label",
+			input: "#nested-input-inside-form",
+			isParent: true
+		},
+		{
+			label: "#separate-label-input-outside-form-label",
+			input: "#separate-label-input-outside-form",
+			isParent: false
+		},
+		{
+			label: "#nested-input-outside-form-label",
+			input: "#nested-input-outside-form",
+			isParent: true
+		}
+	];
+
+test( "_findLabel() works correctly", function() {
+	var index, pair, result,
+		findLabel = $.mobile.checkboxradio.prototype._findLabel;
+
+	for ( index in pairs ) {
+		pair = $.extend( {}, pairs[ index ] );
+		pair.label = $( pair.label );
+		pair.input = $( pair.input );
+
+		result = findLabel.call({
+			element: pair.input,
+			document: $( document )
+		});
+
+		deepEqual( result.element.length > 0, true,
+			pair.input.attr( "id" ) + ": a label was found" );
+		deepEqual( result.element[ 0 ], pair.label[ 0 ],
+			pair.input.attr( "id" ) + ": the right label was found" );
+		deepEqual( result.isParent, pair.isParent,
+			pair.input.attr( "id" ) +
+				": the label was correctly identified as (not?) the parent" );
+	}
+});


### PR DESCRIPTION
This PR does two things. It
1. centralizes the code for retrieving the label into one function (`_findLabel`) so it's easily unit-testable
2. makes use of this.element[ 0 ].labels, if present, otherwise it grabs the labels from this.document[ 0 ].getElementsByTagName( "label" ) and looks for the relevant one

I've run the new unit tests on:
- phantomjs (obviously :) )
- Chrome/Desktop
- WP7.5 (Nokia Lumia 800)
- WP8 (Nokia Lumia 520)
- Windows 8/IE 10 (Browserstack)
- Android 2.3.5 (Samsung Galaxy S II) **EDIT**
- iOS 6.1.5 (iPod) **EDIT**
- FF27/Linux **EDIT**

... and all the right ones fail without the change applied, and all of them pass with the change applied.
