### PR TITLE
Hide page with visibility

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -44,7 +44,7 @@ div.ui-mobile-viewport {
 	width: 100%;
 	min-height: 100%;
 	position: absolute;
-	display: none;
+	visibility: hidden;
 	border: 0;
 }
 /* On ios4, setting focus on the page element causes flashing during transitions when there is an outline, so we turn off outlines */
@@ -52,7 +52,7 @@ div.ui-mobile-viewport {
 	outline: none;
 }
 .ui-mobile .ui-page-active {
-	display: block;
+	visibility: visible;
 	overflow: visible;
 	overflow-x: hidden;
 }

--- a/js/widgets/forms/autogrow.js
+++ b/js/widgets/forms/autogrow.js
@@ -55,10 +55,8 @@ return $.widget( "mobile.textinput", $.mobile.textinput, {
 		// Attach to the various you-have-become-visible notifications that the
 		// various framework elements emit.
 		// TODO: Remove all but the updatelayout handler once #6426 is fixed.
+		this._handleShow( "create" );
 		this._on( true, this.document, {
-
-			// TODO: Move to non-deprecated event
-			"pageshow": "_handleShow",
 			"popupbeforeposition": "_handleShow",
 			"updatelayout": "_handleShow",
 			"panelopen": "_handleShow"
@@ -73,10 +71,10 @@ return $.widget( "mobile.textinput", $.mobile.textinput, {
 	// content has become visible, but the collapsible is still collapsed, so
 	// the autogrow textarea is still not visible.
 	_handleShow: function( event ) {
-		if ( $.contains( event.target, this.element[ 0 ] ) &&
-				this.element.is( ":visible" ) ) {
+		if ( event === "create" || ( $.contains( event.target, this.element[ 0 ] ) &&
+				this.element.is( ":visible" ) ) ) {
 
-			if ( event.type !== "popupbeforeposition" ) {
+			if ( event !== "create" && event.type !== "popupbeforeposition" ) {
 				this._addClass( "ui-textinput-autogrow-resize" );
 				this.element
 					.animationComplete(


### PR DESCRIPTION
This updates to use visibility to hide inactive pages. This has several advantages
- Changing visibility does not effect layout
- now visual updates after transition include full page reflows with animation
- no more page show event handlers
- unlike opacity visibility removes things from tab order
- unlike opacity does not create a new stacking context when hidden ( minor perf benefit ).
