### PR TITLE
Build: Update hashchange to include script tag escape

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
 		"jquery": "1.10.2",
 		"jquery-ui": "jquery/jquery-ui#c0ab71056b936627e8a7821f03c044aec6280a40",
 		"jquery-ui-tabs": "jquery/jquery-ui#fadf2b312a05040436451c64bbfaf4814bc62c56",
-		"jquery-hashchange": "gseguin/jquery-hashchange#77c4b3551fc6bdc2ac6b22b2641cfd7ac6b212d2"
+		"jquery-hashchange": "gseguin/jquery-hashchange#2da0c56fd418fa323c136254f971b6176f1ae135"
 	},
 	"devDependencies": {
 		"requirejs": "2.1.2",

--- a/external/jquery/plugins/jquery.hashchange.js
+++ b/external/jquery/plugins/jquery.hashchange.js
@@ -370,7 +370,7 @@
           iframe_doc.open();
           
           // Set document.domain for the Iframe document as well, if necessary.
-          domain && iframe_doc.write( '<script>document.domain="' + domain + '"</script>' );
+          domain && iframe_doc.write( '\x3cscript>document.domain="' + domain + '"\x3c/script>' );
           
           iframe_doc.close();
           


### PR DESCRIPTION
Grab the version of jquery.hashchange.js that includes
https://github.com/gseguin/jquery-hashchange/pull/1 which will cause the built
library to be inline-able.

Fixes gh-7300
