### PR TITLE
Navigation: Remove initialDst and correctly handle location update for a sequence

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -108,11 +108,6 @@ define([
 					$.mobile.path.isPath( hash ) ||
 					hash === $.mobile.dialogHashKey ) ) ) {
 
-				// Store the initial destination
-				if ( $.mobile.path.isHashValid( location.hash ) ) {
-					$.mobile.navigate.history.initialDst = hash.replace( "#", "" );
-				}
-
 				// make sure to set initial popstate state if it exists
 				// so that navigation back to the initial page works properly
 				if ( $.event.special.navigate.isPushStateEnabled() ) {

--- a/js/navigation/path.js
+++ b/js/navigation/path.js
@@ -287,14 +287,25 @@ define([
 			},
 
 			squash: function( url, resolutionUrl ) {
-				var href, cleanedUrl, search, stateIndex,
+				var href, cleanedUrl, search, stateIndex, docUrl,
 					isPath = this.isPath( url ),
 					uri = this.parseUrl( url ),
 					preservedHash = uri.hash,
 					uiState = "";
 
-				// produce a url against which we can resole the provided path
-				resolutionUrl = resolutionUrl || (path.isPath(url) ? path.getLocation() : path.getDocumentUrl());
+				// produce a url against which we can resolve the provided path
+				if ( !resolutionUrl ) {
+					if ( isPath ) {
+						resolutionUrl = path.getLocation();
+					} else {
+						docUrl = path.getDocumentUrl( true );
+						if ( path.isPath( docUrl.hash ) ) {
+							resolutionUrl = path.squash( docUrl.href );
+						} else {
+							resolutionUrl = docUrl.href;
+						}
+					}
+				}
 
 				// If the url is anything but a simple string, remove any preceding hash
 				// eg #foo/bar -> foo/bar

--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -227,18 +227,6 @@ define( [
 				//
 				// TODO move check to history object or path object?
 				to = !$.mobile.path.isPath( to ) ? ( $.mobile.path.makeUrlAbsolute( "#" + to, this._getDocumentBase() ) ) : to;
-
-				// If we're about to go to an initial URL that contains a
-				// reference to a non-existent internal page, go to the first
-				// page instead. We know that the initial hash refers to a
-				// non-existent page, because the initial hash did not end
-				// up in the initial history entry
-				// TODO move check to history object?
-				if ( to === $.mobile.path.makeUrlAbsolute( "#" + history.initialDst, this._getDocumentBase() ) &&
-					history.stack.length &&
-					history.stack[0].url !== history.initialDst.replace( $.mobile.dialogHashKey, "" ) ) {
-					to = this._getInitialContent();
-				}
 			}
 			return to || this._getInitialContent();
 		},
@@ -317,8 +305,7 @@ define( [
 			// key, and the initial destination isn't equal to the current target
 			// page, use the special dialog handling
 			if ( history.activeIndex > 0 &&
-				to.indexOf( $.mobile.dialogHashKey ) > -1 &&
-				history.initialDst !== to ) {
+				to.indexOf( $.mobile.dialogHashKey ) > -1 ) {
 
 				to = this._handleDialog( changePageOptions, data );
 
@@ -1094,12 +1081,6 @@ define( [
 					url += $.mobile.dialogHashKey;
 				} else {
 					url += "#" + $.mobile.dialogHashKey;
-				}
-
-				// tack on another dialogHashKey if this is the same as the initial hash
-				// this makes sure that a history entry is created for this dialog
-				if ( $.mobile.navigate.history.activeIndex === 0 && url === $.mobile.navigate.history.initialDst ) {
-					url += $.mobile.dialogHashKey;
 				}
 			}
 

--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -903,11 +903,6 @@ $.widget( "mobile.popup", {
 			url = $.mobile.path.parseLocation().hash + hashkey;
 		}
 
-		// Tack on an extra hashkey if this is the first page and we've just reconstructed the initial hash
-		if ( urlHistory.activeIndex === 0 && url === urlHistory.initialDst ) {
-			url += hashkey;
-		}
-
 		// swallow the the initial navigation event, and bind for the next
 		this.window.one( "beforenavigate", function( theEvent ) {
 			theEvent.preventDefault();

--- a/tests/functional/hashchange/hashchange1.html
+++ b/tests/functional/hashchange/hashchange1.html
@@ -41,5 +41,12 @@
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 	</div>
 </div>
+
+<div data-role="page" id="page2">
+	<div data-role="header">
+		<h2>Internal page on another page</h2>
+	</div>
+</div>
+
 </body>
 </html>

--- a/tests/integration/navigation/sequence/index.html
+++ b/tests/integration/navigation/sequence/index.html
@@ -53,8 +53,10 @@
 			<a id="openBasicDialog" href="basic-dialog.html" data-nstest-rel="dialog">Dialog</a>
 			<a id="openAnotherDialog" href="basic-dialog1.html" data-nstest-rel="dialog">Dialog 1</a>
 			<a id="openAnotherPage" href="another-page.html">Another page</a>
+			<a id="openInternalPage" href="#internal-page">Internal page</a>
 		</div>
 	</div>
 
+	<div id="internal-page" data-nstest-role="page"></div>
 </body>
 </html>

--- a/tests/integration/navigation/sequence/sequence-redirect.html
+++ b/tests/integration/navigation/sequence/sequence-redirect.html
@@ -39,13 +39,10 @@
 </head>
 <body>
 
-<h1 id="qunit-header">jQuery Mobile Sequence Test Suite</h1>
-<h2 id="qunit-banner"></h2>
-<h2 id="qunit-userAgent"></h2>
-<ol id="qunit-tests">
-</ol>
+<div id="qunit"></div>
 
 <div data-nstest-role="page" id="sequenceRedirect"></div>
+<div id="internal-page" data-nstest-role="page"></div>
 
 <!--
 This test page is used when testing initial URLs of the form

--- a/tests/integration/navigation/sequence/sequence_core.js
+++ b/tests/integration/navigation/sequence/sequence_core.js
@@ -38,6 +38,34 @@
 		}
 	}
 
+	asyncTest( "Navigating to an internal page", function() {
+		var origUrl,
+			eventNs = ".navigatingToAnInternalPage";
+
+		expect( 1 );
+
+		maybeWaitForStartPage([
+			function() {
+				origUrl = location.href.replace( "&ui-state=dialog", "" );
+				$( "#openInternalPage" ).click();
+			},
+			{
+				pagecontainerchange: { src: $.mobile.pageContainer, event: "pagecontainerchange" + eventNs + "1" }
+			},
+			function() {
+				deepEqual( location.href, origUrl.indexOf( "#" ) >= 0 ?
+					origUrl + "internal-page" :
+					origUrl + "#internal-page",
+					"URL after popup opens differs only by an appended dialog hash key" );
+				$.mobile.back();
+			},
+			{
+				pagecontainerchange: { src: $.mobile.pageContainer, event: "pagecontainerchange" + eventNs + "2" }
+			},
+			start
+		]);
+	});
+
 	asyncTest( "Returning from a dialog results in the page from which it opened", function() {
 		var eventNs = ".returningFromADialog";
 		expect( 2 );

--- a/tests/integration/navigation/sequence/sequence_core.js
+++ b/tests/integration/navigation/sequence/sequence_core.js
@@ -64,19 +64,25 @@
 	});
 
 	asyncTest( "Returning from a popup results in the page from which it opened", function() {
-		var origActive, eventNs = ".returningFromAPopup";
+		var origActive, origUrl,
+			eventNs = ".returningFromAPopup";
 
-		expect( 3 );
+		expect( 4 );
 
 		maybeWaitForStartPage([
 			function() {
 				origActive = $.mobile.activePage;
+				origUrl = location.href;
 				$( "#openPopup" ).click();
 			},
 			{
 				popupafteropen: { src: function() { return $( "#thePopup" ); }, event: "popupafteropen" + eventNs + "1" }
 			},
 			function( result ) {
+				deepEqual( location.href, origUrl.indexOf( "#" ) >= 0 ?
+					origUrl + $.mobile.dialogHashKey :
+					origUrl + "#" + $.mobile.dialogHashKey,
+					"URL after popup opens differs only by an appended dialog hash key" );
 				ok( !result.popupafteropen.timedOut, "Popup emitted 'popupafteropen'" );
 				$( "#thePopup" ).parent().prev().click();
 			},

--- a/tests/unit/content/content_core.js
+++ b/tests/unit/content/content_core.js
@@ -198,23 +198,6 @@
 		equal( "foo/bar", proto._handleDestination( "#foo/bar" ) );
 	});
 
-	test( "returns initial content when the url is base plus initial destination", function() {
-		var initialContent = $( "<div>" );
-
-		proto._getHistory = function() {
-			return {
-				initialDst: "foo",
-				stack: [ {url: "will not be equal to initial destination"} ]
-			};
-		};
-
-		proto._getInitialContent = function() {
-			return initialContent;
-		};
-
-		equal( initialContent, proto._handleDestination(base + "#" + proto._getHistory().initialDst) );
-	});
-
 	module( "Content Widget _recordScroll" );
 
 	test( "does not record scroll position when disabled", function() {


### PR DESCRIPTION
Remove references to `initialDst` from the code. Make sure the URL is correct for the sequence start -> internal page when the initial URL is of the form protocol://path/to/page.html#/path/to/other-page.html (i.e., the resulting URL must be protocol://path/to/other-page.html#internal-page-id, not protocol://path/to/page.html#internal-page-id).

Fixes gh-7177
