### PR TITLE
Popup: pagecontainerbeforechange with reloadPage requires immediate flag

### DIFF
--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -835,7 +835,9 @@ $.widget( "mobile.popup", {
 			parsedDst = $.mobile.path.parseUrl( parsedDst );
 			toUrl = parsedDst.pathname + parsedDst.search + parsedDst.hash;
 
-			if ( this._myUrl !== $.mobile.path.makeUrlAbsolute( toUrl ) ) {
+			if ( this._myUrl !== $.mobile.path.makeUrlAbsolute( toUrl ) ||
+					data.options.reloadPage ) {
+
 				// Going to a different page - close immediately
 				immediate = true;
 			} else {

--- a/tests/integration/popup/form-submission-tests.html
+++ b/tests/integration/popup/form-submission-tests.html
@@ -17,13 +17,9 @@
 	<script src="../../../external/qunit/qunit.js"></script>
 	<script>
 		$.testHelper.asyncLoad([
-			[
-				"widgets/popup"
-			],
+			[ "widgets/popup" ],
 			[ "init" ],
-			[
-				"form_submission_core.js"
-			]
+			[ "form_submission_core.js" ]
 		]);
 	</script>
 

--- a/tests/integration/popup/form-submission-tests.html
+++ b/tests/integration/popup/form-submission-tests.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Popup Form Submission Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+
+	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css"/>
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script>
+		$.testHelper.asyncLoad([
+			[
+				"widgets/popup"
+			],
+			[ "init" ],
+			[
+				"form_submission_core.js"
+			]
+		]);
+	</script>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+
+	<form data-nstest-role="page">
+		<input type="hidden" name="abc" value="def">
+		<div data-nstest-role="popup" id="popup">
+			<button type="submit">Submit from popup</button>
+		</div>
+		<a href="#popup" data-nstest-rel="popup" id="open-popup-link">Open Popup</a>
+	</form>
+</body>
+</html>

--- a/tests/integration/popup/form_submission_core.js
+++ b/tests/integration/popup/form_submission_core.js
@@ -1,0 +1,30 @@
+asyncTest( "Form submission from popup works", function() {
+	var eventNs = ".formSubmissionFromPopupWorks";
+
+	$.testHelper.detailedEventCascade([
+		function() {
+			$( "#open-popup-link" ).click();
+		},
+		{
+			popupafteropen: { src: $( "#popup" ), event: "popupafteropen" + eventNs + "1" }
+		},
+		function( result ) {
+			deepEqual( result.popupafteropen.timedOut, false, "Popup did open" );
+			$( "#popup button" ).click();
+		},
+		{
+			submit: { src: $( document ), event: "submit" + eventNs + "2" },
+			popupafterclose: { src: $( "#popup" ), event: "popupafterclose" + eventNs + "2" },
+			pagecontainerchange: {
+				src: $( ":mobile-pagecontainer" ),
+				event: "pagecontainerchange" + eventNs + "3"
+			}
+		},
+		function( result ) {
+			deepEqual( result.submit.timedOut, false, "Submit event was triggered" );
+			deepEqual( result.popupafterclose.timedOut, false, "Popup did close" );
+			deepEqual( result.pagecontainerchange.timedOut, false, "Page did change" );
+			start();
+		}
+	]);
+});

--- a/tests/integration/popup/form_submission_core.js
+++ b/tests/integration/popup/form_submission_core.js
@@ -1,6 +1,8 @@
 asyncTest( "Form submission from popup works", function() {
 	var eventNs = ".formSubmissionFromPopupWorks";
 
+	expect( 4 );
+
 	$.testHelper.detailedEventCascade([
 		function() {
 			$( "#open-popup-link" ).click();

--- a/tests/integration/popup/form_submission_core.js
+++ b/tests/integration/popup/form_submission_core.js
@@ -1,7 +1,7 @@
 asyncTest( "Form submission from popup works", function() {
-	var eventNs = ".formSubmissionFromPopupWorks";
-
 	expect( 4 );
+
+	var eventNs = ".formSubmissionFromPopupWorks";
 
 	$.testHelper.detailedEventCascade([
 		function() {


### PR DESCRIPTION
The popup must not prevent default when going back to a page with the same URL
from which it was opened if the reloadPage flag is set. Rather, it must close
immediately, handling the page change event as if the user were navigating to a
different page.

Fixes gh-6119
