### PR TITLE
Check the return value of matchMedia in $.mobile.match

### DIFF
--- a/js/media.js
+++ b/js/media.js
@@ -41,7 +41,9 @@ define( [ "jquery", "./core" ], function( jQuery ) {
 
 	// $.mobile.media uses matchMedia to return a boolean.
 	$.mobile.media = function( q ) {
-		return window.matchMedia( q ).matches;
+		var mediaQueryList = window.matchMedia( q );
+		// Firefox returns null in a hidden iframe
+		return mediaQueryList && mediaQueryList.matches;
 	};
 
 })(jQuery);


### PR DESCRIPTION
Firefox returns null instead of a MediaQueryList inside of a hidden
iframe, thus causing an exception to be thrown on startup when jQuery
mobile is loaded inside a hidden iframe.
