### PR TITLE
Checkboxradio: Work outside the page and using custom build

### DIFF
--- a/js/widgets/forms/checkboxradio.js
+++ b/js/widgets/forms/checkboxradio.js
@@ -10,6 +10,7 @@
 //>>css.theme: ../css/themes/default/jquery.mobile.theme.css
 
 define( [ "jquery",
+	"../../vmouse",
 	"../../navigation/path",
 	"../../core",
 	"../../widget",

--- a/tests/unit/individual-modules/checkboxradio-tests.html
+++ b/tests/unit/individual-modules/checkboxradio-tests.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Collapsible Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+
+	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css"/>
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[
+				"widgets/forms/checkboxradio"
+			],
+			[
+				"checkboxradio_core.js"
+			]
+		]);
+	</script>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+
+	<label>The Checkbox<input type="checkbox" id="the-checkbox"></label>
+</body>
+</html>

--- a/tests/unit/individual-modules/checkboxradio_core.js
+++ b/tests/unit/individual-modules/checkboxradio_core.js
@@ -1,0 +1,14 @@
+test( "Checkboxradio widget works correctly", function() {
+	var checkbox = $( "#the-checkbox" ).checkboxradio(),
+		initiallyChecked = checkbox.prop( "checked" );
+
+	deepEqual( checkbox.parent().hasClass( "ui-checkbox" ), true,
+		"Wrapper has class ui-checkbox" );
+	deepEqual( checkbox.siblings( "label" ).hasClass( "ui-btn" ), true,
+		"Input has a sibling <label> with class ui-btn" );
+
+	checkbox.siblings( "label" ).click();
+
+	deepEqual( checkbox.prop( "checked" ), !initiallyChecked,
+		"Clicking the label toggles the checkbox" );
+});


### PR DESCRIPTION
Checkboxradio needs to depend on vmouse because it attaches handlers to vclick and vmouseover.

The unit test for this fix also aids in completing the testing requirements set forth in #5987.
