### PR TITLE
Transition: Don't assume sync then in tests

### DIFF
--- a/tests/unit/transitions/transitions_core.js
+++ b/tests/unit/transitions/transitions_core.js
@@ -75,7 +75,7 @@
 		instance.doneIn();
 	});
 
-	test( "resolves the transition deferred with the requisite data", function() {
+	asyncTest( "resolves the transition deferred with the requisite data", function() {
 		expect( 4 );
 
 		$.when( instance.deferred ).then(function( name, reverse, to, from ) {
@@ -83,6 +83,7 @@
 			equal( reverse, "reverse" );
 			equal( to, $to );
 			equal( from, "from" );
+			start();
 		});
 
 		instance.doneIn();


### PR DESCRIPTION
Transition this broke because of changes to jQuery git build

Ref https://github.com/jquery/jquery/pull/1996
