### PR TITLE
Pagecontainer: Viewport's height 

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -1,6 +1,6 @@
 /* Some unsets */
 .ui-mobile,
-.ui-mobile body {
+.ui-mobile .ui-mobile-viewport {
 	height: 99.9%;
 }
 .ui-mobile fieldset,


### PR DESCRIPTION
If `pagecontainer` is set to a different _wrapper_, page scrolls. `height: 99.9%` should be assigned to `ui-mobile-viewport` to avoid this issue. http://plnkr.co/edit/qMHTRFIBTSQkMX3Qbog8?p=preview
