### PR TITLE
Helpers: Make resetActivePageHeight() less aggressive

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -172,7 +172,13 @@ define( [ "jquery", "./ns", "jquery-ui/jquery.ui.core" ], function( jQuery ) {
 			height = compensateToolbars( page,
 				( typeof height === "number" ) ? height : $.mobile.getScreenHeight() );
 
-			page.css( "min-height", height - ( pageOuterHeight - pageHeight ) );
+			// Remove any previous min-height setting
+			page.css( "min-height", "" );
+
+			// Set the minimum height only if the height as determined by CSS is insufficient
+			if ( page.height() < height ) {
+				page.css( "min-height", height - ( pageOuterHeight - pageHeight ) );
+			}
 		},
 
 		loading: function() {


### PR DESCRIPTION
Do not set min-height if the existing height is good enough.
This fixes iOS 6.1, but not WP8.

Fixes gh-7322
