### PR TITLE
Panel: Remove stale height value from the modal's inline style

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -397,7 +397,9 @@ $.widget( "mobile.panel", {
 					}
 
 					if ( self._modal ) {
-						self._modal.removeClass( self._modalOpenClasses );
+						self._modal
+							.removeClass( self._modalOpenClasses )
+							.height( "" );
 					}
 				},
 				complete = function() {

--- a/tests/integration/panel/panel-stale-height-tests.html
+++ b/tests/integration/panel/panel-stale-height-tests.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Panel Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+
+	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css"/>
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[
+				"widgets/panel",
+				"widgets/page"
+			],
+			[ "init" ],
+			[
+				"panel_stale_height_core.js"
+			]
+		]);
+	</script>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body class="ui-body-b">
+	<div id="qunit"></div>
+
+	<div data-nstest-role="page">
+		<div data-nstest-role="panel" id="stale-height-panel">
+			<p>The panel</p>
+		</div>
+		<a href="#stale-height-panel" id="stale-height-panel-link">Open panel</a>
+	</div>
+
+</body>

--- a/tests/integration/panel/panel_stale_height_core.js
+++ b/tests/integration/panel/panel_stale_height_core.js
@@ -1,0 +1,26 @@
+asyncTest( "Closing a panel removes the modal's height from its inline CSS", function() {
+	var eventNs = ".closingAPanelRemovesModalsHeightFromItsInlineCSS",
+		panel = $( "#stale-height-panel" ),
+		link = $( "#stale-height-panel-link" ),
+		modal = $( ".ui-panel-dismiss" );
+
+	$.testHelper.detailedEventCascade([
+		function() {
+			link.click();
+		},
+		{
+			panelopen: { src: panel, event: "panelopen" + eventNs + "1" }
+		},
+		function() {
+			panel.panel( "close" );
+		},
+		{
+			panelclose: { src: panel, event: "panelclose" + eventNs + "2" }
+		},
+		function() {
+			deepEqual( ( modal.attr( "style" ) || "" ).match( /height:\s*[0-9]/ ), null,
+				"style attribute does not include a height field" );
+			start();
+		}
+	]);
+});


### PR DESCRIPTION
Remove inline height from .ui-panel-dismiss on _closePanel

Not removing the height from .ui-panel-dismiss breaks the layout if the
page height is changed dynamically once the panel has open and closed
once.

Closes gh-7308
Fixes gh-7312
