### PR TITLE
Added classes to allow colspan-like behaviour on grid columns

### DIFF
--- a/css/structure/jquery.mobile.grid.css
+++ b/css/structure/jquery.mobile.grid.css
@@ -101,3 +101,23 @@ li.ui-block-e {
 		float: none; 
 	}
 }
+
+/* colspan-like grid columns */
+.ui-grid-b > .ui-block-span2 {
+  width: 66.6666%;
+}
+.ui-grid-c > .ui-block-span2 {
+  width: 50%;
+}
+.ui-grid-c > .ui-block-span3 {
+  width: 75%;
+}
+.ui-grid-d > .ui-block-span2 {
+  width: 40%;
+}
+.ui-grid-d > .ui-block-span3 {
+  width: 60%;
+}
+.ui-grid-d > .ui-block-span4 {
+  width: 80%;
+}


### PR DESCRIPTION
These classes (ui-block-span2, ui-block-span3, ui-block-span4) are designed to allow columns/blocks to fit more than one column.
Take a 3 column grid, if you want to span the first column by 2/3 of the page width then you could use this construction:

``` html
    <div class="ui-grid-b">
      <div class="ui-block-a ui-block-span2">
        A+B
      </div>
      <div class="ui-block-c">
        C
      </div>
    </div>
```
