### PR TITLE
Textinput: Do sync height update even in IE8

### DIFF
--- a/js/widgets/forms/autogrow.js
+++ b/js/widgets/forms/autogrow.js
@@ -68,7 +68,7 @@ define( [
 							}, this ),
 						"transition" );
 				}
-				this._timeout();
+				this._prepareHeightUpdate();
 			}
 		},
 


### PR DESCRIPTION
Fixes gh-7577

I've made sure #6998 is still fixed.

In a91747c0 I made two changes: I skipped setting height to 0 before calculating the desired height, because that was breaking IE8. However, I also changed the way in which autogrow reacts to show events such pageshow or popupbeforeposition: I made it call _updateHeight() asynchronously, rather than synchronously. This is not a problem on a page, but in a popup, if you call _updateHeight() asynchronously from popupbeforeshow, then the popup coordinate calculation proceeds with the old popup height, because the textarea height is set to the correct value only asynchronously.

I've re-examined #6998 and I've found that setting the height asynchronously is not required, after all.

http://jsbin.com/vecawu/1 tests #7577
http://jsbin.com/kobubi/2/ tests #6998

I've also tested with http://jsbin.com/ludikabi/1/
