### PR TITLE
Widget: Add tests for backcompat

### DIFF
--- a/tests/unit/widget/backcompat-tests.html
+++ b/tests/unit/widget/backcompat-tests.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>jQuery Mobile Widget Test Suite</title>
+
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/requirejs.config.js"></script>
+	<script src="../../../js/jquery.tag.inserter.js"></script>
+	<script src="../../jquery.setNameSpace.js"></script>
+	<script src="../../../external/qunit/qunit.js"></script>
+	<script src="../../../external/qunit-assert-classes/qunit-assert-classes.js"></script>
+	<script src="../../../tests/jquery.testHelper.js"></script>
+	<script>
+		$.testHelper.asyncLoad( [
+			[ "widgets/widget.backcompat" ],
+			[ "./backcompat_core.js" ]
+		] );
+	</script>
+
+	<link rel="stylesheet"  href="../../../css/themes/default/jquery.mobile.css"/>
+	<link rel="stylesheet" href="../../../external/qunit/qunit.css"/>
+	<link rel="stylesheet" href="../../jqm-tests.css"/>
+
+	<script src="../../swarminject.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/tests/unit/widget/backcompat_core.js
+++ b/tests/unit/widget/backcompat_core.js
@@ -1,0 +1,255 @@
+( function( $ ) {
+
+// Convert the values of the keys under option classes to hashes so they may be compared via
+// deepEquals. We convert to hash because order does not matter in a hash, just as it does not
+// matter in a class string.
+function convertClassValuesToHashes( options ) {
+	var classKey, classArray, classIndex;
+
+	if ( options.classes ) {
+		for ( classKey in options.classes ) {
+			if ( typeof options.classes[ classKey ] === "string" ) {
+				classArray = options.classes[ classKey ] ?
+					options.classes[ classKey ].split( " " ) : [];
+
+				// Overwrite the string-typed class value with a hash
+				options.classes[ classKey ] = {};
+				for ( classIndex in classArray ) {
+					options.classes[ classKey ][ classArray[ classIndex ] ] = true;
+				}
+			}
+		}
+	}
+
+	return options;
+}
+
+module( "Synchronization of classes option and style options", {
+	setup: function() {
+		$.widget( "mobile.testwidget", {
+			options: {
+				classes: {
+					"test-testwidget": "ui-button-inline ui-shadow"
+				},
+				inline: true,
+				mini: false,
+				shadow: true,
+				corners: false
+			},
+			classProp: "test-testwidget",
+			_create: function() {
+				this._addClass( this.element, "test-testwidget" );
+				this._enhance();
+			},
+			_enhance: $.noop
+		} );
+		$.widget( "mobile.testwidget", $.mobile.testwidget, $.mobile.widget.backcompat );
+	},
+	teardown: function() {
+		delete $.mobile.testwidget;
+		delete $.fn.testwidget;
+	}
+} );
+
+test( "Style options are updated when the classes option changes", function( assert ) {
+	var testWidget = $.mobile.testwidget( {
+		classes: {
+			"test-testwidget": "ui-corner-all"
+		}
+	} );
+
+	assert.deepEqual( testWidget.option(), {
+			create: null,
+			disabled: false,
+			classes: {
+				"test-testwidget": "ui-corner-all"
+			},
+			inline: false,
+			mini: false,
+			shadow: false,
+			corners: true
+		},
+		"Widget options reflect classes option values" );
+	assert.hasClasses( testWidget.element[ 0 ], "ui-corner-all", "Element has corner class" );
+	assert.lacksClasses( testWidget.element[ 0 ], "ui-button-inline ui-mini ui-shadow",
+		"Element does not have inline, mini, and shadow classes" );
+
+	testWidget.option( "classes.test-testwidget", "ui-button-inline ui-mini" );
+	assert.deepEqual( convertClassValuesToHashes( testWidget.option() ), {
+			create: null,
+			disabled: false,
+			classes: {
+				"test-testwidget": {
+					"ui-button-inline": true,
+					"ui-mini": true
+				}
+			},
+			inline: true,
+			mini: true,
+			shadow: false,
+			corners: false
+		},
+		"Widget options reflect classes option values" );
+	assert.hasClasses( testWidget.element[ 0 ], "ui-button-inline ui-mini" );
+	assert.lacksClasses( testWidget.element[ 0 ], "ui-shadow ui-corner-all" );
+} );
+
+test( "The classes option is updated when style options change", function( assert ) {
+	var testWidget = $.mobile.testwidget( {
+		inline: false,
+		shadow: false
+	} );
+
+	assert.deepEqual( testWidget.option(),
+		{
+			create: null,
+			disabled: false,
+			classes: {
+				"test-testwidget": ""
+			},
+			inline: false,
+			mini: false,
+			shadow: false,
+			corners: false
+		},
+		"After initial creation classes option value is empty" );
+	assert.lacksClasses( testWidget.element[ 0 ],
+		"ui-button-inline ui-mini ui-shadow ui-corner-all",
+		"Element lacks all classes" );
+
+	testWidget.option( "shadow", true );
+	assert.deepEqual( testWidget.option(),
+		{
+			create: null,
+			disabled: false,
+			classes: {
+				"test-testwidget": "ui-shadow"
+			},
+			inline: false,
+			mini: false,
+			shadow: true,
+			corners: false
+		},
+		"After turning on shadow classes option value contains 'ui-shadow'" );
+	assert.hasClasses( testWidget.element[ 0 ], "ui-shadow", "Element has shadow class" );
+	assert.lacksClasses( testWidget.element[ 0 ], "ui-button-inline ui-mini ui-corner-all",
+		"Element lacks all other classes" );
+
+	testWidget.option( "mini", true );
+	assert.deepEqual( convertClassValuesToHashes( testWidget.option() ),
+		{
+			create: null,
+			disabled: false,
+			classes: {
+				"test-testwidget": {
+					"ui-shadow": true,
+					"ui-mini": true
+				}
+			},
+			inline: false,
+			mini: true,
+			shadow: true,
+			corners: false
+		},
+		"After turning on mini classes option value contains 'ui-shadow' and 'ui-mini'" );
+	assert.hasClasses( testWidget.element[ 0 ], "ui-shadow ui-mini",
+		"Element has shadow and mini classes" );
+	assert.lacksClasses( testWidget.element[ 0 ], "ui-button-inline ui-corner-all",
+		"Element lacks all other classes" );
+
+	testWidget.option( {
+		mini: false,
+		inline: true
+	} );
+	assert.deepEqual( convertClassValuesToHashes( testWidget.option() ),
+		{
+			create: null,
+			disabled: false,
+			classes: {
+				"test-testwidget": {
+					"ui-button-inline": true,
+					"ui-shadow": true
+				}
+			},
+			inline: true,
+			mini: false,
+			shadow: true,
+			corners: false
+		},
+		"After turning off mini and turning on inline classes option value contains 'ui-shadow' " +
+			"and 'ui-button-inline'" );
+	assert.hasClasses( testWidget.element[ 0 ], "ui-shadow ui-button-inline",
+		"Element has shadow and mini classes" );
+	assert.lacksClasses( testWidget.element[ 0 ], "ui-mini ui-corner-all",
+		"Element lacks all other classes" );
+} );
+
+test( "The classes option is updated correctly when an option is turned on", function( assert ) {
+	var testWidget = $.mobile.testwidget( {
+		corners: true
+	} );
+
+	assert.deepEqual( convertClassValuesToHashes( testWidget.option() ),
+		{
+			create: null,
+			disabled: false,
+			classes: {
+				"test-testwidget": {
+					"ui-button-inline": true,
+					"ui-corner-all": true,
+					"ui-shadow": true
+				}
+			},
+			inline: true,
+			mini: false,
+			shadow: true,
+			corners: true
+		},
+		"After initial creation classes option value is correct" );
+	assert.hasClasses( testWidget.element[ 0 ], "ui-button-inline ui-corner-all ui-shadow",
+		"Element has classes ui-button-inline, ui-corner-all, and ui-shadow" );
+	assert.lacksClasses( testWidget.element[ 0 ], "ui-mini", "Element lacks ui-mini class" );
+} );
+
+module( "wrapperClass", {
+	setup: function() {
+		$.widget( "mobile.testwidget", {
+			options: {
+				classes: {},
+				enhanced: false,
+				wrapperClass: ""
+			},
+			_create: function() {
+				if ( !this.options.enhanced ) {
+					this._enhance();
+				}
+				return this._superApply( arguments );
+			},
+			_enhance: $.noop
+		});
+		$.widget( "mobile.testwidget", $.mobile.testwidget, $.mobile.widget.backcompat );
+	},
+	teardown: function() {
+		delete $.mobile.testwidget;
+		delete $.fn.testwidget;
+	}
+} );
+
+test( "wrapperClass is correctly applied, modified, and removed", function( assert ) {
+	var testWidget = $.mobile.testwidget( {
+			wrapperClass: "abc"
+		} ),
+		testElement = testWidget.element;
+
+	assert.hasClasses( testElement[ 0 ], "abc", "Wrapper class initially applied" );
+
+	testWidget.option( "wrapperClass", "def" );
+	assert.hasClasses( testElement[ 0 ], "def", "Wrapper class update applied" );
+	assert.lacksClasses( testElement[ 0 ], "abc", "Wrapper class old value removed" );
+
+	testWidget.destroy();
+	assert.deepEqual( !!testElement.attr( "class" ), false,
+		"Class attribute cleared upon destroy()" );
+} );
+
+})( jQuery );


### PR DESCRIPTION
Fixes gh-7972

Also modifies backcompat somewhat:
- We cannot treat the values of class keys as truthy, because `""` counts as true, because a key may be explicitly set to `""` - for example, if `"ui-widgetname": "ui-corner-all"` and you don't want corners
- `Array.splice()` is incapable of removing the first element of an array, so we must use `Array.shift()` in that special case
- When we compute the initial value of the options during _create(), we cannot interleave the precedence of the value of `this.options.classes[ this.classProp ]` with the precedence of the deprecated style option values. We must assume that the initial value of the class key reflects the default values of the style options. We also cannot modify both the value of the class key and the value of the options, because that results in unexpected behaviour.
  We must instead assume that, if `this.options.classes[ this.classProp ]` has been modified, then the application we're a part of is running non-deprecated code and the value of `this.options.classes[ this.classProp ]` completely determines the initial value of the style options.
  Conversely, if `this.options.classes[ this.classProp ]` is not modified (i.e., equal to the value in the prototype), then we must assume that legacy code is in place, and we must use the value of the various style options to construct `this.options.classes[ this.classProp ]`
