### PR TITLE
Remove inline height from .ui-panel-dismiss on _closePanel

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -398,7 +398,7 @@ $.widget( "mobile.panel", {
 
 					if ( self._modal ) {
 						self._modal.removeClass( self._modalOpenClasses )
-						.height('');
+						.height("");
 					}
 				},
 				complete = function() {

--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -397,7 +397,8 @@ $.widget( "mobile.panel", {
 					}
 
 					if ( self._modal ) {
-						self._modal.removeClass( self._modalOpenClasses );
+						self._modal.removeClass( self._modalOpenClasses )
+						.height('');
 					}
 				},
 				complete = function() {


### PR DESCRIPTION
Not removing the height from .ui-panel-dismiss breaks the layout if the
page height is changed dynamically once the panel has open and closed
once.
