### PR TITLE
Path: Remove $.mobile.getDocumentUrl and $.mobile.getDocumentBase

### DIFF
--- a/js/navigation/path.js
+++ b/js/navigation/path.js
@@ -456,15 +456,5 @@ path.getDocumentBase = function( asParsedObject ) {
 	return asParsedObject ? $.extend( {}, path.documentBase ) : path.documentBase.href;
 };
 
-// DEPRECATED as of 1.4.0 - remove in 1.5.0
-$.extend( $.mobile, {
-
-	//return the original document url
-	getDocumentUrl: path.getDocumentUrl,
-
-	//return the original document base url
-	getDocumentBase: path.getDocumentBase
-} );
-
 return path;
 } );


### PR DESCRIPTION
These are exposed through $.mobile.path and were just shortcuts
Fixes gh-6507
