### PR TITLE
Toolbar: remove classes from the correct page when destroying fixedtoolbars

### DIFF
--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -279,7 +279,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 
 		_destroy: function() {
 			var pageClasses, toolbarClasses, hasFixed, header, hasFullscreen,
-				page = this.pagecontainer.pagecontainer( "getActivePage" );
+				page = this.page;
 
 			this._super();
 			if ( this.options.position === "fixed" ) {

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -7,11 +7,11 @@
 
 define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigation", "./page","./toolbar","../zoom" ], function( jQuery ) {
 //>>excludeEnd("jqmBuildExclude");
-(function( $, undefined ) {
+( function( $, undefined ) {
 
 	$.widget( "mobile.toolbar", $.mobile.toolbar, {
 		options: {
-			position:null,
+			position: null,
 			visibleOnPageShow: true,
 			disablePageZoom: true,
 			transition: "slide", //can be none, fade, slide (slide maps to slideup or slidedown)
@@ -56,7 +56,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 			if ( this.options.position === "fixed" && !this.options.supportBlacklist() ) {
 				var $page = ( !!this.page ) ? this.page : ( $( ".ui-page-active" ).length > 0 ) ? $( ".ui-page-active" ) : $( ".ui-page" ).eq( 0 );
 
-				if ( o.fullscreen !== undefined) {
+				if ( o.fullscreen !== undefined ) {
 					if ( o.fullscreen ) {
 						this.element.addClass( "ui-"+ this.role +"-fullscreen" );
 						$page.addClass( "ui-page-" + this.role + "-fullscreen" );
@@ -68,7 +68,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 					}
 				}
 			}
-			this._super(o);
+			this._super( o );
 		},
 
 		_addTransitionClass: function() {
@@ -85,7 +85,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 		},
 
 		_bindPageEvents: function() {
-			var page = ( !!this.page )? this.element.closest( ".ui-page" ): this.document;
+			var page = ( !!this.page ) ? this.element.closest( ".ui-page" ) : this.document;
 			//page event bindings
 			// Fixed toolbars require page zoom to be disabled, otherwise usability issues crop up
 			// This method is meant to disable zoom while a fixed-positioned toolbar page is visible
@@ -96,10 +96,10 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 				"updatelayout": "_handleAnimationStart",
 				"pageshow": "_handlePageShow",
 				"pagebeforehide": "_handlePageBeforeHide"
-			});
+			} );
 		},
 
-		_handlePageBeforeShow: function( ) {
+		_handlePageBeforeShow: function() {
 			var o = this.options;
 			if ( o.disablePageZoom ) {
 				$.mobile.zoom.disable( true );
@@ -111,12 +111,12 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 
 		_handleAnimationStart: function() {
 			if ( this.options.updatePagePadding ) {
-				this.updatePagePadding( ( !!this.page )? this.page: ".ui-page-active" );
+				this.updatePagePadding( ( !!this.page ) ? this.page : ".ui-page-active" );
 			}
 		},
 
 		_handlePageShow: function() {
-			this.updatePagePadding( ( !!this.page )? this.page: ".ui-page-active" );
+			this.updatePagePadding( ( !!this.page ) ? this.page : ".ui-page-active" );
 			if ( this.options.updatePagePadding ) {
 				this._on( this.window, { "throttledresize": "updatePagePadding" } );
 			}
@@ -163,7 +163,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 			if ( this.options.fullscreen ) { return; }
 			// tbPage argument can be a Page object or an event, if coming from throttled resize.
 			tbPage = ( tbPage && tbPage.type === undefined && tbPage ) || this.page || $el.closest( ".ui-page" );
-			tbPage = ( !!this.page )? this.page: ".ui-page-active";
+			tbPage = ( !!this.page ) ? this.page : ".ui-page-active";
 			$( tbPage ).css( "padding-" + ( header ? "top" : "bottom" ), $el.outerHeight() + pos );
 		},
 
@@ -172,15 +172,15 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 				$el = this.element,
 				scroll = $win.scrollTop(),
 				elHeight = $el.height(),
-				pHeight = ( !!this.page )? $el.closest( ".ui-page" ).height():$(".ui-page-active").height(),
+				pHeight = ( !!this.page ) ? $el.closest( ".ui-page" ).height() : $( ".ui-page-active" ).height(),
 				viewportHeight = $.mobile.getScreenHeight();
 
 			return !notransition &&
 				( this.options.transition && this.options.transition !== "none" &&
-				(
-					( this.role === "header" && !this.options.fullscreen && scroll > elHeight ) ||
-					( this.role === "footer" && !this.options.fullscreen && scroll + viewportHeight < pHeight - elHeight )
-				) || this.options.fullscreen
+					(
+						( this.role === "header" && !this.options.fullscreen && scroll > elHeight ) ||
+						( this.role === "footer" && !this.options.fullscreen && scroll + viewportHeight < pHeight - elHeight )
+					) || this.options.fullscreen
 				);
 		},
 
@@ -231,7 +231,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 				o = self.options,
 				delayShow, delayHide,
 				isVisible = true,
-				page = ( !!this.page )? this.page: $(".ui-page");
+				page = ( !!this.page ) ? this.page : $(".ui-page");
 
 			// tap toggle
 			page
@@ -272,8 +272,8 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 		},
 
 		_setRelative: function() {
-			if( this.options.position !== "fixed" ){
-				$( "[data-"+ $.mobile.ns + "role='page']" ).css({ "position": "relative" });
+			if ( this.options.position !== "fixed" ){
+				$( "[data-" + $.mobile.ns + "role='page']" ).css( { "position": "relative" } );
 			}
 		},
 
@@ -283,13 +283,13 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 
 			this._super();
 			if ( this.options.position === "fixed" ) {
-				hasFixed = $(  "body>.ui-" + this.role + "-fixed" )
+				hasFixed = $(  "body > .ui-" + this.role + "-fixed" )
 							.add( page.find( ".ui-" + this.options.role + "-fixed" ) )
 							.not( this.element ).length > 0;
-				hasFullscreen = $(  "body>.ui-" + this.role + "-fixed" )
+				hasFullscreen = $(  "body > .ui-" + this.role + "-fixed" )
 							.add( page.find( ".ui-" + this.options.role + "-fullscreen" ) )
 							.not( this.element ).length > 0;
-				toolbarClasses =  "ui-header-fixed ui-footer-fixed ui-header-fullscreen in out" +
+				toolbarClasses = "ui-header-fixed ui-footer-fixed ui-header-fullscreen in out" +
 					" ui-footer-fullscreen fade slidedown slideup ui-fixed-hidden";
 				this.element.removeClass( toolbarClasses );
 				if ( !hasFullscreen ) {

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -54,7 +54,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 				this._makeFixed();
 			}
 			if ( this.options.position === "fixed" && !this.options.supportBlacklist() ) {
-				var $page = ( !!this.page )? this.page: ( $(".ui-page-active").length > 0 )? $(".ui-page-active"): $(".ui-page").eq(0);
+				var $page = ( !!this.page ) ? this.page : ( $( ".ui-page-active" ).length > 0 ) ? $( ".ui-page-active" ) : $( ".ui-page" ).eq( 0 );
 
 				if ( o.fullscreen !== undefined) {
 					if ( o.fullscreen ) {
@@ -279,7 +279,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 
 		_destroy: function() {
 			var pageClasses, toolbarClasses, hasFixed, header, hasFullscreen,
-				page = ( !!this.page )? this.page: ( $(".ui-page-active").length > 0 )? $(".ui-page-active"): $(".ui-page").eq(0);
+				page = ( !!this.page ) ? this.page : ( $( ".ui-page-active" ).length > 0 ) ? $( ".ui-page-active" ) : $( ".ui-page" ).eq( 0 );
 
 			this._super();
 			if ( this.options.position === "fixed" ) {

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -279,7 +279,7 @@ define( [ "jquery", "../widget", "../core", "../animationComplete", "../navigati
 
 		_destroy: function() {
 			var pageClasses, toolbarClasses, hasFixed, header, hasFullscreen,
-				page = this.page;
+				page = ( !!this.page )? this.page: ( $(".ui-page-active").length > 0 )? $(".ui-page-active"): $(".ui-page").eq(0);
 
 			this._super();
 			if ( this.options.position === "fixed" ) {

--- a/tests/integration/fixed-toolbar/fixedToolbar.js
+++ b/tests/integration/fixed-toolbar/fixedToolbar.js
@@ -374,5 +374,35 @@
 			}
 		]);
 	});
+	
+	asyncTest( "destroy removes classes from correct page " , function() {
+		expect( 3 );
+		
+		$.testHelper.pageSequence([
+			function() {
+				$( ":mobile-pagecontainer" ).pagecontainer( "change", "#page-destroy-test-page-1" );
+				
+			},
+			function() {
+				$( ":mobile-pagecontainer" ).pagecontainer( "change", "#page-destroy-test-page-2" );
+			},
+			function() {
+				var first = $("#page-destroy-test-page-1"),
+					second = $("#page-destroy-test-page-2");
+					
+				ok( first.hasClass("ui-page-header-fixed") === true , "ui-page-header-fixed class exists on first page before destroy" );
+				
+				var firstHeader = $("#headerOnFirstPage").toolbar("destroy");
+				
+				ok( first.hasClass("ui-page-header-fixed") === false , "ui-page-header-fixed class is removed from first page" );
+				ok( second.hasClass("ui-page-header-fixed") === true , "ui-page-header-fixed class is not removed from second page" );
+				
+				start();
+			},
+			function() {
+				$( ":mobile-pagecontainer" ).pagecontainer( "change", "#default" );
+			}
+		]);
+	});
 
 })(jQuery);

--- a/tests/integration/fixed-toolbar/fixedToolbar.js
+++ b/tests/integration/fixed-toolbar/fixedToolbar.js
@@ -4,56 +4,57 @@
 (function($){
 	$( "html" ).height( screen.height * 3 );
 
-	function scrollDown(){
-		window.scrollTo(0,screen.height );
+	function scrollDown() {
+		window.scrollTo( 0, screen.height );
 	}
 
-	function scrollUp(){
-		window.scrollTo(0,0);
+	function scrollUp() {
+		window.scrollTo( 0, 0 );
 	}
 
-	module( "toolbar", {setup: function() {
-		var startTimeout;
+	module( "toolbar", {
+		setup: function() {
+			var startTimeout;
 
-		// swallow the inital page change
-		stop();
-		$(document).one("pagechange", function() {
-			clearTimeout(startTimeout);
-		});
+			// swallow the inital page change
+			stop();
+			$( document ).one( "pagechange", function() {
+				clearTimeout( startTimeout );
+			});
 
-		startTimeout = setTimeout( start , 1000);
-	}});
+			startTimeout = setTimeout( start , 1000 );
+		}
+	});
 
-	asyncTest( "Fixed header and footer transition classes are applied correctly", function(){
+	asyncTest( "Fixed header and footer transition classes are applied correctly", function() {
 		expect( 5 );
 
-		$.testHelper.sequence([
-			function(){
+		$.testHelper.sequence( [
+			function() {
 				$( '#classes-test-b, #classes-test-g, #classes-test-e,#classes-test-h,#classes-test-i,#classes-test-j, #classes-test-k' ).toolbar( "hide" );
 				scrollDown();
 			},
 
-			function(){
+			function() {
 				//show first
 				$( '#classes-test-b, #classes-test-g, #classes-test-e,#classes-test-h,#classes-test-i,#classes-test-j, #classes-test-k' ).toolbar( "show" );
 			},
 
 			function() {
-				ok( $( '#classes-test-g' ).hasClass('slidedown'), 'The slidedown class should be applied by default');
-				ok( !$( '#classes-test-h' ).hasClass('slidedown'), 'The slidedown class should not be applied when the header has a data-transition of "none"');
+				ok( $( '#classes-test-g' ).hasClass( 'slidedown' ), 'The slidedown class should be applied by default' );
+				ok( !$( '#classes-test-h' ).hasClass( 'slidedown' ), 'The slidedown class should not be applied when the header has a data-transition of "none"' );
 
-				ok( !$( '#classes-test-h' ).hasClass('in'), 'The "in" class should not be applied when the header has a data-transition of "none"');
-				ok( $( '#classes-test-i' ).hasClass('slidedown'), 'The "slidedown" class should  be applied when the header has a data-transition of "slide"');
-				ok( $( '#classes-test-j' ).hasClass('slideup'), 'The "slideup" class should  be applied when the footer has a data-transition of "slide"');
+				ok( !$( '#classes-test-h' ).hasClass( 'in' ), 'The "in" class should not be applied when the header has a data-transition of "none"');
+				ok( $( '#classes-test-i' ).hasClass( 'slidedown' ), 'The "slidedown" class should  be applied when the header has a data-transition of "slide"' );
+				ok( $( '#classes-test-j' ).hasClass( 'slideup' ), 'The "slideup" class should  be applied when the footer has a data-transition of "slide"' );
 
 			},
 
-			function(){
+			function() {
 				scrollUp();
 				start();
-				}
-		], 1000);
-
+			}
+		], 1000 );
 	});
 
 
@@ -61,8 +62,8 @@
 
 		expect( 2 );
 
-		$.testHelper.sequence([
-			function(){
+		$.testHelper.sequence( [
+			function() {
 				$( '#classes-test-g' ).toolbar( "show" );
 				scrollDown();
 			},
@@ -70,29 +71,29 @@
 			function() {
 				$( '#classes-test-g' ).toolbar( "hide" );
 
-				ok( $( '#classes-test-g' ).hasClass('out'), 'The out class should be applied when hide is called');
+				ok( $( '#classes-test-g' ).hasClass( 'out' ), 'The out class should be applied when hide is called' );
 			},
 
 			function() {
-				ok( $( '#classes-test-g' ).hasClass('ui-fixed-hidden'), 'The toolbar has the ui-fixed-hidden class applied after hide');
+				ok( $( '#classes-test-g' ).hasClass( 'ui-fixed-hidden' ), 'The toolbar has the ui-fixed-hidden class applied after hide' );
 				$( '#classes-test-g' ).toolbar( "show" );
 
 			},
 
-			function(){
+			function() {
 				scrollUp();
 				start();
 			}
 
-		], 700);
+		], 700 );
 	});
 
 	asyncTest( "The show method is working properly", function() {
 
 		expect( 2 );
 
-		$.testHelper.sequence([
-			function(){
+		$.testHelper.sequence( [
+			function() {
 				scrollDown();
 			},
 
@@ -103,36 +104,36 @@
 			function() {
 				$( '#classes-test-g' ).toolbar( "show" );
 
-				ok( $( '#classes-test-g' ).hasClass('in'), 'The in class should be applied when show is called');
+				ok( $( '#classes-test-g' ).hasClass( 'in' ), 'The in class should be applied when show is called' );
 			},
 
 			function() {
-				ok( !$( '#classes-test-g' ).hasClass('ui-fixed-hidden'), 'The toolbar does not have the ui-fixed-hidden class applied after show');
+				ok( !$( '#classes-test-g' ).hasClass( 'ui-fixed-hidden' ), 'The toolbar does not have the ui-fixed-hidden class applied after show' );
 
 			},
 
-			function(){
+			function() {
 				scrollUp();
 				start();
 			}
-		], 700);
+		], 700 );
 	});
 
 	asyncTest( "The toggle method is working properly", function() {
 
 		expect( 3 );
 
-		$.testHelper.sequence([
-			function(){
+		$.testHelper.sequence( [
+			function() {
 				scrollDown();
 			},
 
-			function(){
+			function() {
 				$( '#classes-test-g' ).toolbar( "show" );
 			},
 
 			function() {
-				ok( !$( '#classes-test-g' ).hasClass('ui-fixed-hidden'), 'The toolbar does not have the ui-fixed-hidden class');
+				ok( !$( '#classes-test-g' ).hasClass( 'ui-fixed-hidden' ), 'The toolbar does not have the ui-fixed-hidden class' );
 			},
 
 			function() {
@@ -140,7 +141,7 @@
 			},
 
 			function() {
-				ok( $( '#classes-test-g' ).hasClass('ui-fixed-hidden'), 'The toolbar does have the ui-fixed-hidden class');
+				ok( $( '#classes-test-g' ).hasClass( 'ui-fixed-hidden' ), 'The toolbar does have the ui-fixed-hidden class' );
 			},
 
 			function() {
@@ -148,36 +149,36 @@
 			},
 
 			function() {
-				ok( !$( '#classes-test-g' ).hasClass('ui-fixed-hidden'), 'The toolbar does not have the ui-fixed-hidden class');
+				ok( !$( '#classes-test-g' ).hasClass( 'ui-fixed-hidden' ), 'The toolbar does not have the ui-fixed-hidden class' );
 
 			},
 
-			function(){
+			function() {
 				scrollUp();
 				start();
 			}
 
-		], 500);
+		], 500 );
 	});
 
 	asyncTest( "Fullscreen toolbars add classes to page", function() {
 		expect( 2 );
 
-		$.testHelper.sequence([
+		$.testHelper.sequence( [
 			function(){
 				$.mobile.changePage( "#fullscreen-test-a" );
 			},
 
-			function(){	
+			function(){
 				ok( $('#classes-test-l').closest( ".ui-page" ).hasClass( "ui-page-header-fullscreen" ), "Parent page of a fullscreen header has class ui-page-header-fullscreen" );
 				ok( $('#classes-test-m').closest( ".ui-page" ).hasClass( "ui-page-footer-fullscreen" ), "Parent page of a fullscreen footer has class ui-page-header-fullscreen" );
 			},
 
-			function(){
+			function() {
 				scrollUp();
 				start();
 			}
-		], 500);
+		], 500 );
 	});
 
 	asyncTest( "The persistent headers and footers are working properly", function() {
@@ -190,13 +191,13 @@
 			nextpagefooter =  $( "#persist-test-b .ui-footer-fixed" );
 
 
-		$.testHelper.pageSequence([
-			function(){
+		$.testHelper.pageSequence( [
+			function() {
 				ok( nextpageheader.length && nextpagefooter.length, "next page has fixed header and fixed footer" );
 				$.mobile.changePage( "#persist-test-a" );
 			},
 
-			function(){
+			function() {
 				$( "#persist-test-b" )
 					.one( "pagebeforeshow", function(){
 						ok( nextpageheader.parent( ".ui-mobile-viewport" ).length, "fixed header and footer are now a child of page container" );
@@ -222,15 +223,15 @@
 
 		var nextpageheader =  $( "#persist-test-d .ui-header-fixed" );
 
-		$.testHelper.pageSequence([
-			function(){
+		$.testHelper.pageSequence( [
+			function() {
 				ok( nextpageheader.length, "next page has fixed header and fixed footer" );
 				$.mobile.changePage( "#persist-test-c" );
 			},
 
-			function(){
+			function() {
 				$( "#persist-test-d" )
-					.one( "pagebeforeshow", function(){
+					.one( "pagebeforeshow", function() {
 						deepEqual( nextpageheader.parent()[0], $.mobile.pageContainer[0], "fixed header is now a child of page container" );
 					});
 
@@ -254,15 +255,15 @@
 
 		var nextpagefooter =  $( "#persist-test-f .ui-footer-fixed" );
 
-		$.testHelper.pageSequence([
-			function(){
+		$.testHelper.pageSequence( [
+			function() {
 				ok( nextpagefooter.length, "next page has fixed footer and fixed footer" );
 				$.mobile.changePage( "#persist-test-e" );
 			},
 
-			function(){
+			function() {
 				$( "#persist-test-f" )
-					.one( "pagebeforeshow", function(){
+					.one( "pagebeforeshow", function() {
 						deepEqual( nextpagefooter.parent()[0], $.mobile.pageContainer[0], "fixed footer is now a child of page container" );
 					});
 
@@ -275,11 +276,11 @@
 			},
 
 			start
-		]);
+		] );
 	});
 
 	var asyncTestFooterAndHeader = function( pageSelector, visible ) {
-		$.testHelper.pageSequence([
+		$.testHelper.pageSequence( [
 			function() {
 				$.mobile.changePage( pageSelector );
 			},
@@ -299,7 +300,7 @@
 			},
 
 			start
-		]);
+		] );
 	};
 
 	asyncTest( "data-visible-on-page-show hides toolbars when false", function() {
@@ -347,9 +348,7 @@
 			},
 
 			function() {
-
 				$.mobile.pageContainer.change( "#default" );
-
 			}
 		]);
 	});
@@ -362,8 +361,8 @@
 				$( ":mobile-pagecontainer" ).pagecontainer( "change", "#page-destroy-test" );
 			},
 			function() {
-				var unEnhanced = $("#testDestroyFixedFullscreen").clone(),
-		            destroyed = $("#testDestroyFixedFullscreen").toolbar().toolbar("destroy");
+				var unEnhanced = $( "#testDestroyFixedFullscreen" ).clone(),
+		            destroyed = $( "#testDestroyFixedFullscreen" ).toolbar().toolbar( "destroy" );
 
 		        ok( $.testHelper.domEqual( destroyed, unEnhanced ),
 		        	"unEnhanced equals destroyed" );
@@ -387,15 +386,15 @@
 				$( ":mobile-pagecontainer" ).pagecontainer( "change", "#page-destroy-test-page-2" );
 			},
 			function() {
-				var first = $("#page-destroy-test-page-1"),
-					second = $("#page-destroy-test-page-2");
+				var first = $( "#page-destroy-test-page-1" ),
+					second = $( "#page-destroy-test-page-2" );
 					
-				ok( first.hasClass("ui-page-header-fixed") === true , "ui-page-header-fixed class exists on first page before destroy" );
+				ok( first.hasClass( "ui-page-header-fixed" ) === true , "ui-page-header-fixed class exists on first page before destroy" );
 				
-				var firstHeader = $("#headerOnFirstPage").toolbar("destroy");
+				var firstHeader = $( "#headerOnFirstPage" ).toolbar( "destroy" );
 				
-				ok( first.hasClass("ui-page-header-fixed") === false , "ui-page-header-fixed class is removed from first page" );
-				ok( second.hasClass("ui-page-header-fixed") === true , "ui-page-header-fixed class is not removed from second page" );
+				ok( first.hasClass( "ui-page-header-fixed" ) === false , "ui-page-header-fixed class is removed from first page" );
+				ok( second.hasClass( "ui-page-header-fixed" ) === true , "ui-page-header-fixed class is not removed from second page" );
 				
 				start();
 			},

--- a/tests/integration/fixed-toolbar/index.html
+++ b/tests/integration/fixed-toolbar/index.html
@@ -110,5 +110,16 @@
             <h1>title</h1>
         </div>
 	</div>
+	
+	<div data-nstest-role="page" id="page-destroy-test-page-1">
+		<div id="headerOnFirstPage" data-nstest-role="header" data-nstest-position="fixed">
+			<h1>title</h1>
+		</div>
+	</div>
+	<div data-nstest-role="page" id="page-destroy-test-page-2">
+		<div data-nstest-role="header" data-nstest-position="fixed">
+			<h1>title</h1>
+		</div>
+	</div>
 </body>
 </html>

--- a/tests/unit/fixed-toolbar/fixedToolbar.js
+++ b/tests/unit/fixed-toolbar/fixedToolbar.js
@@ -6,18 +6,18 @@
 
 	test( "Fixed Header Structural Classes are applied correctly", function(){
 		//footer
-		ok( !$('#classes-test-a').hasClass('ui-header-fixed'), 'An ordinary header should not have fixed classes');
-		ok( $('#classes-test-b').hasClass('ui-header-fixed'), 'An header with data-position=fixed should have ui-header-fixed class');
-		ok( $('#classes-test-c').hasClass('ui-header-fullscreen'), 'An header with data-position=fixed and data-fullscreen should have ui-header-fullscreen class');
+		ok( !$( '#classes-test-a' ).hasClass( 'ui-header-fixed' ), 'An ordinary header should not have fixed classes' );
+		ok( $( '#classes-test-b' ).hasClass( 'ui-header-fixed' ), 'An header with data-position=fixed should have ui-header-fixed class' );
+		ok( $( '#classes-test-c' ).hasClass( 'ui-header-fullscreen' ), 'An header with data-position=fixed and data-fullscreen should have ui-header-fullscreen class' );
 
 		//footer
-		ok( !$('#classes-test-d').hasClass('ui-footer-fixed'), 'An ordinary footer should not have fixed classes');
-		ok( $('#classes-test-e').hasClass('ui-footer-fixed'), 'A footer with data-position=fixed should have ui-footer-fixed class"');
-		ok( $('#classes-test-f').hasClass('ui-footer-fullscreen'), 'A footer with data-position=fixed and data-fullscreen should have ui-footer-fullscreen class');
+		ok( !$( '#classes-test-d' ).hasClass( 'ui-footer-fixed' ), 'An ordinary footer should not have fixed classes' );
+		ok( $( '#classes-test-e' ).hasClass( 'ui-footer-fixed' ), 'A footer with data-position=fixed should have ui-footer-fixed class"' );
+		ok( $( '#classes-test-f' ).hasClass( 'ui-footer-fullscreen' ), 'A footer with data-position=fixed and data-fullscreen should have ui-footer-fullscreen class' );
 
 		//parent
-		ok( $('#classes-test-b').closest( ".ui-page" ).hasClass( "ui-page-header-fixed" ), "Parent page of a fixed header has class ui-page-header-fixed" );
-		ok( $('#classes-test-e').closest( ".ui-page" ).hasClass( "ui-page-footer-fixed" ), "Parent page of a fixed footer has class ui-page-header-fixed" );
+		ok( $( '#classes-test-b' ).closest( ".ui-page" ).hasClass( "ui-page-header-fixed" ), "Parent page of a fixed header has class ui-page-header-fixed" );
+		ok( $( '#classes-test-e' ).closest( ".ui-page" ).hasClass( "ui-page-footer-fixed" ), "Parent page of a fixed footer has class ui-page-header-fixed" );
 	});
 
 	test( "User zooming is disabled when the header is visible and disablePageZoom is true", function(){
@@ -59,8 +59,8 @@
 	});
 	
 	test( "Destroy works properly with external toolbars" , function() {
-		var unEnhanced = $("#external-header").clone(),
-			destroyed = $("#external-header").toolbar().toolbar("destroy");
+		var unEnhanced = $( "#external-header" ).clone(),
+			destroyed = $( "#external-header" ).toolbar().toolbar( "destroy" );
 
 		ok( $.testHelper.domEqual( destroyed, unEnhanced ),
 			"unEnhanced equals destroyed" );

--- a/tests/unit/fixed-toolbar/fixedToolbar.js
+++ b/tests/unit/fixed-toolbar/fixedToolbar.js
@@ -57,4 +57,12 @@
 
 		$.mobile.zoom.enable( true );
 	});
+	
+	test( "Destroy works properly with external toolbars" , function() {
+		var unEnhanced = $("#external-header").clone(),
+			destroyed = $("#external-header").toolbar().toolbar("destroy");
+
+		ok( $.testHelper.domEqual( destroyed, unEnhanced ),
+			"unEnhanced equals destroyed" );
+	});
 })(jQuery);

--- a/tests/unit/fixed-toolbar/index.html
+++ b/tests/unit/fixed-toolbar/index.html
@@ -95,5 +95,9 @@
 		<div data-nstest-role="header" data-nstest-fullscreen="true" data-nstest-position="fixed"></div>
 		<div data-nstest-role="footer" data-nstest-fullscreen="true" data-nstest-position="fixed"></div>
 	</div>
+	
+	<div id="external-header" data-nstest-position="fixed" data-nstest-fullscreen="true">
+		<h1>&nbsp;</h1>
+	</div>
 </body>
 </html>


### PR DESCRIPTION
Should resolve issue #7995.
