### PR TITLE
Build: Increase phantom js timeout to 1 minute

### DIFF
--- a/build/tasks/options/qunit.js
+++ b/build/tasks/options/qunit.js
@@ -4,7 +4,7 @@ var path = require( "path" );
 module.exports = function( grunt ) {
 return {
 	options: {
-		timeout: 30000,
+		timeout: 60000,
 		"--web-security": "no",
 		coverage: {
 			baseUrl: ".",


### PR DESCRIPTION
If its going to time out the build is no good anyway so the extra time does
not matter execpt when things are running slow on travis this may save a fail

Fixes gh-8063
