### PR TITLE
Popup: Add tabindex after open, and remove it after close

### DIFF
--- a/demos/_assets/js/view-source.js
+++ b/demos/_assets/js/view-source.js
@@ -32,10 +32,6 @@ function attachPopupHandler( popup, sources ) {
 					}
 				});
 			SyntaxHighlighter.highlight( {}, pre[ 0 ] );
-
-			// Give the syntax highlighter top-level div a tabindex so one can select and copy the
-			// code snippet
-			collapsible.children().last().attr( "tabindex", 0 );
 		});
 
 		collapsibleSet.find( "[data-role='collapsible']" ).first().attr( "data-collapsed", "false" );

--- a/js/widgets/popup.js
+++ b/js/widgets/popup.js
@@ -658,6 +658,7 @@ $.widget( "mobile.popup", {
 			this.document.find( "[aria-haspopup='true'][aria-owns='" +
 				$.mobile.path.hashToSelector( id ) + "']" ).attr( "aria-expanded", true );
 		}
+		this._ui.container.attr( "tabindex", 0 );
 		this._trigger( "afteropen" );
 	},
 
@@ -748,6 +749,8 @@ $.widget( "mobile.popup", {
 			this.document.find( "[aria-haspopup='true'][aria-owns='" +
 				$.mobile.path.hashToSelector( id ) + "']" ).attr( "aria-expanded", false );
 		}
+
+		this._ui.container.removeAttr( "tabindex" );
 
 		// alert users that the popup is closed
 		this._trigger( "afterclose" );

--- a/tests/integration/popup/popup_core.js
+++ b/tests/integration/popup/popup_core.js
@@ -30,13 +30,20 @@
 
 				function( result ) {
 					deepEqual( link.getAttribute( "aria-expanded" ), "true", popupId + ": 'aria-expanded' attribute is set to true when the popup is open" );
-					ok( !popup.parent().prev().hasClass( "ui-screen-hidden" ), popupId + ": Open popup screen is not hidden" );
-					ok( popup.attr( "class" ).match( /( |^)ui-body-([a-z]|inherit)( |$)/ ), popupId + ": Open popup has a valid theme" );
+					ok( !popup.parent().prev().hasClass( "ui-screen-hidden" ),
+						popupId + ": Open popup screen is not hidden" );
+					ok( popup.attr( "class" ).match( /( |^)ui-body-([a-z]|inherit)( |$)/ ),
+						popupId + ": Open popup has a valid theme" );
 
 					popup.popup( "option", "overlayTheme", "a" );
-					ok( popup.parent().prev().hasClass( "ui-overlay-a" ), popupId + ": Setting an overlay theme while the popup is open causes the theme to be applied and the screen to be faded in" );
-					ok( popup.parent().prev().hasClass( "in" ), popupId + ": Setting an overlay theme while the popup is open causes the theme to be applied and the screen to be faded in" );
-					ok( popup.parent().hasClass( "ui-popup-active" ), popupId + ": Open popup has the 'ui-popup-active' class" );
+					ok( popup.parent().prev().hasClass( "ui-overlay-a" ),
+						popupId + ": Setting an overlay theme while the popup is open causes " +
+							"the theme to be applied and the screen to be faded in" );
+					ok( popup.parent().prev().hasClass( "in" ),
+						popupId + ": Setting an overlay theme while the popup is open causes " +
+							"the theme to be applied and the screen to be faded in" );
+					ok( popup.parent().hasClass( "ui-popup-active" ),
+						popupId + ": Open popup has the 'ui-popup-active' class" );
 
 					deepEqual( popup.parent().attr( "tabindex" ), "0",
 						"Popup container has attribute tabindex" );
@@ -53,9 +60,12 @@
 				function( result) {
 					deepEqual( animationCompleteCallCount, 1, "animationComplete called only once" );
 					deepEqual( link.getAttribute( "aria-expanded" ), "false", "'aria-expanded' attribute is set to false when the popup is not open" );
-					ok( !popup.parent().hasClass( "in" ), "Closed popup container does not have class 'in'" );
-					ok( popup.parent().prev().hasClass( "ui-screen-hidden" ), "Closed popup screen is hidden" );
-					ok( !popup.parent().hasClass( "ui-popup-active" ), "Open popup dos not have the 'ui-popup-active' class" );
+					ok( !popup.parent().hasClass( "in" ),
+						"Closed popup container does not have class 'in'" );
+					ok( popup.parent().prev().hasClass( "ui-screen-hidden" ),
+						"Closed popup screen is hidden" );
+					ok( !popup.parent().hasClass( "ui-popup-active" ),
+						"Open popup dos not have the 'ui-popup-active' class" );
 					deepEqual( popup.parent()[ 0 ].hasAttribute( "tabindex" ), false,
 						"Popup container does not have attribute tabindex" );
 				},

--- a/tests/integration/popup/popup_core.js
+++ b/tests/integration/popup/popup_core.js
@@ -11,10 +11,12 @@
 			var $popup = $( document.getElementById( popupId ) ),
 				link = $( linkSelector )[ 0 ];
 
-			expect( 14 );
+			expect( 17 );
 
 			$.testHelper.detailedEventCascade([
 				function() {
+					deepEqual( $popup.parent()[ 0 ].hasAttribute( "tabindex" ), false,
+						"Popup container does not have attribute tabindex" );
 					deepEqual( link.getAttribute( "aria-haspopup" ), "true", popupId + ": 'aria-haspopup' attribute is set to true on link that opens the popup" );
 					deepEqual( link.getAttribute( "aria-owns" ), popupId, popupId + ": 'aria-owns' attribute is set to the ID of the owned popup ('test-popup')" );
 					deepEqual( link.getAttribute( "aria-expanded" ), "false", popupId + ": 'aria-expanded' attribute is set to false when the popup is not open" );
@@ -36,6 +38,9 @@
 					ok( $popup.parent().prev().hasClass( "in" ), popupId + ": Setting an overlay theme while the popup is open causes the theme to be applied and the screen to be faded in" );
 					ok( $popup.parent().hasClass( "ui-popup-active" ), popupId + ": Open popup has the 'ui-popup-active' class" );
 
+					deepEqual( $popup.parent().attr( "tabindex" ), "0",
+						"Popup container has attribute tabindex" );
+
 					animationCompleteCallCount = 0;
 					$.mobile.back();
 				},
@@ -51,6 +56,8 @@
 					ok( !$popup.parent().hasClass( "in" ), "Closed popup container does not have class 'in'" );
 					ok( $popup.parent().prev().hasClass( "ui-screen-hidden" ), "Closed popup screen is hidden" );
 					ok( !$popup.parent().hasClass( "ui-popup-active" ), "Open popup dos not have the 'ui-popup-active' class" );
+					deepEqual( $popup.parent()[ 0 ].hasAttribute( "tabindex" ), false,
+						"Popup container does not have attribute tabindex" );
 				},
 
 				{ timeout: { length: 500 } },

--- a/tests/integration/popup/popup_core.js
+++ b/tests/integration/popup/popup_core.js
@@ -8,7 +8,7 @@
 		originalAnimationComplete = $.fn.animationComplete,
 		animationCompleteCallCount = 0,
 		opensAndCloses = function( eventNs, popupId, linkSelector, contentSelector ) {
-			var popup = $( document.getElementById( popupId ) ),
+			var popup = $( "#" + popupId ),
 				link = $( linkSelector )[ 0 ];
 
 			expect( 17 );

--- a/tests/integration/popup/popup_core.js
+++ b/tests/integration/popup/popup_core.js
@@ -8,37 +8,37 @@
 		originalAnimationComplete = $.fn.animationComplete,
 		animationCompleteCallCount = 0,
 		opensAndCloses = function( eventNs, popupId, linkSelector, contentSelector ) {
-			var $popup = $( document.getElementById( popupId ) ),
+			var popup = $( document.getElementById( popupId ) ),
 				link = $( linkSelector )[ 0 ];
 
 			expect( 17 );
 
 			$.testHelper.detailedEventCascade([
 				function() {
-					deepEqual( $popup.parent()[ 0 ].hasAttribute( "tabindex" ), false,
+					deepEqual( popup.parent()[ 0 ].hasAttribute( "tabindex" ), false,
 						"Popup container does not have attribute tabindex" );
 					deepEqual( link.getAttribute( "aria-haspopup" ), "true", popupId + ": 'aria-haspopup' attribute is set to true on link that opens the popup" );
 					deepEqual( link.getAttribute( "aria-owns" ), popupId, popupId + ": 'aria-owns' attribute is set to the ID of the owned popup ('test-popup')" );
 					deepEqual( link.getAttribute( "aria-expanded" ), "false", popupId + ": 'aria-expanded' attribute is set to false when the popup is not open" );
-					$popup.popup( "open" );
+					popup.popup( "open" );
 				},
 
 				{
-					opened: { src: $popup, event: "popupafteropen" + eventNs },
+					opened: { src: popup, event: "popupafteropen" + eventNs },
 					navigate: { src: $(window), event: $.event.special.navigate.originalEventName + eventNs }
 				},
 
 				function( result ) {
 					deepEqual( link.getAttribute( "aria-expanded" ), "true", popupId + ": 'aria-expanded' attribute is set to true when the popup is open" );
-					ok( !$popup.parent().prev().hasClass( "ui-screen-hidden" ), popupId + ": Open popup screen is not hidden" );
-					ok( $popup.attr( "class" ).match( /( |^)ui-body-([a-z]|inherit)( |$)/ ), popupId + ": Open popup has a valid theme" );
+					ok( !popup.parent().prev().hasClass( "ui-screen-hidden" ), popupId + ": Open popup screen is not hidden" );
+					ok( popup.attr( "class" ).match( /( |^)ui-body-([a-z]|inherit)( |$)/ ), popupId + ": Open popup has a valid theme" );
 
-					$popup.popup( "option", "overlayTheme", "a" );
-					ok( $popup.parent().prev().hasClass( "ui-overlay-a" ), popupId + ": Setting an overlay theme while the popup is open causes the theme to be applied and the screen to be faded in" );
-					ok( $popup.parent().prev().hasClass( "in" ), popupId + ": Setting an overlay theme while the popup is open causes the theme to be applied and the screen to be faded in" );
-					ok( $popup.parent().hasClass( "ui-popup-active" ), popupId + ": Open popup has the 'ui-popup-active' class" );
+					popup.popup( "option", "overlayTheme", "a" );
+					ok( popup.parent().prev().hasClass( "ui-overlay-a" ), popupId + ": Setting an overlay theme while the popup is open causes the theme to be applied and the screen to be faded in" );
+					ok( popup.parent().prev().hasClass( "in" ), popupId + ": Setting an overlay theme while the popup is open causes the theme to be applied and the screen to be faded in" );
+					ok( popup.parent().hasClass( "ui-popup-active" ), popupId + ": Open popup has the 'ui-popup-active' class" );
 
-					deepEqual( $popup.parent().attr( "tabindex" ), "0",
+					deepEqual( popup.parent().attr( "tabindex" ), "0",
 						"Popup container has attribute tabindex" );
 
 					animationCompleteCallCount = 0;
@@ -46,17 +46,17 @@
 				},
 
 				{
-					closed: { src: $popup, event: "popupafterclose" + eventNs + "2" },
+					closed: { src: popup, event: "popupafterclose" + eventNs + "2" },
 					navigate: { src: $(window), event: $.event.special.navigate.originalEventName + eventNs + "2" }
 				},
 
 				function( result) {
 					deepEqual( animationCompleteCallCount, 1, "animationComplete called only once" );
 					deepEqual( link.getAttribute( "aria-expanded" ), "false", "'aria-expanded' attribute is set to false when the popup is not open" );
-					ok( !$popup.parent().hasClass( "in" ), "Closed popup container does not have class 'in'" );
-					ok( $popup.parent().prev().hasClass( "ui-screen-hidden" ), "Closed popup screen is hidden" );
-					ok( !$popup.parent().hasClass( "ui-popup-active" ), "Open popup dos not have the 'ui-popup-active' class" );
-					deepEqual( $popup.parent()[ 0 ].hasAttribute( "tabindex" ), false,
+					ok( !popup.parent().hasClass( "in" ), "Closed popup container does not have class 'in'" );
+					ok( popup.parent().prev().hasClass( "ui-screen-hidden" ), "Closed popup screen is hidden" );
+					ok( !popup.parent().hasClass( "ui-popup-active" ), "Open popup dos not have the 'ui-popup-active' class" );
+					deepEqual( popup.parent()[ 0 ].hasAttribute( "tabindex" ), false,
 						"Popup container does not have attribute tabindex" );
 				},
 


### PR DESCRIPTION
Fixes gh-7856

This used to be #7912 but I had to move the branch from my repo to the main repo, because I needed the version built on view for #7955.

Here's the discussion from the previous PR:

> @arschmitz:
> @gabrielschulhof did you test for regressions on the "blue focus flash"? @lisadeluca want to take a look at this too since you worked on the other issue?
> 
> @gabrielschulhof:
> @arschmitz @ldeluca yes, I tested. I believe the blue focus flash has not returned. I think it was caused by the fact that we were `.attr( "tabindex", 0 ).focus()` before, whereas now we simply add the attribute, but we do not focus.
