### PR TITLE
Panel: Android 2.3.7 not scrolling to top when panel closes

### DIFF
--- a/js/widgets/panel.js
+++ b/js/widgets/panel.js
@@ -410,6 +410,9 @@ $.widget( "mobile.panel", {
 
 					self.element.addClass( o.classes.panelClosed );
 
+					//scroll to the top
+					self._positionPanel( true );
+
 					if ( o.display !== "overlay" ) {
 						self._page().parent().removeClass( o.classes.pageContainer );
 						self._wrapper.removeClass( o.classes.pageContentPrefix + "-open" );


### PR DESCRIPTION
I tested this on an android 2.3.7 emulator and it fixed the problem.  I ran the grunt test for the panel tests and they passed.  Would like a second pair of eyes.

Fixes #6767
