### PR TITLE
IE 10 moving to background.

### DIFF
--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -288,8 +288,7 @@ $.widget( "mobile.popup", {
 			target = $( targetElement );
 			if ( 0 === target.parents().filter( ui.container[ 0 ] ).length ) {
 				$( this.document[ 0 ].activeElement ).one( "focus", function(/* theEvent */) {
-					if (targetElement.nodeName.toLowerCase() !== "body")
-				        {
+					if ( targetElement.nodeName.toLowerCase() !== "body" ) {
 				            target.blur();
 				        }
 				});

--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -288,7 +288,10 @@ $.widget( "mobile.popup", {
 			target = $( targetElement );
 			if ( 0 === target.parents().filter( ui.container[ 0 ] ).length ) {
 				$( this.document[ 0 ].activeElement ).one( "focus", function(/* theEvent */) {
-					$(target).not("body").blur();
+					if (targetElement.nodeName.toLowerCase() !== "body")
+				        {
+				            target.blur();
+				        }
 				});
 				ui.focusElement.focus();
 				theEvent.preventDefault();

--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -288,7 +288,7 @@ $.widget( "mobile.popup", {
 			target = $( targetElement );
 			if ( 0 === target.parents().filter( ui.container[ 0 ] ).length ) {
 				$( this.document[ 0 ].activeElement ).one( "focus", function(/* theEvent */) {
-					target.blur();
+					$(target).not("body").blur();
 				});
 				ui.focusElement.focus();
 				theEvent.preventDefault();


### PR DESCRIPTION
In IE 10 (and possibly older versions of IE) when there is a single tab open and a popup is displayed and there is another window on the same monitor, calling target.blur() can cause the browser to go to the background because the body element is the targetElement.  Ensuring the element is not the body element before calling blur() fixes this issue.
