### PR TITLE
Wrapper: Compatibility with browserify

### DIFF
--- a/build/wrap.start
+++ b/build/wrap.start
@@ -9,4 +9,4 @@
 		// Browser globals
 		factory( root.jQuery, root, doc );
 	}
-}( this, document, function ( jQuery, window, document, undefined ) {
+}( window, document, function ( jQuery, window, document, undefined ) {


### PR DESCRIPTION
As described in https://github.com/Leaflet/Leaflet/pull/1572 , `this` won't refer to `window` when using browserify. Patching the wrapper should solve this issue.
