### PR TITLE
Fieldcontain: Reset width for notext buttons

### DIFF
--- a/css/structure/jquery.mobile.forms.fieldcontain.css
+++ b/css/structure/jquery.mobile.forms.fieldcontain.css
@@ -62,4 +62,7 @@
 		width: auto;
 		margin-right: .625em;
 	}
+	.ui-field-contain > label ~ .ui-btn-inline.ui-btn-icon-notext {
+		width: 1.75em;
+	}
 }


### PR DESCRIPTION
Buttons with .ui-btn-icon-notext normally have a fixed width of 1.75em.
However when putting them as inline buttons inside a .ui-field-contain, from a certain page width on they get a width:auto, making them use the available width on the page instead of staying at a fixed width.
This overrides the width:auto with the 1.75em again in that situation.
