### PR TITLE
Build: Include events.js from jquery.mobile.js

### DIFF
--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -4,6 +4,7 @@
 define([
 	"require",
 	"./widgets/loader",
+	"./events",
 	"./events/navigate",
 	"./navigation/path",
 	"./navigation/history",


### PR DESCRIPTION
events.js was making it into the build only by virtue of the fact that it was
being pulled by navigation.js. In the process of fixing gh-7805 it became clear
that navigation.js doesn't really need events.js. Thus, the reference to
events.js was removed from navigation.js, thereby orphaning events.js from the
build. This rectifies the problem by explicitly adding events.js to the build.

Fixes gh-7925
