### PR TITLE
Navigation: Separate pagecontainer and transitions

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -69,6 +69,23 @@ define( [ "jquery", "./ns", "jquery-ui/jquery.ui.core" ], function( jQuery ) {
 		// Place to store various widget extensions
 		behaviors: {},
 
+		// Direct focus to the page title, or otherwise first focusable element
+		focusPage: function( page ) {
+			var autofocus = page.find( "[autofocus]" ),
+				pageTitle = page.find( ".ui-title:eq(0)" );
+
+			if ( autofocus.length ) {
+				autofocus.focus();
+				return;
+			}
+
+			if ( pageTitle.length ) {
+				pageTitle.focus();
+			} else{
+				page.focus();
+			}
+		},
+
 		// Scroll page vertically: scroll to 0 to hide iOS address bar, or pass a Y value
 		silentScroll: function( ypos ) {
 			if ( $.type( ypos ) !== "number" ) {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -69,21 +69,23 @@ define( [ "jquery", "./ns", "jquery-ui/jquery.ui.core" ], function( jQuery ) {
 		// Place to store various widget extensions
 		behaviors: {},
 
-		// Direct focus to the page title, or otherwise first focusable element
+		// Custom logic for giving focus to a page
 		focusPage: function( page ) {
-			var autofocus = page.find( "[autofocus]" ),
-				pageTitle = page.find( ".ui-title:eq(0)" );
 
-			if ( autofocus.length ) {
-				autofocus.focus();
-				return;
+			// First, look for an element explicitly marked for page focus
+			var focusElement = page.find( "[autofocus]" );
+
+			// If we do not find an element with the "autofocus" attribute, look for the page title
+			if ( !focusElement.length ) {
+				focusElement = page.find( ".ui-title:eq(0)" );
 			}
 
-			if ( pageTitle.length ) {
-				pageTitle.focus();
-			} else{
-				page.focus();
+			// Finally, fall back to focusing the page itself
+			if ( !focusElement.length ) {
+				focusElement = page;
 			}
+
+			focusElement.focus();
 		},
 
 		// Scroll page vertically: scroll to 0 to hide iOS address bar, or pass a Y value

--- a/js/index.php
+++ b/js/index.php
@@ -33,6 +33,7 @@ $files = array(
 	'navigation/navigator.js',
 	'navigation/method.js',
 	'widgets/pagecontainer.js',
+	'widgets/pagecontainer.transitions.js',
 	'navigation.js',
 	'transitions/transition.js',
 	'transitions/serial.js',

--- a/js/jquery.mobile.js
+++ b/js/jquery.mobile.js
@@ -52,7 +52,8 @@ define([
 	"./widgets/filterable.backcompat",
 	"./widgets/tabs",
 	"./zoom",
-	"./zoom/iosorientationfix"
+	"./zoom/iosorientationfix",
+	"./widgets/pagecontainer.transitions"
 ], function( require ) {
 	require( [ "./init" ], function() {} );
 });

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -97,23 +97,6 @@ define( [
 		}
 	};
 
-	// Direct focus to the page title, or otherwise first focusable element
-	$.mobile.focusPage = function ( page ) {
-		var autofocus = page.find( "[autofocus]" ),
-			pageTitle = page.find( ".ui-title:eq(0)" );
-
-		if ( autofocus.length ) {
-			autofocus.focus();
-			return;
-		}
-
-		if ( pageTitle.length ) {
-			pageTitle.focus();
-		} else{
-			page.focus();
-		}
-	};
-
 	// No-op implementation of transition degradation
 	$.mobile._maybeDegradeTransition = $.mobile._maybeDegradeTransition || function( transition ) {
 		return transition;

--- a/js/transitions/transition.js
+++ b/js/transitions/transition.js
@@ -136,7 +136,7 @@ define( [
 			$.mobile.pageContainer.toggleClass( "ui-mobile-viewport-transitioning viewport-" + this.name );
 		},
 
-		transition: function() {
+		transition: function( toScroll ) {
 			// NOTE many of these could be calculated/recorded in the constructor, it's my
 			//      opinion that binding them as late as possible has value with regards to
 			//      better transitions with fewer bugs. Ie, it's not guaranteed that the
@@ -148,7 +148,7 @@ define( [
 				maxTransitionOverride = $.mobile.maxTransitionWidth !== false &&
 					$.mobile.window.width() > $.mobile.maxTransitionWidth;
 
-			this.toScroll = $.mobile.navigate.history.getActive().lastScroll || $.mobile.defaultHomeScroll;
+			this.toScroll = ( toScroll ? toScroll : 0 );
 
 			none = !$.support.cssTransitions || !$.support.cssAnimations ||
 				maxTransitionOverride || !this.name || this.name === "none" ||

--- a/js/transitions/transition.js
+++ b/js/transitions/transition.js
@@ -11,10 +11,7 @@ define( [
 
 	// TODO event.special.scrollstart
 	"../events/scroll",
-	"../animationComplete",
-
-	// TODO $.mobile.focusPage reference
-	"../navigation" ], function( jQuery ) {
+	"../animationComplete" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 
 (function( $, window, undefined ) {

--- a/js/widgets/pagecontainer.transitions.js
+++ b/js/widgets/pagecontainer.transitions.js
@@ -1,0 +1,32 @@
+//>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
+//>>description: Extension that adds transition management support to pagecontainer widget
+//>>label: Transitions Support for Pagecontainer
+//>>group: Navigation
+define( [
+	"jquery",
+	"./pagecontainer",
+	"../transitions/handlers" ], function( jQuery ) {
+//>>excludeEnd("jqmBuildExclude");
+(function( $, undefined ) {
+
+$.widget( "mobile.pagecontainer", $.mobile.pagecontainer, {
+	_getTransitionHandler: function( transition ) {
+		transition = $.mobile._maybeDegradeTransition( transition );
+
+		//find the transition handler for the specified transition. If there
+		//isn't one in our transitionHandlers dictionary, use the default one.
+		//call the handler immediately to kick off the transition.
+		return $.mobile.transitionHandlers[ transition ] || $.mobile.defaultTransitionHandler;
+	},
+
+	_performTransition: function( transition, reverse, to, from ) {
+		var TransitionHandler = this._getTransitionHandler( transition );
+
+		return ( new TransitionHandler( transition, reverse, to, from ) ).transition();
+	}
+});
+
+})( jQuery );
+//>>excludeStart("jqmBuildExclude", pragmas.jqmBuildExclude);
+});
+//>>excludeEnd("jqmBuildExclude");

--- a/js/widgets/pagecontainer.transitions.js
+++ b/js/widgets/pagecontainer.transitions.js
@@ -5,6 +5,9 @@
 define( [
 	"jquery",
 	"./pagecontainer",
+
+	// For $.mobile.navigate.history
+	"../navigation/method",
 	"../transitions/handlers" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
 (function( $, undefined ) {
@@ -22,7 +25,8 @@ $.widget( "mobile.pagecontainer", $.mobile.pagecontainer, {
 	_performTransition: function( transition, reverse, to, from ) {
 		var TransitionHandler = this._getTransitionHandler( transition );
 
-		return ( new TransitionHandler( transition, reverse, to, from ) ).transition();
+		return ( new TransitionHandler( transition, reverse, to, from ) ).transition(
+			$.mobile.navigate.history.getActive().lastScroll || $.mobile.defaultHomeScroll );
 	}
 });
 

--- a/tests/integration/select/index.html
+++ b/tests/integration/select/index.html
@@ -16,7 +16,8 @@
 			[
 				"widgets/forms/select",
 				"widgets/forms/select.custom",
-				"../../integration/select/defineKeepNative.js"
+				"../../integration/select/defineKeepNative.js",
+				"widgets/pagecontainer.transitions",
 			],
 			[ "init" ],
 			[

--- a/tests/unit/init/no-autoinit-page-transitions-tests.html
+++ b/tests/unit/init/no-autoinit-page-transitions-tests.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<script src="../../../external/jquery/jquery.js"></script>
+	<script src="../../jquery.testHelper.js"></script>
+	<script>
+		$.testHelper.redirect( "./no-autoinit-page-tests.html", [ "transitions=true" ] );
+	</script>
+</head>
+<body>
+</body>
+</html>

--- a/tests/unit/init/no_autoinit_page_core.js
+++ b/tests/unit/init/no_autoinit_page_core.js
@@ -1,6 +1,8 @@
 asyncTest( "resetActivePageHeight() will be called when page is initialized late", function() {
 	var resetActivePageHeightCallCount = 0;
 
+	expect( 1 );
+
 	$( document ).on( "mobileinit", function() {
 		$.mobile.autoInitializePage = false;
 
@@ -13,13 +15,19 @@ asyncTest( "resetActivePageHeight() will be called when page is initialized late
 	});
 
 	require([ "jquery", "./init" ], function() {
-		setTimeout( function() {
-			$.mobile.initializePage();
-
-			deepEqual( resetActivePageHeightCallCount, 1,
-				"$.mobile.resetActivePageHeight() was called from delayed initializePage()" );
-			start();
-		}, 5000 );
+		$.testHelper.detailedEventCascade([
+			function() {
+				$.mobile.initializePage();
+			},
+			{
+				pagecontainershow: { src: $( "body" ), event: "pagecontainershow.noAutoinit1" }
+			},
+			function() {
+				deepEqual( resetActivePageHeightCallCount, 1,
+					"$.mobile.resetActivePageHeight() was called from delayed initializePage()" );
+				start();
+			}
+		]);
 	});
 
 });

--- a/tests/unit/init/no_autoinit_page_core.js
+++ b/tests/unit/init/no_autoinit_page_core.js
@@ -14,7 +14,9 @@ asyncTest( "resetActivePageHeight() will be called when page is initialized late
 		})( $.mobile.resetActivePageHeight );
 	});
 
-	require([ "jquery", "./init" ], function() {
+	require([ "jquery", "./init" ]
+		.concat( ( window.location.search.indexOf( "transitions" ) > -1 ) ?
+			[ "./widgets/pagecontainer.transitions" ] : [] ), function() {
 		$.testHelper.detailedEventCascade([
 			function() {
 				$.mobile.initializePage();


### PR DESCRIPTION
`pagecontainer` no longer depends on transitions, providing instant page changes only. Nevertheless, a new extension, `pagecontainer.transitions` implements page change via transition. Transitions no longer need navigation, because `$.mobile.focusPage()` is moved to `helpers` and because they now receive the `scrollTo` position from whoever initiates the transition, rather than retrieving it themeselves from `$.mobile.navigate.history`

Fixes gh-6929
Fixes gh-4022
Fixes gh-7158
