### PR TITLE
Bower: Fix the jquery version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
 		"tools"
 	],
 	"dependencies": {
-		"jquery": "1.11.1",
+		"jquery": ">=1.11.1",
 		"jquery-ui": "jquery/jquery-ui#c0ab71056b936627e8a7821f03c044aec6280a40"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Uses >= for installing jquery version

Fixes #7872
