### PR TITLE
Pagecontainer classes

### DIFF
--- a/demos/backbone-requirejs/index.php
+++ b/demos/backbone-requirejs/index.php
@@ -42,7 +42,7 @@
 
       <h2>jQuery Mobile configuration</h2>
 
-      <p>The technique used in this <a href="backbone-require.html" rel="external">example page</a> is by no means the only technique available, but it is one of the most elegant.  The Backbone.js router is used exclusively to handle all hashchange events, and the jQuery Mobile <code>$.mobile.pageContainer.pagecontainer( "change", url, options )</code> method is used to programmatically change the page.</p>
+      <p>The technique used in this <a href="backbone-require.html" rel="external">example page</a> is by no means the only technique available, but it is one of the most elegant.  The Backbone.js router is used exclusively to handle all hashchange events, and the jQuery Mobile <code>.pagecontainer( "change", url, options )</code> method is used to programmatically change the page.</p>
 
       <p>Below are two internal jQuery Mobile properties that are turned off to allow this to happen:</p>
 
@@ -115,7 +115,7 @@
       } );
 </code>
 </pre>
-<p>Next, inside of the Backbone.js Router class object, we can respond to haschange events and manually call the <code>$.mobile.pageContainer.pagecontainer( "change" )</code> method.  Below is a small snippet of <strong>mobileRouter.js</strong>.</p>
+<p>Next, inside of the Backbone.js Router class object, we can respond to haschange events and manually call the <code>pagecontainer( "change" )</code> method.  Below is a small snippet of <strong>mobileRouter.js</strong>.</p>
 <pre>
 <code>
         // Backbone.js Routes
@@ -133,7 +133,7 @@
         home: function() {
 
             // Programatically changes to the categories page
-            $.mobile.pageContainer.pagecontainer( "change", "#categories" , {
+            $( ".ui-pagecontainer" ).pagecontainer( "change", "#categories" , {
 				reverse: false,
 				changeHash: false
 			});

--- a/demos/backbone-requirejs/index.php
+++ b/demos/backbone-requirejs/index.php
@@ -42,7 +42,7 @@
 
       <h2>jQuery Mobile configuration</h2>
 
-      <p>The technique used in this <a href="backbone-require.html" rel="external">example page</a> is by no means the only technique available, but it is one of the most elegant.  The Backbone.js router is used exclusively to handle all hashchange events, and the jQuery Mobile <code>$.mobile.changePage()</code> method is used to programmatically change the page.</p>
+      <p>The technique used in this <a href="backbone-require.html" rel="external">example page</a> is by no means the only technique available, but it is one of the most elegant.  The Backbone.js router is used exclusively to handle all hashchange events, and the jQuery Mobile <code>$.mobile.pageContainer.pagecontainer( "change", url, options )</code> method is used to programmatically change the page.</p>
 
       <p>Below are two internal jQuery Mobile properties that are turned off to allow this to happen:</p>
 
@@ -115,7 +115,7 @@
       } );
 </code>
 </pre>
-<p>Next, inside of the Backbone.js Router class object, we can respond to haschange events and manually call the jQuery Mobile <code>changePage()</code> method.  Below is a small snippet of <strong>mobileRouter.js</strong>.</p>
+<p>Next, inside of the Backbone.js Router class object, we can respond to haschange events and manually call the <code>$.mobile.pageContainer.pagecontainer( "change" )</code> method.  Below is a small snippet of <strong>mobileRouter.js</strong>.</p>
 <pre>
 <code>
         // Backbone.js Routes
@@ -133,7 +133,10 @@
         home: function() {
 
             // Programatically changes to the categories page
-            $.mobile.changePage( "#categories" , { reverse: false, changeHash: false } );
+            $.mobile.pageContainer.pagecontainer( "change", "#categories" , {
+				reverse: false,
+				changeHash: false
+			});
 
         }
 </code>

--- a/demos/backbone-requirejs/js/collections/CategoriesCollection.js
+++ b/demos/backbone-requirejs/js/collections/CategoriesCollection.js
@@ -83,7 +83,8 @@ define([
                 // Triggers the custom `added` method (which the Category View listens for)
                 self.trigger( "added" );
 
-                // Resolves the deferred object (this triggers the changePage method inside of the Category Router)
+                // Resolves the deferred object (this triggers the pagecontainer change() method
+                // inside of the Category Router)
                 deferred.resolve();
 
             }, 1000);

--- a/demos/backbone-requirejs/js/routers/mobileRouter.js
+++ b/demos/backbone-requirejs/js/routers/mobileRouter.js
@@ -16,6 +16,8 @@ define([
         // The Router constructor
         initialize: function() {
 
+            this.pagecontainer = $( ".ui-pagecontainer" ).pagecontainer( "instance" );
+
             // Instantiates a new Animal Category View
             this.animalsView = new CategoryView( { el: "#animals", collection: new CategoriesCollection( [] , { type: "animals" } ) } );
 
@@ -45,7 +47,7 @@ define([
         home: function() {
 
             // Programatically changes to the categories page
-            $.mobile.pageContainer.pagecontainer( "change", "#categories", {
+            this.pagecontainer.change( "#categories", {
 				reverse: false,
 				changeHash: false
 			});
@@ -68,11 +70,10 @@ define([
                 currentView.collection.fetch().done( function() {
 
                     // Programatically changes to the current categories page
-                    $.mobile.pageContainer.pagecontainer( "change", "#" + type, {
+                    this.pagecontainer.change( "#" + type, {
 						reverse: false,
 						changeHash: false
 					});
-    
                 } );
 
             }
@@ -81,7 +82,7 @@ define([
             else {
 
                 // Programatically changes to the current categories page
-                $.mobile.pageContainer.pagecontainer( "change", "#" + type, {
+                this.pagecontainer.change( "#" + type, {
 					reverse: false,
 					changeHash: false
 				});

--- a/demos/backbone-requirejs/js/routers/mobileRouter.js
+++ b/demos/backbone-requirejs/js/routers/mobileRouter.js
@@ -45,7 +45,10 @@ define([
         home: function() {
 
             // Programatically changes to the categories page
-            $.mobile.changePage( "#categories" , { reverse: false, changeHash: false } );
+            $.mobile.pageContainer.pagecontainer( "change", "#categories", {
+				reverse: false,
+				changeHash: false
+			});
 
         },
 
@@ -65,7 +68,10 @@ define([
                 currentView.collection.fetch().done( function() {
 
                     // Programatically changes to the current categories page
-                    $.mobile.changePage( "#" + type, { reverse: false, changeHash: false } );
+                    $.mobile.pageContainer.pagecontainer( "change", "#" + type, {
+						reverse: false,
+						changeHash: false
+					});
     
                 } );
 
@@ -75,7 +81,10 @@ define([
             else {
 
                 // Programatically changes to the current categories page
-                $.mobile.changePage( "#" + type, { reverse: false, changeHash: false } );
+                $.mobile.pageContainer.pagecontainer( "change", "#" + type, {
+					reverse: false,
+					changeHash: false
+				});
 
             }
 

--- a/demos/old-faq-pages/index.php
+++ b/demos/old-faq-pages/index.php
@@ -9,7 +9,7 @@
 <li data-role="list-divider">Pages</li>
 <li data-section="Questions &amp; Answers" data-filtertext="head load scripts styles pageinit onload pagebeforecreate ajax nav pages"><a href="faq/scripts-and-styles-not-loading.php">Why aren't my scripts and styles loading?</a></li>
 <li data-section="Questions &amp; Answers" data-filtertext="document.ready onload paginit DOM ready on ready scripts "><a href="faq/dom-ready-not-working.php">Why isn't DOM ready working for my scripts?</a></li>
-<li data-section="Questions &amp; Answers" data-filtertext="ajax nav load page mobile.loadpage"><a href="faq/how-do-i-load-a-page.php">How do I load a page?</a></li>
+<li data-section="Questions &amp; Answers" data-filtertext="ajax nav load page pagecontainer load"><a href="faq/how-do-i-load-a-page.php">How do I load a page?</a></li>
 <li data-section="Questions &amp; Answers" data-filtertext="ajax nav multi page document load"><a href="faq/why-is-only-the-first-page-loaded.php">Why is only the first page of my multi page document loaded?</a></li>
 <li data-section="Questions &amp; Answers" data-filtertext="pass url query params ajax nav"><a href="faq/pass-query-params-to-page.php">I'm trying to pass query params to a page but it's not working?</a></li>
 <li data-section="Questions &amp; Answers" data-filtertext="hash pass parameters information ajax nav"><a href="faq/pass-via-the-hash-to-page.php">I'm trying to pass information via the hash but it's not working?</a></li>

--- a/demos/pages/samepagetransition.html
+++ b/demos/pages/samepagetransition.html
@@ -33,7 +33,7 @@
 
   <div role="main" class="ui-content">
      <h1>same page transitions</h1>
-     <div>All links within this page navigate to the page itself having the <code>allowSamePageTransition</code> option at <code>changePage()</code> method set to <strong>true</strong>. It seems, just the slide transition raises an issue so the page gets hidden.
+     <div>All links within this page navigate to the page itself having the <code>allowSamePageTransition</code> option at the <code>$.mobile.pageContainer.pagecontainer( "change" )</code> method set to <strong>true</strong>. It seems, just the slide transition raises an issue so the page gets hidden.
       <label><input type="checkbox" id="cb1" data-theme="b"> reverse transition </label>
       <label><input type="checkbox" id="cb2" data-theme="b"> add ui-page-active on pageshow </label>
     </div>
@@ -59,9 +59,11 @@ $('#page1').on('pagecreate', function() {
     var trans = $(this).text() || 'none',
         rev = !!$('#cb1').attr('checked');
 
-    $.mobile.changePage('#page1', { transition: trans,
-                                    allowSamePageTransition: true,
-                                    reverse: rev } );
+    $.mobile.pageContainer.pagecontainer( "change", "#page1", {
+		transition: trans,
+		allowSamePageTransition: true,
+		reverse: rev
+	});
     $('#p1').text( 'last transition: ' + trans + ' - reverse: ' + rev );
   });
 });

--- a/demos/pages/samepagetransition.html
+++ b/demos/pages/samepagetransition.html
@@ -33,7 +33,7 @@
 
   <div role="main" class="ui-content">
      <h1>same page transitions</h1>
-     <div>All links within this page navigate to the page itself having the <code>allowSamePageTransition</code> option at the <code>$.mobile.pageContainer.pagecontainer( "change" )</code> method set to <strong>true</strong>. It seems, just the slide transition raises an issue so the page gets hidden.
+     <div>All links within this page navigate to the page itself having the <code>allowSamePageTransition</code> option at the <code>.pagecontainer( "change" )</code> method set to <strong>true</strong>. It seems, just the slide transition raises an issue so the page gets hidden.
       <label><input type="checkbox" id="cb1" data-theme="b"> reverse transition </label>
       <label><input type="checkbox" id="cb2" data-theme="b"> add ui-page-active on pageshow </label>
     </div>
@@ -59,7 +59,7 @@ $('#page1').on('pagecreate', function() {
     var trans = $(this).text() || 'none',
         rev = !!$('#cb1').attr('checked');
 
-    $.mobile.pageContainer.pagecontainer( "change", "#page1", {
+    $( this ).closest( ".ui-pagecontainer" ).pagecontainer( "change", "#page1", {
 		transition: trans,
 		allowSamePageTransition: true,
 		reverse: rev

--- a/demos/pages/startpage.html
+++ b/demos/pages/startpage.html
@@ -15,9 +15,11 @@ $('#page1').on('pagecreate', function() {
     var trans = $(this).text() || 'none',
         rev = !!$('#cb1').attr('checked');
 
-    $.mobile.changePage('#page1', { transition: trans,
-                                    allowSamePageTransition: true,
-                                    reverse: rev } );
+    $.mobile.pageContainer.pagecontainer( "change", "#page1", {
+		transition: trans,
+        allowSamePageTransition: true,
+        reverse: rev
+	});
     $('#p1').text( 'last transition: ' + trans + ' - reverse: ' + rev );
   });
 });

--- a/demos/pages/startpage.html
+++ b/demos/pages/startpage.html
@@ -15,7 +15,7 @@ $('#page1').on('pagecreate', function() {
     var trans = $(this).text() || 'none',
         rev = !!$('#cb1').attr('checked');
 
-    $.mobile.pageContainer.pagecontainer( "change", "#page1", {
+    $( this ).closest( ".ui-pagecontainer" ).pagecontainer( "change", "#page1", {
 		transition: trans,
         allowSamePageTransition: true,
         reverse: rev

--- a/js/init.js
+++ b/js/init.js
@@ -135,7 +135,7 @@ $.extend( $.mobile, {
 				$.mobile.navigate.navigator.squash( path.parseLocation().href );
 			}
 
-			$.mobile.changePage( $.mobile.firstPage, {
+			$.mobile.pageContainer.pagecontainer( "change", $.mobile.firstPage, {
 				transition: "none",
 				reverse: true,
 				changeHash: false,

--- a/js/init.js
+++ b/js/init.js
@@ -71,7 +71,8 @@ $.extend( $.mobile, {
 	// find and enhance the pages in the dom and transition to the first page.
 	initializePage: function() {
 		// find present pages
-		var path = $.mobile.path,
+		var pagecontainer,
+			path = $.mobile.path,
 			$pages = $( ":jqmData(role='page'), :jqmData(role='dialog')" ),
 			hash = path.stripHash( path.stripQueryParams( path.parseLocation().hash ) ),
 			theLocation = $.mobile.path.parseLocation(),
@@ -100,18 +101,11 @@ $.extend( $.mobile, {
 		$.enhance._installWidget();
 
 		// define page container
-		$.mobile.pageContainer = $.mobile.firstPage
-			.parent()
-				.addClass( "ui-mobile-viewport" )
-				.pagecontainer();
+		pagecontainer = $.mobile.firstPage.parent().pagecontainer();
 
 		// initialize navigation events now, after mobileinit has occurred and the page container
 		// has been created but before the rest of the library is alerted to that fact
 		$.mobile.navreadyDeferred.resolve();
-
-		// alert listeners that the pagecontainer has been determined for binding
-		// to events triggered on it
-		$window.trigger( "pagecontainercreate" );
 
 		// cue page loading message
 		$.mobile.loading( "show" );
@@ -135,7 +129,7 @@ $.extend( $.mobile, {
 				$.mobile.navigate.navigator.squash( path.parseLocation().href );
 			}
 
-			$.mobile.pageContainer.pagecontainer( "change", $.mobile.firstPage, {
+			pagecontainer.pagecontainer( "change", $.mobile.firstPage, {
 				transition: "none",
 				reverse: true,
 				changeHash: false,

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -139,25 +139,6 @@ $.mobile._maybeDegradeTransition = $.mobile._maybeDegradeTransition || function(
 	};
 
 // Exposed $.mobile methods
-
-$.mobile.changePage = function( to, options ) {
-	$.mobile.pageContainer.pagecontainer( "change", to, options );
-};
-
-$.mobile.changePage.defaults = {
-	transition: undefined,
-	reverse: false,
-	changeHash: true,
-	fromHashChange: false,
-	role: undefined, // By default we rely on the role defined by the @data-role attribute.
-	duplicateCachedPage: undefined,
-	pageContainer: undefined,
-	showLoadMsg: true, //loading message shows by default when pages are being fetched during changePage
-	dataUrl: undefined,
-	fromPage: undefined,
-	allowSamePageTransition: false
-};
-
 $.mobile._registerInternalEvents = function() {
 	var getAjaxFormData = function( $form, calculateOnly ) {
 		var url,
@@ -248,7 +229,7 @@ $.mobile._registerInternalEvents = function() {
 		if ( !event.isDefaultPrevented() ) {
 			formData = getAjaxFormData( $( this ) );
 			if ( formData ) {
-				$.mobile.changePage( formData.url, formData.options );
+				$.mobile.pageContainer.pagecontainer( "change", formData.url, formData.options );
 				event.preventDefault();
 			}
 		}
@@ -411,7 +392,12 @@ $.mobile._registerInternalEvents = function() {
 		//this may need to be more specific as we use data-rel more
 		role = $link.attr( "data-" + $.mobile.ns + "rel" ) || undefined;
 
-		$.mobile.changePage( href, { transition: transition, reverse: reverse, role: role, link: $link } );
+		$.mobile.pageContainer.pagecontainer( "change", href, {
+			transition: transition,
+			reverse: reverse,
+			role: role,
+			link: $link
+		});
 		event.preventDefault();
 	} );
 

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -93,7 +93,7 @@ $.mobile.back = function() {
 			nav.app.backHistory ) {
 		nav.app.backHistory();
 	} else {
-		$.mobile.pageContainer.pagecontainer( "back" );
+		$.mobile.pagecontainers.active.back();
 	}
 };
 
@@ -210,7 +210,8 @@ $.mobile._registerInternalEvents = function() {
 		if ( !event.isDefaultPrevented() ) {
 			formData = getAjaxFormData( $( this ) );
 			if ( formData ) {
-				$.mobile.pageContainer.pagecontainer( "change", formData.url, formData.options );
+				$( this ).closest( ".ui-pagecontainer" )
+					.pagecontainer( "change", formData.url, formData.options );
 				event.preventDefault();
 			}
 		}
@@ -373,7 +374,7 @@ $.mobile._registerInternalEvents = function() {
 		//this may need to be more specific as we use data-rel more
 		role = $link.attr( "data-" + $.mobile.ns + "rel" ) || undefined;
 
-		$.mobile.pageContainer.pagecontainer( "change", href, {
+		$link.closest( ".ui-pagecontainer" ).pagecontainer( "change", href, {
 			transition: transition,
 			reverse: reverse,
 			role: role,
@@ -384,7 +385,8 @@ $.mobile._registerInternalEvents = function() {
 
 	//prefetch pages when anchors with data-prefetch are encountered
 	$.mobile.document.delegate( ".ui-page", "pageshow.prefetch", function() {
-		var urls = [];
+		var urls = [],
+			that = this;
 		$( this ).find( "a:jqmData(prefetch)" ).each( function() {
 			var $link = $( this ),
 				url = $link.attr( "href" );
@@ -392,7 +394,7 @@ $.mobile._registerInternalEvents = function() {
 			if ( url && $.inArray( url, urls ) === -1 ) {
 				urls.push( url );
 
-				$.mobile.pageContainer.pagecontainer( "load", url, {
+				that.closest( ".ui-pagecontainer" ).pagecontainer( "load", url, {
 					role: $link.attr( "data-" + $.mobile.ns + "rel" ),
 					prefetch: true
 				});
@@ -401,7 +403,7 @@ $.mobile._registerInternalEvents = function() {
 	} );
 
 	// TODO ensure that the navigate binding in the content widget happens at the right time
-	$.mobile.pageContainer.pagecontainer();
+	//$.mobile.pageContainer.pagecontainer();
 
 	//set page min-heights to be device specific
 	$.mobile.document.bind( "pageshow", function() {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -74,25 +74,6 @@ function findClosestLink( ele ) {
 	return ele;
 }
 
-$.mobile.loadPage = function( url, opts ) {
-	var container;
-
-	opts = opts || {};
-	container = ( opts.pageContainer || $.mobile.pageContainer );
-
-	// create the deferred that will be supplied to loadPage callers
-	// and resolved by the content widget's load method
-	opts.deferred = $.Deferred();
-
-	// Preferring to allow exceptions for uninitialized opts.pageContainer
-	// widgets so we know if we need to force init here for users
-	container.pagecontainer( "load", url, opts );
-
-	// provide the deferred
-	return opts.deferred.promise();
-};
-
-//define vars for interal use
 
 /* internal utility functions */
 
@@ -411,7 +392,10 @@ $.mobile._registerInternalEvents = function() {
 			if ( url && $.inArray( url, urls ) === -1 ) {
 				urls.push( url );
 
-				$.mobile.loadPage( url, { role: $link.attr( "data-" + $.mobile.ns + "rel" ), prefetch: true } );
+				$.mobile.pageContainer.pagecontainer( "load", url, {
+					role: $link.attr( "data-" + $.mobile.ns + "rel" ),
+					prefetch: true
+				});
 			}
 		} );
 	} );

--- a/js/transitions/transition.js
+++ b/js/transitions/transition.js
@@ -153,7 +153,7 @@ $.extend( $.mobile.Transition.prototype, {
 	},
 
 	toggleViewportClass: function() {
-		$.mobile.pageContainer.toggleClass( "ui-mobile-viewport-transitioning viewport-" + this.name );
+		this.$to.closest( ".ui-pagecontainer" ).toggleClass( "ui-mobile-viewport-transitioning viewport-" + this.name );
 	},
 
 	transition: function() {

--- a/js/widgets/fixedToolbar.js
+++ b/js/widgets/fixedToolbar.js
@@ -166,7 +166,7 @@ return $.widget( "mobile.toolbar", $.mobile.toolbar, {
 
 			if ( nextFooter.length || nextHeader.length ) {
 
-				nextFooter.add( nextHeader ).appendTo( $.mobile.pageContainer );
+				nextFooter.add( nextHeader ).appendTo( this.element.closest( ".ui-pagecontainer" ) );
 
 				ui.nextPage.one( "pageshow", function() {
 					nextHeader.prependTo( this );

--- a/js/widgets/forms/select.custom.js
+++ b/js/widgets/forms/select.custom.js
@@ -431,7 +431,7 @@ return $.widget( "mobile.selectmenu", $.mobile.selectmenu, {
 
 		if ( menuHeight > screenHeight - 80 || !$.support.scrollTop ) {
 
-			self.menuPage.appendTo( $.mobile.pageContainer ).page();
+			self.menuPage.appendTo( this.element.closest( ".ui-pagecontainer" ) ).page();
 			self.menuPageContent = self.menuPage.find( ".ui-content" );
 			self.menuPageClose = self.menuPage.find( ".ui-header a" );
 

--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -9,7 +9,6 @@
 
 //>>label: Content Management
 //>>group: Navigation
-<<<<<<< HEAD
 //>>description: Widget to create page container which manages pages and transitions
 //>>docs: http://api.jquerymobile.com/pagecontainer/
 //>>demos: http://demos.jquerymobile.com/@VERSION/navigation/

--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -9,6 +9,7 @@
 
 //>>label: Content Management
 //>>group: Navigation
+<<<<<<< HEAD
 //>>description: Widget to create page container which manages pages and transitions
 //>>docs: http://api.jquerymobile.com/pagecontainer/
 //>>demos: http://demos.jquerymobile.com/@VERSION/navigation/
@@ -49,11 +50,7 @@ $.widget( "mobile.pagecontainer", {
 			reverse: false,
 			changeHash: true,
 			fromHashChange: false,
-
-			// By default we rely on the role defined by the @data-role attribute.
-			role: undefined,
 			duplicateCachedPage: undefined,
-			pageContainer: undefined,
 
 			//loading message shows by default when pages are being fetched during change()
 			showLoadMsg: true,

--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -62,6 +62,15 @@ $.widget( "mobile.pagecontainer", {
 	initSelector: false,
 
 	_create: function() {
+
+		// Maintain a global array of pagecontainers
+		$.mobile.pagecontainers = ( $.mobile.pagecontainers ? $.mobile.pagecontainers : [] )
+			.concat( [ this ] );
+
+		// In the future this will be tracked to give easy access to the active pagecontainer
+		// For now we just set it since multiple containers are not supported.
+		$.mobile.pagecontainers.active = this;
+
 		this._trigger( "beforecreate" );
 		this.setLastScrollEnabled = true;
 
@@ -84,7 +93,7 @@ $.widget( "mobile.pagecontainer", {
 		// TODO move from page* events to content* events
 		this._on( { pagechange: "_afterContentChange" } );
 
-		this._addClass( "ui-pagecontainer" );
+		this._addClass( "ui-pagecontainer", "ui-mobile-viewport" );
 
 		// Handle initial hashchange from chrome :(
 		this.window.one( "navigate", $.proxy( function() {
@@ -1197,6 +1206,19 @@ $.widget( "mobile.pagecontainer", {
 		var closestBase = ( this.activePage &&
 			$.mobile.getClosestBaseUrl( this.activePage ) );
 		return closestBase || $.mobile.path.documentBase.hrefNoHash;
+	},
+
+	_destroy: function() {
+		var myIndex;
+
+		if ( $.mobile.pagecontainers ) {
+			myIndex = $.inArray( this.element, $.mobile.pagecontainers );
+			if ( myIndex >= 0 ) {
+				$.mobile.pagecontainers.splice( myIndex, 1 );
+			}
+		}
+
+		this._super();
 	}
 } );
 

--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -913,7 +913,7 @@ $.widget( "mobile.pagecontainer", {
 			triggerData.absUrl = $.mobile.path.makeUrlAbsolute( to, this._findBaseWithDefault() );
 		} else {
 
-			// If the toPage is a jQuery object grab the absolute url stored in the loadPage
+			// If the toPage is a jQuery object grab the absolute url stored in the load()
 			// callback where it exists
 			triggerData.absUrl = settings.absUrl;
 		}
@@ -955,7 +955,7 @@ $.widget( "mobile.pagecontainer", {
 		// string, because an object can also be replaced by a string
 		to = triggerData.toPage;
 
-		// If the caller passed us a url, call loadPage() to make sure it is loaded into the DOM.
+		// If the caller passed us a url, call load() to make sure it is loaded into the DOM.
 		// We'll listen to the promise object it returns so we know when it is done loading or if
 		// an error ocurred.
 		if ( $.type( to ) === "string" ) {

--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -85,6 +85,8 @@ $.widget( "mobile.pagecontainer", {
 		// TODO move from page* events to content* events
 		this._on( { pagechange: "_afterContentChange" } );
 
+		this._addClass( "ui-pagecontainer" );
+
 		// Handle initial hashchange from chrome :(
 		this.window.one( "navigate", $.proxy( function() {
 			this.setLastScrollEnabled = true;
@@ -93,10 +95,10 @@ $.widget( "mobile.pagecontainer", {
 
 	_setOptions: function( options ) {
 		if ( options.theme !== undefined && options.theme !== "none" ) {
-			this.element.removeClass( "ui-overlay-" + this.options.theme )
-				.addClass( "ui-overlay-" + options.theme );
+			this._removeClass( null, "ui-overlay-" + this.options.theme )
+				._addClass( null, "ui-overlay-" + options.theme );
 		} else if ( options.theme !== undefined ) {
-			this.element.removeClass( "ui-overlay-" + this.options.theme );
+			this._removeClass( null, "ui-overlay-" + this.options.theme );
 		}
 
 		this._super( options );

--- a/js/widgets/pagecontainer.js
+++ b/js/widgets/pagecontainer.js
@@ -43,7 +43,24 @@ $.widget( "mobile.pagecontainer", {
 	version: "@VERSION",
 
 	options: {
-		theme: "a"
+		theme: "a",
+		changeOptions: {
+			transition: undefined,
+			reverse: false,
+			changeHash: true,
+			fromHashChange: false,
+
+			// By default we rely on the role defined by the @data-role attribute.
+			role: undefined,
+			duplicateCachedPage: undefined,
+			pageContainer: undefined,
+
+			//loading message shows by default when pages are being fetched during change()
+			showLoadMsg: true,
+			dataUrl: undefined,
+			fromPage: undefined,
+			allowSamePageTransition: false
+		}
 	},
 
 	initSelector: false,
@@ -279,7 +296,7 @@ $.widget( "mobile.pagecontainer", {
 				this.forward();
 			}
 
-			// Prevent changePage call
+			// Prevent change() call
 			return false;
 		} else {
 
@@ -342,11 +359,7 @@ $.widget( "mobile.pagecontainer", {
 			}
 		}
 
-		this._changeContent( this._handleDestination( to ), changePageOptions );
-	},
-
-	_changeContent: function( to, opts ) {
-		$.mobile.changePage( to, opts );
+		this.change( this._handleDestination( to ), changePageOptions );
 	},
 
 	_getBase: function() {
@@ -843,7 +856,7 @@ $.widget( "mobile.pagecontainer", {
 		// Release transition lock so navigation is free again
 		isPageTransitioning = false;
 		if ( pageTransitionQueue.length > 0 ) {
-			$.mobile.changePage.apply( null, pageTransitionQueue.pop() );
+			this.change.apply( this, pageTransitionQueue.pop() );
 		}
 	},
 
@@ -868,7 +881,7 @@ $.widget( "mobile.pagecontainer", {
 			isPageTransitioning = false;
 
 			// Store the original absolute url so that it can be provided to events in the
-			// triggerData of the subsequent changePage call
+			// triggerData of the subsequent change() call
 			options.absUrl = triggerData.absUrl;
 
 			this.transition( content, triggerData, options );
@@ -920,13 +933,13 @@ $.widget( "mobile.pagecontainer", {
 	change: function( to, options ) {
 
 		// If we are in the midst of a transition, queue the current request. We'll call
-		// changePage() once we're done with the current transition to service the request.
+		// change() once we're done with the current transition to service the request.
 		if ( isPageTransitioning ) {
 			pageTransitionQueue.unshift( arguments );
 			return;
 		}
 
-		var settings = $.extend( {}, $.mobile.changePage.defaults, options ),
+		var settings = $.extend( {}, this.options.changeOptions, options ),
 			triggerData = {};
 
 		// Make sure we have a fromPage.
@@ -962,7 +975,7 @@ $.widget( "mobile.pagecontainer", {
 			isDialog, alreadyThere, newPageTitle, params, cssTransitionDeferred, beforeTransition;
 
 		// If we are in the midst of a transition, queue the current request. We'll call
-		// changePage() once we're done with the current transition to service the request.
+		// change() once we're done with the current transition to service the request.
 		if ( isPageTransitioning ) {
 
 			// Make sure to only queue the to and settings values so the arguments work with a call
@@ -1017,11 +1030,11 @@ $.widget( "mobile.pagecontainer", {
 			toPage.jqmData( "role" ) === "dialog" ) &&
 			toPage.jqmData( "dialog" ) !== true;
 
-		// By default, we prevent changePage requests when the fromPage and toPage are the same
+		// By default, we prevent change() requests when the fromPage and toPage are the same
 		// element, but folks that generate content manually/dynamically and reuse pages want to be
 		// able to transition to the same page. To allow this, they will need to change the default
 		// value of allowSamePageTransition to true, *OR*, pass it in as an option when they
-		// manually call changePage(). It should be noted that our default transition animations
+		// manually call change(). It should be noted that our default transition animations
 		// assume that the formPage and toPage are different elements, so they may behave
 		// unexpectedly. It is up to the developer that turns on the allowSamePageTransitiona
 		// option to either turn off transition animations, or make sure that an appropriate
@@ -1045,7 +1058,7 @@ $.widget( "mobile.pagecontainer", {
 		// We need to make sure the page we are given has already been enhanced.
 		toPage.page( { role: settings.role } );
 
-		// If the changePage request was sent from a hashChange event, check to see if the page is
+		// If the change() request was sent from a hashChange event, check to see if the page is
 		// already within the urlHistory stack. If so, we'll assume the user hit the forward/back
 		// button and will try to match the transition accordingly.
 		if ( settings.fromHashChange ) {

--- a/tests/functional/hashchange/hashchange.html
+++ b/tests/functional/hashchange/hashchange.html
@@ -22,7 +22,7 @@
 		if ( !!~location.search.indexOf( "no-history" ) ) {
 			$.mobile.pushStateEnabled = false;
 			$.mobile.hashListeningEnabled = false;
-			$.mobile.changePage.defaults.changeHash = false;
+			$.mobile.pagecontainer.prototype.options.changeOptions.changeHash = false;
 		}
 	});
 })( jQuery );

--- a/tests/integration/checkboxradio/checkboxradio_core.js
+++ b/tests/integration/checkboxradio/checkboxradio_core.js
@@ -1,0 +1,150 @@
+/*
+ * mobile checkboxradio unit tests
+ */
+(function($){
+	module( 'jquery.mobile.forms.checkboxradio.js' );
+
+	asyncTest( "radio button labels should update the active button class to last clicked and clear checked", function(){
+		var $radioBtns = $( '#radio-active-btn-test input' ),
+			singleActiveAndChecked = function(){
+				deepEqual( $( "#radio-active-btn-test .ui-radio-on" ).length, 1, "there should be only one active button" );
+				// Use the .checked property, not the checked attribute which is not dynamic
+				var numChecked = 0;
+				$( "#radio-active-btn-test input" ).each(function(i, e) {
+					if( e.checked ) {
+						numChecked++;
+					}
+				});
+				deepEqual( numChecked, 1, "there should be only one checked" );
+			};
+
+		$.testHelper.sequence([
+			function(){
+				$radioBtns.last().siblings( 'label' ).click();
+			},
+
+			function(){
+				ok( $radioBtns.last().prop( 'checked' ), "last input is checked" );
+				ok( $radioBtns.last().siblings( 'label' ).hasClass( 'ui-radio-on' ),
+					"last input label is an active button" );
+
+				ok( !$radioBtns.first().prop( 'checked' ), "first input label is not active" );
+				ok( !$radioBtns.first().siblings( 'label' ).hasClass( 'ui-radio-on' ),
+					"first input label is not active" );
+
+				singleActiveAndChecked();
+
+				$radioBtns.first().siblings( 'label' ).click();
+			},
+
+			function(){
+				ok( $radioBtns.first().prop( 'checked' ));
+				ok( $radioBtns.first().siblings( 'label' ).hasClass( 'ui-radio-on' ),
+					"first input label is an active button" );
+
+				ok( !$radioBtns.last().prop( 'checked' ));
+				ok( !$radioBtns.last().siblings( 'label' ).hasClass( 'ui-radio-on' ),
+					"last input label is not active" );
+
+				singleActiveAndChecked();
+
+				start();
+			}
+		], 500);
+
+	});
+
+	asyncTest( "clicking the label triggers a click on the element", function() {
+		var clicked = false;
+
+		expect( 1 );
+
+		$( "#checkbox-click-triggered" ).one('click', function() {
+			clicked = true;
+		});
+
+		$.testHelper.sequence([
+			function() {
+				$( "[for='checkbox-click-triggered']" ).click();
+			},
+
+			function() {
+				ok(clicked, "click was fired on input");
+				start();
+			}
+		], 2000);
+	});
+
+	asyncTest( "clicking the label triggers a change on the element", function() {
+		var changed = false;
+
+		expect( 1 );
+
+		$( "#checkbox-change-triggered" ).one('change', function() {
+			changed = true;
+		});
+
+		$.testHelper.sequence([
+			function() {
+				$( "[for='checkbox-change-triggered']" ).click();
+			},
+
+			function() {
+				ok(changed, "change was fired on input");
+				start();
+			}
+		], 2000);
+	});
+
+	asyncTest( "form submission should include radio button values", function() {
+		var $form = $( "#radio-form" ), $input = $form.find("input").first();
+
+		$.testHelper.pageSequence([
+			function() {
+				$input.click();
+				$form.submit();
+			},
+
+			function( timeout ){
+				var check = location.hash || location.search;
+
+				ok( check.indexOf("radio1=1") >= 0, "the radio was checked" );
+
+				// if the page change in the previous function failed don't go back
+				if( !timeout ){
+					window.history.back();
+				}
+			},
+
+			function(){
+				start();
+			}
+		]);
+	});
+
+	asyncTest( "form submission should include checkbox button values", function() {
+		var $form = $( "#check-form" ), $inputs = $form.find("input");
+
+		$.testHelper.pageSequence([
+			function() {
+				$inputs.click();
+				$form.submit();
+			},
+
+			function( timeout ){
+				var check = location.hash || location.search;
+
+				ok( check.indexOf("checkbox-form=on") >= 0, "the first checkbox was checked" );
+				ok( check.indexOf("checkbox-form-2=on") >= 0, "the second checkbox was checked" );
+				// if the page change in the previous function failed don't go back
+				if( !timeout ){
+					window.history.back();
+				}
+			},
+
+			function(){
+				start();
+			}
+		]);
+	});
+})(jQuery);

--- a/tests/integration/degrade-inputs/degradeInputs.js
+++ b/tests/integration/degrade-inputs/degradeInputs.js
@@ -13,7 +13,7 @@
 		// and _expect_ that the default page will remain "unreaped". This will break if that assumption changes
 		$.testHelper.pageSequence([
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "#dialog" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "#dialog" );
 			},
 
 			function() {

--- a/tests/integration/degrade-inputs/degradeInputs.js
+++ b/tests/integration/degrade-inputs/degradeInputs.js
@@ -1,0 +1,38 @@
+/*
+ * degradeInputs unit tests
+ */
+
+(function($){
+	module('jquery.mobile.degradeInputs.js');
+
+	asyncTest('should degrade input type to a different type, as specified in page options', function(){
+		var degradeInputs = $.mobile.page.prototype.options.degradeInputs;
+		expect( Object.keys( degradeInputs ).length * 2 );
+
+		// NOTE the initial page is already enhanced (or expected to be) so we load the dialog to enhance it
+		// and _expect_ that the default page will remain "unreaped". This will break if that assumption changes
+		$.testHelper.pageSequence([
+			function() {
+				$.mobile.pageContainer.pagecontainer( "change", "#dialog" );
+			},
+
+			function() {
+				$.each(degradeInputs, function( oldType, newType ) {
+					if (newType === false) {
+						newType = oldType;
+					}
+
+					$('#page-test-container').html('<input type="' + oldType + '" />').trigger("create");
+
+					deepEqual($('#page-test-container input').attr("type"), newType, "type attr on page is: " + newType);
+
+					$('#dialog-test-container').html('<input type="' + oldType + '" />').trigger("create");
+
+					deepEqual($('#dialog-test-container input').attr("type"), newType, "type attr on dialog is: " + newType);
+				});
+
+				start();
+			}
+		]);
+	});
+})(jQuery);

--- a/tests/integration/dialog-extension/dialog_events.js
+++ b/tests/integration/dialog-extension/dialog_events.js
@@ -93,11 +93,11 @@ QUnit.asyncTest( "Clicking dialog 'Close' button renders it unclickable", functi
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
-			$.mobile.changePage( $( "#doubleCloseTestPage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#doubleCloseTestPage" ) );
 		},
 
 		function() {
@@ -129,7 +129,7 @@ QUnit.asyncTest( "dialog element with no theming", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -163,7 +163,7 @@ QUnit.asyncTest( "dialog element with data-theme", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -196,7 +196,7 @@ QUnit.asyncTest( "dialog element with data-theme & data-overlay-theme", function
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -229,7 +229,7 @@ QUnit.asyncTest( "page container is updated to dialog overlayTheme at pagebefore
 
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.changePage( "#mypage" );
+				$.mobile.pageContainer.pagecontainer( "change", "#mypage" );
 			},
 
 			function() {

--- a/tests/integration/dialog-extension/dialog_events.js
+++ b/tests/integration/dialog-extension/dialog_events.js
@@ -93,11 +93,11 @@ QUnit.asyncTest( "Clicking dialog 'Close' button renders it unclickable", functi
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#doubleCloseTestPage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#doubleCloseTestPage" ) );
 		},
 
 		function() {
@@ -129,7 +129,7 @@ QUnit.asyncTest( "dialog element with no theming", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -163,7 +163,7 @@ QUnit.asyncTest( "dialog element with data-theme", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -196,7 +196,7 @@ QUnit.asyncTest( "dialog element with data-theme & data-overlay-theme", function
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -229,7 +229,7 @@ QUnit.asyncTest( "page container is updated to dialog overlayTheme at pagebefore
 
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "#mypage" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "#mypage" );
 			},
 
 			function() {
@@ -241,11 +241,11 @@ QUnit.asyncTest( "page container is updated to dialog overlayTheme at pagebefore
 				pageTheme = "ui-overlay-" +
 					$( ".ui-page-active" ).page( "option", "overlayTheme" );
 
-				$.mobile.pageContainer.removeClass( pageTheme );
+				$( ".ui-pagecontainer" ).removeClass( pageTheme );
 
 				$( ".ui-page-active" )
 					.bind( "pagebeforeshow", function() {
-						assert.ok( $.mobile.pageContainer.hasClass( pageTheme ),
+						assert.ok( $( ".ui-pagecontainer" ).hasClass( pageTheme ),
 							"Page container has the same theme as the dialog overlayTheme on " +
 								"pagebeforeshow" );
 						QUnit.start();

--- a/tests/integration/dialog-extension/dialog_no_hash.js
+++ b/tests/integration/dialog-extension/dialog_no_hash.js
@@ -15,7 +15,7 @@ asyncTest( "dialog opens and closes correctly when hash handling is off", functi
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {

--- a/tests/integration/dialog-extension/dialog_no_hash.js
+++ b/tests/integration/dialog-extension/dialog_no_hash.js
@@ -15,7 +15,7 @@ asyncTest( "dialog opens and closes correctly when hash handling is off", functi
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {

--- a/tests/integration/dialog-extension/no-hash-tests.html
+++ b/tests/integration/dialog-extension/no-hash-tests.html
@@ -9,7 +9,7 @@
 	<script src="../../../js/jquery.tag.inserter.js"></script>
 	<script>
 		$( document ).bind( "mobileinit", function() {
-			$.mobile.changePage.defaults.changeHash = false;
+			$.mobile.pagecontainer.prototype.options.changeOptions.changeHash = false;
 			$.mobile.hashListeningEnabled = false;
 			$.mobile.pushStateEnabled = false;
 		} );

--- a/tests/integration/dialog/dialog_events.js
+++ b/tests/integration/dialog/dialog_events.js
@@ -59,7 +59,7 @@ QUnit.asyncTest( "dialog element with no theming", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -95,7 +95,7 @@ QUnit.asyncTest( "dialog element with data-theme", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -129,7 +129,7 @@ QUnit.asyncTest( "dialog element with data-theme & data-overlay-theme", function
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -164,7 +164,7 @@ QUnit.asyncTest( "pagecontainer is set to dialog overlayTheme at pagebeforeshow"
 
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.changePage( "#mypage" );
+				$.mobile.pageContainer.pagecontainer( "change", "#mypage" );
 			},
 
 			function() {

--- a/tests/integration/dialog/dialog_events.js
+++ b/tests/integration/dialog/dialog_events.js
@@ -59,7 +59,7 @@ QUnit.asyncTest( "dialog element with no theming", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -74,7 +74,7 @@ QUnit.asyncTest( "dialog element with no theming", function( assert ) {
 			// Assert dialog theme inheritance (issue 1375):
 			assert.hasClasses( dialog, "ui-page-theme-a",
 				"Expected explicit theme ui-page-theme-a" );
-			assert.hasClasses( $.mobile.pageContainer, "ui-overlay-a",
+			assert.hasClasses( $( ".ui-pagecontainer" ), "ui-overlay-a",
 				"Expected default overlay theme ui-overlay-a" );
 			assert.hasClasses( dialog.find( jqmDataSelector( "role=header" ) ), "ui-bar-inherit",
 				"Expected header to inherit from dialog" );
@@ -95,7 +95,7 @@ QUnit.asyncTest( "dialog element with data-theme", function( assert ) {
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -110,9 +110,9 @@ QUnit.asyncTest( "dialog element with data-theme", function( assert ) {
 			// Assert dialog theme inheritance (issue 1375):
 			assert.hasClasses( dialog, "ui-page-theme-e",
 				"Expected explicit theme ui-page-theme-e" );
-			assert.lacksClasses( $.mobile.pageContainer, "ui-overlay-b",
+			assert.lacksClasses( $( ".ui-pagecontainer" ), "ui-overlay-b",
 				"Expected no overlay theme ui-overlay-b" );
-			assert.hasClasses( $.mobile.pageContainer, "ui-overlay-a",
+			assert.hasClasses( $( ".ui-pagecontainer" ), "ui-overlay-a",
 				"Expected default overlay theme ui-overlay-a" );
 			assert.hasClasses( dialog.find( jqmDataSelector( "role=header" ) ), "ui-bar-inherit",
 				"Expected header to inherit from dialog" );
@@ -129,7 +129,7 @@ QUnit.asyncTest( "dialog element with data-theme & data-overlay-theme", function
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -144,7 +144,7 @@ QUnit.asyncTest( "dialog element with data-theme & data-overlay-theme", function
 			// Assert dialog theme inheritance (issue 1375):
 			assert.hasClasses( dialog, "ui-page-theme-e",
 				"Expected explicit theme ui-page-theme-e" );
-			assert.hasClasses( $.mobile.pageContainer, "ui-overlay-b",
+			assert.hasClasses( $( ".ui-pagecontainer" ), "ui-overlay-b",
 				"Expected explicit overlay theme ui-overlay-b" );
 			assert.hasClasses( dialog.find( jqmDataSelector( "role=header" ) ), "ui-bar-inherit",
 				"Expected header to inherit from dialog" );
@@ -164,7 +164,7 @@ QUnit.asyncTest( "pagecontainer is set to dialog overlayTheme at pagebeforeshow"
 
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "#mypage" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "#mypage" );
 			},
 
 			function() {
@@ -176,11 +176,11 @@ QUnit.asyncTest( "pagecontainer is set to dialog overlayTheme at pagebeforeshow"
 			function() {
 				pageTheme = "ui-overlay-" + $.mobile.activePage.page( "option", "overlayTheme" );
 
-				$.mobile.pageContainer.removeClass( pageTheme );
+				$( ".ui-pagecontainer" ).removeClass( pageTheme );
 
 				$.mobile.activePage
 					.bind( "pagebeforeshow", function() {
-						assert.hasClasses( $.mobile.pageContainer, pageTheme,
+						assert.hasClasses( $( ".ui-pagecontainer" ), pageTheme,
 							"Page container has the same theme as the dialog overlayTheme on " +
 								"pagebeforeshow" );
 						QUnit.start();

--- a/tests/integration/dialog/dialog_no_hash.js
+++ b/tests/integration/dialog/dialog_no_hash.js
@@ -15,7 +15,7 @@ asyncTest( "dialog opens and closes correctly when hash handling is off", functi
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( $( "#mypage" ) );
+			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {
@@ -39,5 +39,4 @@ asyncTest( "dialog opens and closes correctly when hash handling is off", functi
 		}
 	] );
 } );
-
 } )( jQuery );

--- a/tests/integration/dialog/dialog_no_hash.js
+++ b/tests/integration/dialog/dialog_no_hash.js
@@ -15,7 +15,7 @@ asyncTest( "dialog opens and closes correctly when hash handling is off", functi
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", $( "#mypage" ) );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#mypage" ) );
 		},
 
 		function() {

--- a/tests/integration/dialog/no-hash-tests.html
+++ b/tests/integration/dialog/no-hash-tests.html
@@ -8,8 +8,8 @@
 	<script src="../../../js/requirejs.config.js"></script>
 	<script src="../../../js/jquery.tag.inserter.js"></script>
 	<script>
-		$(document).bind('mobileinit',function() {
-			$.mobile.changePage.defaults.changeHash = false;
+		$( document ).on( "mobileinit", function() {
+			$.mobile.pagecontainer.prototype.options.changeOptions.changeHash = false;
 			$.mobile.hashListeningEnabled = false;
 			$.mobile.pushStateEnabled = false;
 		} );

--- a/tests/integration/fixed-toolbar/fixedToolbar.js
+++ b/tests/integration/fixed-toolbar/fixedToolbar.js
@@ -165,7 +165,7 @@ asyncTest( "Fullscreen toolbars add classes to page", function() {
 
 	$.testHelper.sequence([
 		function(){
-			$.mobile.pageContainer.pagecontainer( "change", "#fullscreen-test-a" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#fullscreen-test-a" );
 		},
 
 		function() {
@@ -194,7 +194,7 @@ asyncTest( "The persistent headers and footers are working properly", function()
 	$.testHelper.pageSequence([
 		function(){
 			ok( nextpageheader.length && nextpagefooter.length, "next page has fixed header and fixed footer" );
-			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-a" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#persist-test-a" );
 		},
 
 		function() {
@@ -203,12 +203,12 @@ asyncTest( "The persistent headers and footers are working properly", function()
 					ok( nextpageheader.parent( ".ui-mobile-viewport" ).length, "fixed header and footer are now a child of page container" );
 				} );
 
-			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-b" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#persist-test-b" );
 		},
 
 		function() {
 			ok( nextpageheader.parent( ".ui-page" ).length, "fixed header and footer are now a child of page again" );
-			$.mobile.pageContainer.pagecontainer( "change", "#default" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#default" );
 		},
 
 		start
@@ -226,21 +226,21 @@ asyncTest( "The persistent headers should work without a footer", function() {
 	$.testHelper.pageSequence([
 		function(){
 			ok( nextpageheader.length, "next page has fixed header and fixed footer" );
-			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-c" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#persist-test-c" );
 		},
 
 		function() {
 			$( "#persist-test-d" )
 				.one( "pagebeforeshow", function() {
-					deepEqual( nextpageheader.parent()[ 0 ], $.mobile.pageContainer[ 0 ], "fixed header is now a child of page container" );
+					deepEqual( nextpageheader.parent()[ 0 ], $( ".ui-pagecontainer" )[ 0 ], "fixed header is now a child of page container" );
 				} );
 
-			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-d" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#persist-test-d" );
 		},
 
 		function() {
 			deepEqual( nextpageheader.parent()[0], $.mobile.activePage[0], "fixed header is now a child of page again" );
-			$.mobile.pageContainer.pagecontainer( "change", "#default" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#default" );
 		},
 
 		start
@@ -258,20 +258,20 @@ asyncTest( "The persistent footers should work without a header", function() {
 	$.testHelper.pageSequence([
 		function(){
 			ok( nextpagefooter.length, "next page has fixed footer and fixed footer" );
-			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-e" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#persist-test-e" );
 		},
 		function() {
 			$( "#persist-test-f" )
 				.one( "pagebeforeshow", function() {
-					deepEqual( nextpagefooter.parent()[ 0 ], $.mobile.pageContainer[ 0 ], "fixed footer is now a child of page container" );
+					deepEqual( nextpagefooter.parent()[ 0 ], $( ".ui-pagecontainer" )[ 0 ], "fixed footer is now a child of page container" );
 				} );
 
-			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-f" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#persist-test-f" );
 		},
 
 		function() {
 			deepEqual( nextpagefooter.parent()[0], $.mobile.activePage[0], "fixed footer is now a child of page again" );
-			$.mobile.pageContainer.pagecontainer( "change", "#default" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#default" );
 		},
 
 		start
@@ -282,7 +282,7 @@ asyncTest( "The persistent footers should work without a header", function() {
 var asyncTestFooterAndHeader = function( pageSelector, visible ) {
 	$.testHelper.pageSequence([
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", pageSelector );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", pageSelector );
 		},
 
 		function() {
@@ -297,7 +297,7 @@ var asyncTestFooterAndHeader = function( pageSelector, visible ) {
 			equal( !$header.hasClass( "ui-fixed-hidden" ), visible, "the header should be " + hiddenStr );
 
 
-			$.mobile.pageContainer.pagecontainer( "change", "#default" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#default" );
 		},
 
 		start
@@ -350,7 +350,7 @@ asyncTest( "page-retains-fixed-header-on-popup-remove", function() {
 
 		function() {
 
-			$.mobile.pageContainer.change( "#default" );
+			$( ".ui-pagecontainer" ).change( "#default" );
 
 		}
 	] );

--- a/tests/integration/fixed-toolbar/fixedToolbar.js
+++ b/tests/integration/fixed-toolbar/fixedToolbar.js
@@ -163,9 +163,9 @@ asyncTest( "The toggle method is working properly", function() {
 asyncTest( "Fullscreen toolbars add classes to page", function() {
 	expect( 2 );
 
-	$.testHelper.sequence( [
-		function() {
-			$.mobile.changePage( "#fullscreen-test-a" );
+	$.testHelper.sequence([
+		function(){
+			$.mobile.pageContainer.pagecontainer( "change", "#fullscreen-test-a" );
 		},
 
 		function() {
@@ -190,10 +190,11 @@ asyncTest( "The persistent headers and footers are working properly", function()
 		nextpagefooter = $( "#persist-test-b .ui-footer-fixed" );
 
 
-	$.testHelper.pageSequence( [
-		function() {
+
+	$.testHelper.pageSequence([
+		function(){
 			ok( nextpageheader.length && nextpagefooter.length, "next page has fixed header and fixed footer" );
-			$.mobile.changePage( "#persist-test-a" );
+			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-a" );
 		},
 
 		function() {
@@ -202,12 +203,12 @@ asyncTest( "The persistent headers and footers are working properly", function()
 					ok( nextpageheader.parent( ".ui-mobile-viewport" ).length, "fixed header and footer are now a child of page container" );
 				} );
 
-			$.mobile.changePage( "#persist-test-b" );
+			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-b" );
 		},
 
 		function() {
 			ok( nextpageheader.parent( ".ui-page" ).length, "fixed header and footer are now a child of page again" );
-			$.mobile.changePage( "#default" );
+			$.mobile.pageContainer.pagecontainer( "change", "#default" );
 		},
 
 		start
@@ -222,10 +223,10 @@ asyncTest( "The persistent headers should work without a footer", function() {
 
 	var nextpageheader = $( "#persist-test-d .ui-header-fixed" );
 
-	$.testHelper.pageSequence( [
-		function() {
+	$.testHelper.pageSequence([
+		function(){
 			ok( nextpageheader.length, "next page has fixed header and fixed footer" );
-			$.mobile.changePage( "#persist-test-c" );
+			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-c" );
 		},
 
 		function() {
@@ -234,12 +235,12 @@ asyncTest( "The persistent headers should work without a footer", function() {
 					deepEqual( nextpageheader.parent()[ 0 ], $.mobile.pageContainer[ 0 ], "fixed header is now a child of page container" );
 				} );
 
-			$.mobile.changePage( "#persist-test-d" );
+			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-d" );
 		},
 
 		function() {
-			deepEqual( nextpageheader.parent()[ 0 ], $.mobile.activePage[ 0 ], "fixed header is now a child of page again" );
-			$.mobile.changePage( "#default" );
+			deepEqual( nextpageheader.parent()[0], $.mobile.activePage[0], "fixed header is now a child of page again" );
+			$.mobile.pageContainer.pagecontainer( "change", "#default" );
 		},
 
 		start
@@ -254,34 +255,34 @@ asyncTest( "The persistent footers should work without a header", function() {
 
 	var nextpagefooter = $( "#persist-test-f .ui-footer-fixed" );
 
-	$.testHelper.pageSequence( [
-		function() {
+	$.testHelper.pageSequence([
+		function(){
 			ok( nextpagefooter.length, "next page has fixed footer and fixed footer" );
-			$.mobile.changePage( "#persist-test-e" );
+			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-e" );
 		},
-
 		function() {
 			$( "#persist-test-f" )
 				.one( "pagebeforeshow", function() {
 					deepEqual( nextpagefooter.parent()[ 0 ], $.mobile.pageContainer[ 0 ], "fixed footer is now a child of page container" );
 				} );
 
-			$.mobile.changePage( "#persist-test-f" );
+			$.mobile.pageContainer.pagecontainer( "change", "#persist-test-f" );
 		},
 
 		function() {
-			deepEqual( nextpagefooter.parent()[ 0 ], $.mobile.activePage[ 0 ], "fixed footer is now a child of page again" );
-			$.mobile.changePage( "#default" );
+			deepEqual( nextpagefooter.parent()[0], $.mobile.activePage[0], "fixed footer is now a child of page again" );
+			$.mobile.pageContainer.pagecontainer( "change", "#default" );
 		},
 
 		start
 	] );
 } );
 
+
 var asyncTestFooterAndHeader = function( pageSelector, visible ) {
-	$.testHelper.pageSequence( [
+	$.testHelper.pageSequence([
 		function() {
-			$.mobile.changePage( pageSelector );
+			$.mobile.pageContainer.pagecontainer( "change", pageSelector );
 		},
 
 		function() {
@@ -295,7 +296,8 @@ var asyncTestFooterAndHeader = function( pageSelector, visible ) {
 			equal( !$footer.hasClass( "ui-fixed-hidden" ), visible, "the footer should be " + hiddenStr );
 			equal( !$header.hasClass( "ui-fixed-hidden" ), visible, "the header should be " + hiddenStr );
 
-			$.mobile.changePage( "#default" );
+
+			$.mobile.pageContainer.pagecontainer( "change", "#default" );
 		},
 
 		start

--- a/tests/integration/listview/listview_core.js
+++ b/tests/integration/listview/listview_core.js
@@ -25,7 +25,7 @@ asyncTest( "The page should be enhanced correctly", function() {
 	expect( 3 );
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#basic-linked-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#basic-linked-test" );
 		},
 
 		function() {
@@ -40,7 +40,7 @@ asyncTest( "The page should be enhanced correctly", function() {
 asyncTest( "Slides to the listview page when the li a is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#basic-linked-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#basic-linked-test" );
 		},
 
 		function() {
@@ -57,7 +57,7 @@ asyncTest( "Slides to the listview page when the li a is clicked", function() {
 asyncTest( "Slides back to main page when back button is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#basic-link-results" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#basic-link-results" );
 		},
 
 		function() {
@@ -74,7 +74,7 @@ asyncTest( "Slides back to main page when back button is clicked", function() {
 asyncTest( "Presence of ui-li-has- classes", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#ui-li-has-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#ui-li-has-test" );
 		},
 
 		function() {
@@ -105,7 +105,7 @@ module( 'Ordered Lists' );
 asyncTest( "changes to the numbered list page and enhances it", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#numbered-list-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#numbered-list-test" );
 		},
 
 		function() {
@@ -133,11 +133,11 @@ asyncTest( "changes to number 1 page when the li a is clicked", function() {
 asyncTest( "takes us back to the numbered list when the back button is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", '#numbered-list-test' );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", '#numbered-list-test' );
 		},
 
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", '#numbered-list-results' );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", '#numbered-list-results' );
 		},
 
 		function() {
@@ -156,7 +156,7 @@ module( 'Read only list' );
 asyncTest( "changes to the read only page when hash is changed", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#read-only-list-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#read-only-list-test" );
 		},
 
 		function() {
@@ -173,7 +173,7 @@ module( 'Split view list' );
 asyncTest( "changes the page to the split view list and enhances it correctly.", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -188,7 +188,7 @@ asyncTest( "changes the page to the split view list and enhances it correctly.",
 asyncTest( "change the page to the split view page 1 when the first link is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -205,7 +205,7 @@ asyncTest( "change the page to the split view page 1 when the first link is clic
 asyncTest( "Slide back to the parent list view when the back button is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -226,7 +226,7 @@ asyncTest( "Slide back to the parent list view when the back button is clicked",
 asyncTest( "Clicking on the icon (the second link) should take the user to other a href of this LI", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -245,7 +245,7 @@ module( "List Dividers" );
 asyncTest( "Makes the list divider page the active page and enhances it correctly.", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#list-divider-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#list-divider-test" );
 		},
 
 		function() {
@@ -469,7 +469,7 @@ asyncTest( "Corner styling on programmatically created list items", function() {
 	// https://github.com/jquery/jquery-mobile/issues/1470
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#programmatically-generated-list" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#programmatically-generated-list" );
 		},
 		function() {
 			ok( !$( "#programmatically-generated-list-items li:first-child" ).hasClass( "ui-last-child" ), "First list item should not have class ui-last-child" );
@@ -483,7 +483,7 @@ module( "Programmatic list items manipulation" );
 asyncTest( "Removing list items", 4, function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#removing-items-from-list-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#removing-items-from-list-test" );
 		},
 
 		function() {
@@ -509,7 +509,7 @@ module( "Rounded corners" );
 asyncTest( "Top and bottom corners rounded in inset list", 14, function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#corner-rounded-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#corner-rounded-test" );
 		},
 
 		function() {
@@ -549,7 +549,7 @@ module( "Cached Linked List" );
 asyncTest( "list inherits theme from parent", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#list-theme-inherit" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#list-theme-inherit" );
 		},
 
 		function() {
@@ -565,7 +565,7 @@ asyncTest( "list inherits theme from parent", function() {
 asyncTest( "split list items respect the icon", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#split-list-icon" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#split-list-icon" );
 		},
 
 		function() {
@@ -586,7 +586,7 @@ asyncTest( "split list items respect the icon", function() {
 asyncTest( "links in list dividers are ignored", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#list-divider-ignore-link" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#list-divider-ignore-link" );
 		},
 
 		function() {
@@ -604,7 +604,7 @@ module( "Borders" );
 asyncTest( "last list item has border-bottom", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#list-last-visible-item-border" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#list-last-visible-item-border" );
 		},
 
 		function() {
@@ -621,7 +621,7 @@ asyncTest( "last list item has border-bottom", function() {
 asyncTest( "list inside collapsible content", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#list-inside-collapsible-content" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#list-inside-collapsible-content" );
 		},
 
 		function() {

--- a/tests/integration/listview/listview_core.js
+++ b/tests/integration/listview/listview_core.js
@@ -25,7 +25,7 @@ asyncTest( "The page should be enhanced correctly", function() {
 	expect( 3 );
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#basic-linked-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#basic-linked-test" );
 		},
 
 		function() {
@@ -40,7 +40,7 @@ asyncTest( "The page should be enhanced correctly", function() {
 asyncTest( "Slides to the listview page when the li a is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#basic-linked-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#basic-linked-test" );
 		},
 
 		function() {
@@ -57,7 +57,7 @@ asyncTest( "Slides to the listview page when the li a is clicked", function() {
 asyncTest( "Slides back to main page when back button is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#basic-link-results" );
+			$.mobile.pageContainer.pagecontainer( "change", "#basic-link-results" );
 		},
 
 		function() {
@@ -74,7 +74,7 @@ asyncTest( "Slides back to main page when back button is clicked", function() {
 asyncTest( "Presence of ui-li-has- classes", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#ui-li-has-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#ui-li-has-test" );
 		},
 
 		function() {
@@ -105,7 +105,7 @@ module( 'Ordered Lists' );
 asyncTest( "changes to the numbered list page and enhances it", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#numbered-list-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#numbered-list-test" );
 		},
 
 		function() {
@@ -133,11 +133,11 @@ asyncTest( "changes to number 1 page when the li a is clicked", function() {
 asyncTest( "takes us back to the numbered list when the back button is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( '#numbered-list-test' );
+			$.mobile.pageContainer.pagecontainer( "change", '#numbered-list-test' );
 		},
 
 		function() {
-			$.mobile.changePage( '#numbered-list-results' );
+			$.mobile.pageContainer.pagecontainer( "change", '#numbered-list-results' );
 		},
 
 		function() {
@@ -156,7 +156,7 @@ module( 'Read only list' );
 asyncTest( "changes to the read only page when hash is changed", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#read-only-list-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#read-only-list-test" );
 		},
 
 		function() {
@@ -173,7 +173,7 @@ module( 'Split view list' );
 asyncTest( "changes the page to the split view list and enhances it correctly.", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#split-list-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -188,7 +188,7 @@ asyncTest( "changes the page to the split view list and enhances it correctly.",
 asyncTest( "change the page to the split view page 1 when the first link is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#split-list-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -205,7 +205,7 @@ asyncTest( "change the page to the split view page 1 when the first link is clic
 asyncTest( "Slide back to the parent list view when the back button is clicked", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#split-list-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -226,7 +226,7 @@ asyncTest( "Slide back to the parent list view when the back button is clicked",
 asyncTest( "Clicking on the icon (the second link) should take the user to other a href of this LI", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#split-list-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#split-list-test" );
 		},
 
 		function() {
@@ -245,7 +245,7 @@ module( "List Dividers" );
 asyncTest( "Makes the list divider page the active page and enhances it correctly.", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#list-divider-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#list-divider-test" );
 		},
 
 		function() {
@@ -469,7 +469,7 @@ asyncTest( "Corner styling on programmatically created list items", function() {
 	// https://github.com/jquery/jquery-mobile/issues/1470
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#programmatically-generated-list" );
+			$.mobile.pageContainer.pagecontainer( "change", "#programmatically-generated-list" );
 		},
 		function() {
 			ok( !$( "#programmatically-generated-list-items li:first-child" ).hasClass( "ui-last-child" ), "First list item should not have class ui-last-child" );
@@ -483,7 +483,7 @@ module( "Programmatic list items manipulation" );
 asyncTest( "Removing list items", 4, function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#removing-items-from-list-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#removing-items-from-list-test" );
 		},
 
 		function() {
@@ -509,7 +509,7 @@ module( "Rounded corners" );
 asyncTest( "Top and bottom corners rounded in inset list", 14, function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#corner-rounded-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#corner-rounded-test" );
 		},
 
 		function() {
@@ -549,7 +549,7 @@ module( "Cached Linked List" );
 asyncTest( "list inherits theme from parent", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#list-theme-inherit" );
+			$.mobile.pageContainer.pagecontainer( "change", "#list-theme-inherit" );
 		},
 
 		function() {
@@ -565,7 +565,7 @@ asyncTest( "list inherits theme from parent", function() {
 asyncTest( "split list items respect the icon", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#split-list-icon" );
+			$.mobile.pageContainer.pagecontainer( "change", "#split-list-icon" );
 		},
 
 		function() {
@@ -586,7 +586,7 @@ asyncTest( "split list items respect the icon", function() {
 asyncTest( "links in list dividers are ignored", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#list-divider-ignore-link" );
+			$.mobile.pageContainer.pagecontainer( "change", "#list-divider-ignore-link" );
 		},
 
 		function() {
@@ -604,7 +604,7 @@ module( "Borders" );
 asyncTest( "last list item has border-bottom", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#list-last-visible-item-border" );
+			$.mobile.pageContainer.pagecontainer( "change", "#list-last-visible-item-border" );
 		},
 
 		function() {
@@ -621,7 +621,7 @@ asyncTest( "last list item has border-bottom", function() {
 asyncTest( "list inside collapsible content", function() {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#list-inside-collapsible-content" );
+			$.mobile.pageContainer.pagecontainer( "change", "#list-inside-collapsible-content" );
 		},
 
 		function() {

--- a/tests/integration/navigation/navigation_base.js
+++ b/tests/integration/navigation/navigation_base.js
@@ -90,8 +90,8 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 				report: "navigate from a page in a non-base directory to an internal page"
 			} );
 
-			// Try calling changePage() directly with a relative path.
-			$.mobile.changePage( "base-page-1.html" );
+			// Try calling change() directly with a relative path.
+			$.mobile.pageContainer.pagecontainer( "change", "base-page-1.html" );
 		},
 
 		function() {
@@ -102,7 +102,7 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 			} );
 
 			// Try calling changePage() directly with a relative path.
-			$.mobile.changePage( "../content/content-page-1.html" );
+			$.mobile.pageContainer.pagecontainer( "change", "../content/content-page-1.html" );
 		},
 
 		function() {
@@ -113,7 +113,7 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 			} );
 
 			// Try calling changePage() with an id
-			$.mobile.changePage( "content-page-2.html" );
+			$.mobile.pageContainer.pagecontainer( "change", "content-page-2.html" );
 		},
 
 		function() {
@@ -136,8 +136,8 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 				report: "call changePage() with a page id"
 			} );
 
-			// Try calling changePage() with an id
-			$.mobile.changePage( "internal-page-1" );
+			// Try calling change() with an id
+			$.mobile.pageContainer.pagecontainer( "change", "internal-page-1" );
 		},
 
 		function() {
@@ -145,7 +145,7 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 			$.testHelper.assertUrlLocation( assert, {
 				hash: "internal-page-2",
 				push: home + "#internal-page-2",
-				report: "calling changePage() with a page id that is not prefixed with '#' " +
+				report: "calling change() with a page id that is not prefixed with '#' " +
 					"should not change page"
 			} );
 
@@ -209,7 +209,7 @@ asyncTest( "external page form with no action submits to external page URL", fun
 var testBaseTagAlteration = function( assertions ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "../../base-change.html" );
+			$.mobile.pageContainer.pagecontainer( "change", "../../base-change.html" );
 		},
 
 		function() {

--- a/tests/integration/navigation/navigation_base.js
+++ b/tests/integration/navigation/navigation_base.js
@@ -91,7 +91,7 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 			} );
 
 			// Try calling change() directly with a relative path.
-			$.mobile.pageContainer.pagecontainer( "change", "base-page-1.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "base-page-1.html" );
 		},
 
 		function() {
@@ -102,7 +102,7 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 			} );
 
 			// Try calling changePage() directly with a relative path.
-			$.mobile.pageContainer.pagecontainer( "change", "../content/content-page-1.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "../content/content-page-1.html" );
 		},
 
 		function() {
@@ -113,7 +113,7 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 			} );
 
 			// Try calling changePage() with an id
-			$.mobile.pageContainer.pagecontainer( "change", "content-page-2.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "content-page-2.html" );
 		},
 
 		function() {
@@ -137,7 +137,7 @@ asyncTest( "can navigate between internal and external pages", function( assert 
 			} );
 
 			// Try calling change() with an id
-			$.mobile.pageContainer.pagecontainer( "change", "internal-page-1" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "internal-page-1" );
 		},
 
 		function() {
@@ -209,7 +209,7 @@ asyncTest( "external page form with no action submits to external page URL", fun
 var testBaseTagAlteration = function( assertions ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "../../base-change.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "../../base-change.html" );
 		},
 
 		function() {

--- a/tests/integration/navigation/navigation_core.js
+++ b/tests/integration/navigation/navigation_core.js
@@ -4,7 +4,7 @@
 $.testHelper.delayStart();
 
 // TODO move siteDirectory over to the nav path helper
-var changePageFn = $.mobile.changePage,
+var changePageFn = $.mobile.pagecontainer.prototype.change,
 	originalTitle = document.title,
 	originalLinkBinding = $.mobile.linkBindingEnabled,
 	siteDirectory = location.pathname.replace( /[^/]+$/, "" ),
@@ -89,7 +89,7 @@ QUnit.module( "jquery.mobile.navigation.js", {
 	teardown: function() {
 		$.Event.prototype.which = undefined;
 		$.mobile.linkBindingEnabled = originalLinkBinding;
-		$.mobile.changePage = changePageFn;
+		$.mobile.pagecontainer.prototype.change = changePageFn;
 		document.title = originalTitle;
 	}
 } );
@@ -127,7 +127,7 @@ QUnit.asyncTest( "window.history.back() from external to internal page", functio
 QUnit.asyncTest( "external empty page does not result in any contents", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "blank.html" );
+			$.mobile.pageContainer.pagecontainer( "change", "blank.html" );
 		},
 
 		function() {
@@ -145,7 +145,7 @@ QUnit.asyncTest( "external empty page does not result in any contents", function
 QUnit.asyncTest( "external page is removed from the DOM after pagehide", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "external.html" );
+			$.mobile.pageContainer.pagecontainer( "change", "external.html" );
 		},
 
 		// Page is pulled and displayed in the dom
@@ -175,7 +175,7 @@ QUnit.asyncTest( "preventDefault on pageremove prevents external page from being
 
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.changePage( "external.html" );
+				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
 			},
 
 			// Page is pulled and displayed in the dom
@@ -189,7 +189,7 @@ QUnit.asyncTest( "preventDefault on pageremove prevents external page from being
 				assert.strictEqual( $( "#external-test" ).length, 1 );
 
 				// Switch back to the page again!
-				$.mobile.changePage( "external.html" );
+				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
 			},
 
 			// Page is still present and displayed in the dom
@@ -214,7 +214,7 @@ QUnit.asyncTest( "preventDefault on pageremove prevents external page from being
 QUnit.asyncTest( "external page is cached in the DOM after pagehide", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "cached-external.html" );
+			$.mobile.pageContainer.pagecontainer( "change", "cached-external.html" );
 		},
 
 		// Page is pulled and displayed in the dom
@@ -236,7 +236,7 @@ QUnit.asyncTest( "external page is cached after pagehide when option is set glob
 		$.testHelper.pageSequence( [
 			function() {
 				$.mobile.page.prototype.options.domCache = true;
-				$.mobile.changePage( "external.html" );
+				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
 			},
 
 			// Page is pulled and displayed in the dom
@@ -259,7 +259,7 @@ QUnit.asyncTest( "page last scroll distance is remembered when navigating to/fro
 		$.testHelper.pageSequence( [
 			function() {
 				$( "body" ).height( $( window ).height() + 500 );
-				$.mobile.changePage( "external.html" );
+				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
 			},
 
 			function() {
@@ -293,7 +293,7 @@ QUnit.asyncTest( "page last scroll distance is remembered when navigating to/fro
 		] );
 	} );
 
-QUnit.asyncTest( "forms with data attribute ajax set to false will not call changePage",
+QUnit.asyncTest( "forms with data attribute ajax set to false will not call change()",
 	function( assert ) {
 		var called = false;
 		var newChangePage = function() {
@@ -302,9 +302,9 @@ QUnit.asyncTest( "forms with data attribute ajax set to false will not call chan
 
 		$.testHelper.sequence( [
 
-			// Avoid initial page load triggering changePage early
+			// Avoid initial page load triggering change() early
 			function() {
-				$.mobile.changePage = newChangePage;
+				$.mobile.pagecontainer.prototype.change = newChangePage;
 
 				$( "#non-ajax-form" ).one( "submit", function( event ) {
 					assert.ok( true, "submit callbacks are fired" );
@@ -319,7 +319,7 @@ QUnit.asyncTest( "forms with data attribute ajax set to false will not call chan
 	} );
 
 QUnit.asyncTest(
-	"forms with ajax attribute absent or set to anything but false will call changePage",
+	"forms with data-ajax attribute absent/set or set to anything but false will call change()",
 	function( assert ) {
 		var called = 0,
 			newChangePage = function() {
@@ -328,9 +328,9 @@ QUnit.asyncTest(
 
 		$.testHelper.sequence( [
 
-			// Avoid initial page load triggering changePage early
+			// Avoid initial page load triggering change() early
 			function() {
-				$.mobile.changePage = newChangePage;
+				$.mobile.pagecontainer.prototype.change = newChangePage;
 				$( "#ajax-form, #rand-ajax-form" ).submit();
 			},
 
@@ -520,7 +520,7 @@ QUnit.asyncTest(
 
 			// Setup
 			function() {
-				$.mobile.changePage( "#skip-dialog-first" );
+				$.mobile.pageContainer.pagecontainer( "change", "#skip-dialog-first" );
 			},
 
 			// Transition to the dialog
@@ -998,13 +998,13 @@ QUnit.asyncTest( "query param link from a dialog to itself should be a not add a
 		] );
 	} );
 
-QUnit.asyncTest( "query data passed as a string to changePage is appended to URL",
+QUnit.asyncTest( "query data passed as a string to change() is appended to URL",
 	function( assert ) {
 		$.testHelper.pageSequence( [
 
 			// Open our test page
 			function() {
-				$.mobile.changePage( "form-tests/changepage-data.html", {
+				$.mobile.pageContainer.pagecontainer( "change", "form-tests/changepage-data.html", {
 					data: "foo=1&bar=2"
 				} );
 			},
@@ -1020,13 +1020,13 @@ QUnit.asyncTest( "query data passed as a string to changePage is appended to URL
 		] );
 	} );
 
-QUnit.asyncTest( "query data passed as an object to changePage is appended to URL",
+QUnit.asyncTest( "query data passed as an object to change() is appended to URL",
 	function( assert ) {
 		$.testHelper.pageSequence( [
 
 			// Open our test page
 			function() {
-				$.mobile.changePage( "form-tests/changepage-data.html", {
+				$.mobile.pageContainer.pagecontainer( "change", "form-tests/changepage-data.html", {
 					data: {
 						foo: 3,
 						bar: 4
@@ -1319,7 +1319,7 @@ QUnit.asyncTest( "application url with dialogHashKey loads first application pag
 					"navigated successfully to #foo" );
 
 				// Now navigate to an hash that contains just a dialogHashKey.
-				$.mobile.changePage( "#" + $.mobile.dialogHashKey );
+				$.mobile.pageContainer.pagecontainer( "change", "#" + $.mobile.dialogHashKey );
 			},
 
 			function() {
@@ -1507,7 +1507,7 @@ QUnit.asyncTest( "clicks are ignored where data-ajax='false' parents exist", fun
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#link-hijacking-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#link-hijacking-test" );
 		},
 
 		function() {
@@ -1552,7 +1552,7 @@ QUnit.asyncTest( "vclicks are ignored where data-ajax='false' parents exist", fu
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#link-hijacking-test" );
+			$.mobile.pageContainer.pagecontainer( "change", "#link-hijacking-test" );
 		},
 
 		function() {
@@ -1580,7 +1580,8 @@ QUnit.asyncTest( "vclicks are ignored where data-ajax='false' parents exist", fu
 QUnit.asyncTest( "data-urls with parens work properly (avoid jqmData regex)", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "data-url-tests/parentheses.html?foo=(bar)" );
+			$.mobile.pageContainer.pagecontainer( "change",
+				"data-url-tests/parentheses.html?foo=(bar)" );
 		},
 
 		function() {
@@ -1602,7 +1603,7 @@ QUnit.asyncTest( "data-urls with parens work properly (avoid jqmData regex)", fu
 QUnit.asyncTest( "loading an embedded page with query params works", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#bar?baz=bak", { dataUrl: false } );
+			$.mobile.pageContainer.pagecontainer( "change", "#bar?baz=bak", { dataUrl: false } );
 		},
 
 		function() {
@@ -1618,7 +1619,7 @@ QUnit.asyncTest( "external page is accessed correctly even if it has a space in 
 	function( assert ) {
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.changePage( " external.html" );
+				$.mobile.pageContainer.pagecontainer( "change", " external.html" );
 			},
 			function() {
 				assert.equal( $.mobile.activePage.attr( "id" ), "external-test",
@@ -1646,7 +1647,7 @@ QUnit.asyncTest( "page load events are providided with the absolute url for the 
 			assert.equal( data.absUrl, absHomeUrl + "#bar" );
 		} );
 
-		$.mobile.changePage( "#bar" );
+		$.mobile.pageContainer.pagecontainer( "change", "#bar" );
 
 		requestPath = "/theres/no/way/this/page/exists.html";
 
@@ -1655,7 +1656,7 @@ QUnit.asyncTest( "page load events are providided with the absolute url for the 
 			QUnit.start();
 		} );
 
-		$.mobile.changePage( requestPath );
+		$.mobile.pageContainer.pagecontainer( "change", requestPath );
 	} );
 
 } )( QUnit, jQuery );

--- a/tests/integration/navigation/navigation_core.js
+++ b/tests/integration/navigation/navigation_core.js
@@ -127,7 +127,7 @@ QUnit.asyncTest( "window.history.back() from external to internal page", functio
 QUnit.asyncTest( "external empty page does not result in any contents", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "blank.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "blank.html" );
 		},
 
 		function() {
@@ -145,7 +145,7 @@ QUnit.asyncTest( "external empty page does not result in any contents", function
 QUnit.asyncTest( "external page is removed from the DOM after pagehide", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "external.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "external.html" );
 		},
 
 		// Page is pulled and displayed in the dom
@@ -175,7 +175,7 @@ QUnit.asyncTest( "preventDefault on pageremove prevents external page from being
 
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "external.html" );
 			},
 
 			// Page is pulled and displayed in the dom
@@ -189,7 +189,7 @@ QUnit.asyncTest( "preventDefault on pageremove prevents external page from being
 				assert.strictEqual( $( "#external-test" ).length, 1 );
 
 				// Switch back to the page again!
-				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "external.html" );
 			},
 
 			// Page is still present and displayed in the dom
@@ -214,7 +214,7 @@ QUnit.asyncTest( "preventDefault on pageremove prevents external page from being
 QUnit.asyncTest( "external page is cached in the DOM after pagehide", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "cached-external.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "cached-external.html" );
 		},
 
 		// Page is pulled and displayed in the dom
@@ -236,7 +236,7 @@ QUnit.asyncTest( "external page is cached after pagehide when option is set glob
 		$.testHelper.pageSequence( [
 			function() {
 				$.mobile.page.prototype.options.domCache = true;
-				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "external.html" );
 			},
 
 			// Page is pulled and displayed in the dom
@@ -259,7 +259,7 @@ QUnit.asyncTest( "page last scroll distance is remembered when navigating to/fro
 		$.testHelper.pageSequence( [
 			function() {
 				$( "body" ).height( $( window ).height() + 500 );
-				$.mobile.pageContainer.pagecontainer( "change", "external.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "external.html" );
 			},
 
 			function() {
@@ -520,7 +520,7 @@ QUnit.asyncTest(
 
 			// Setup
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "#skip-dialog-first" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "#skip-dialog-first" );
 			},
 
 			// Transition to the dialog
@@ -1004,9 +1004,12 @@ QUnit.asyncTest( "query data passed as a string to change() is appended to URL",
 
 			// Open our test page
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "form-tests/changepage-data.html", {
-					data: "foo=1&bar=2"
-				} );
+				$( ".ui-pagecontainer" ).pagecontainer( "change",
+					"form-tests/changepage-data.html",
+					{
+						data: "foo=1&bar=2"
+					}
+				);
 			},
 
 			function() {
@@ -1026,7 +1029,8 @@ QUnit.asyncTest( "query data passed as an object to change() is appended to URL"
 
 			// Open our test page
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "form-tests/changepage-data.html", {
+				$( ".ui-pagecontainer" ).pagecontainer( "change",
+					"form-tests/changepage-data.html", {
 					data: {
 						foo: 3,
 						bar: 4
@@ -1319,7 +1323,7 @@ QUnit.asyncTest( "application url with dialogHashKey loads first application pag
 					"navigated successfully to #foo" );
 
 				// Now navigate to an hash that contains just a dialogHashKey.
-				$.mobile.pageContainer.pagecontainer( "change", "#" + $.mobile.dialogHashKey );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "#" + $.mobile.dialogHashKey );
 			},
 
 			function() {
@@ -1507,7 +1511,7 @@ QUnit.asyncTest( "clicks are ignored where data-ajax='false' parents exist", fun
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#link-hijacking-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#link-hijacking-test" );
 		},
 
 		function() {
@@ -1552,7 +1556,7 @@ QUnit.asyncTest( "vclicks are ignored where data-ajax='false' parents exist", fu
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#link-hijacking-test" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#link-hijacking-test" );
 		},
 
 		function() {
@@ -1580,7 +1584,7 @@ QUnit.asyncTest( "vclicks are ignored where data-ajax='false' parents exist", fu
 QUnit.asyncTest( "data-urls with parens work properly (avoid jqmData regex)", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change",
+			$( ".ui-pagecontainer" ).pagecontainer( "change",
 				"data-url-tests/parentheses.html?foo=(bar)" );
 		},
 
@@ -1603,7 +1607,7 @@ QUnit.asyncTest( "data-urls with parens work properly (avoid jqmData regex)", fu
 QUnit.asyncTest( "loading an embedded page with query params works", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#bar?baz=bak", { dataUrl: false } );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#bar?baz=bak", { dataUrl: false } );
 		},
 
 		function() {
@@ -1619,7 +1623,7 @@ QUnit.asyncTest( "external page is accessed correctly even if it has a space in 
 	function( assert ) {
 		$.testHelper.pageSequence( [
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", " external.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", " external.html" );
 			},
 			function() {
 				assert.equal( $.mobile.activePage.attr( "id" ), "external-test",
@@ -1647,7 +1651,7 @@ QUnit.asyncTest( "page load events are providided with the absolute url for the 
 			assert.equal( data.absUrl, absHomeUrl + "#bar" );
 		} );
 
-		$.mobile.pageContainer.pagecontainer( "change", "#bar" );
+		$( ".ui-pagecontainer" ).pagecontainer( "change", "#bar" );
 
 		requestPath = "/theres/no/way/this/page/exists.html";
 
@@ -1656,7 +1660,7 @@ QUnit.asyncTest( "page load events are providided with the absolute url for the 
 			QUnit.start();
 		} );
 
-		$.mobile.pageContainer.pagecontainer( "change", requestPath );
+		$( ".ui-pagecontainer" ).pagecontainer( "change", requestPath );
 	} );
 
 } )( QUnit, jQuery );

--- a/tests/integration/navigation/sequence/sequence_core.js
+++ b/tests/integration/navigation/sequence/sequence_core.js
@@ -51,7 +51,7 @@ asyncTest( "Navigating to an internal page", function() {
 			$( "#openInternalPage" ).click();
 		},
 		{
-			pagecontainerchange: { src: $.mobile.pageContainer, event: "pagecontainerchange" + eventNs + "1" }
+			pagecontainerchange: { src: $( ".ui-pagecontainer" ), event: "pagecontainerchange" + eventNs + "1" }
 		},
 		function() {
 			deepEqual( location.href, origUrl.indexOf( "#" ) >= 0 ?
@@ -61,7 +61,7 @@ asyncTest( "Navigating to an internal page", function() {
 			$.mobile.back();
 		},
 		{
-			pagecontainerchange: { src: $.mobile.pageContainer, event: "pagecontainerchange" + eventNs + "2" }
+			pagecontainerchange: { src: $( ".ui-pagecontainer" ), event: "pagecontainerchange" + eventNs + "2" }
 		},
 		start
 	] );
@@ -76,14 +76,14 @@ asyncTest( "Returning from a dialog results in the page from which it opened", f
 			$( "#openBasicDialog" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "1" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "1" }
 		},
 		function( result ) {
 			ok( $.mobile.activePage.attr( "id" ) === "basicDialog", "Basic dialog has opened" );
 			$( "a:first", $.mobile.activePage[ 0 ] ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Active page is original page" );
@@ -140,14 +140,14 @@ asyncTest( "Going from a dialog to another page works", function() {
 			$( "#openBasicDialog" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "1" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "1" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicDialog", "Basic dialog has opened" );
 			$( "#fromDialogToAnotherPage" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 
 		function() {
@@ -155,7 +155,7 @@ asyncTest( "Going from a dialog to another page works", function() {
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Coming back from another page to the start page works" );
@@ -183,14 +183,14 @@ asyncTest( "Going from a popup to another page works", function() {
 			$( "#openPageFromPopup" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherPage", "Landed on another page" );
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Coming back from another page to the start page works" );
@@ -210,14 +210,14 @@ asyncTest( "Opening one dialog followed by opening another dialog works", functi
 			$( "#openBasicDialog" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "1" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "1" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicDialog", "Basic dialog has opened" );
 			$( "a:first", $.mobile.activePage[ 0 ] ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 
 		// NOTE: The second part of this test is also a copy of the test above
@@ -226,14 +226,14 @@ asyncTest( "Opening one dialog followed by opening another dialog works", functi
 			$( "#openAnotherDialog" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherDialog", "Another dialog has opened" );
 			$( "a:first", $.mobile.activePage[ 0 ] ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Active page is original page" );
@@ -305,28 +305,28 @@ asyncTest( "Opening another page after returning from a dialog works", function(
 			$( "#openBasicDialog" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "1" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "1" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicDialog", "Basic dialog has opened" );
 			$( "a:first", $.mobile.activePage[ 0 ] ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Active page is original page" );
 			$( "#openAnotherPage" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherPage", "Landed on another page" );
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Active page is original page" );
@@ -366,14 +366,14 @@ asyncTest( "Opening another page after returning from a popup works", function()
 			$( "#openAnotherPage" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherPage", "Landed on another page" );
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Active page is original page" );
@@ -392,7 +392,7 @@ asyncTest( "Sequence page1 -> dialog1 -> popup1 -> page2 <- back", function() {
 			$( "#openBasicDialog" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "1" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "1" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicDialog", "Basic dialog has opened" );
@@ -411,7 +411,7 @@ asyncTest( "Sequence page1 -> dialog1 -> popup1 -> page2 <- back", function() {
 			popupafterclose: { src: function() {
 					return $( "#popupFromBasicDialog" );
 			}, event: "popupafterclose" + eventNs + "3" },
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function( result ) {
 			ok( !result.popupafterclose.timedOut, "Popup emitted 'popupafterclose'" );
@@ -419,7 +419,7 @@ asyncTest( "Sequence page1 -> dialog1 -> popup1 -> page2 <- back", function() {
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Active page is original page" );
@@ -447,21 +447,21 @@ asyncTest( "Sequence page1 -> popup1 -> dialog1 -> page2 <- back", function() {
 			$( "#openDialogFromPopup" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicDialog", "Basic dialog has opened" );
 			$( "#fromDialogToAnotherPage" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherPage", "Landed on another page" );
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Coming back from another page to the start page works" );
@@ -492,7 +492,7 @@ asyncTest( "Sequence page -> popup1 -> dialog -> popup2 <- back <- back", functi
 			popupafterclose: { src: function() {
 					return $( "#thePopup" );
 			}, event: "popupafterclose" + eventNs + "2" },
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 		function( result ) {
 			ok( !result.popupafterclose.timedOut, "Popup emitted 'popupafterclose'" );
@@ -519,7 +519,7 @@ asyncTest( "Sequence page -> popup1 -> dialog -> popup2 <- back <- back", functi
 			$( "a:first", $.mobile.activePage[ 0 ] ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 		function( result ) {
 			ok( !result.pagechange.timedOut, "A pagechange event has occurred as a result of returning from the dialog" );
@@ -539,14 +539,14 @@ asyncTest( "Sequence page1 -> dialog -> page2 <- back -> forward <- back", funct
 			$( "#openBasicDialog" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "1" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "1" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicDialog", "Basic dialog has opened" );
 			$( "#fromDialogToAnotherPage" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 
 		function() {
@@ -554,21 +554,21 @@ asyncTest( "Sequence page1 -> dialog -> page2 <- back -> forward <- back", funct
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Coming back from another page to the start page works" );
 			window.history.forward();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherPage", "Landed on another page after going forward" );
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Coming back from another page to the start page works again" );
@@ -596,28 +596,28 @@ asyncTest( "Sequence page1 -> popup -> page2 <- back -> forward <- back", functi
 			$( "#openPageFromPopup" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "2" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "2" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherPage", "Landed on another page" );
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Coming back from another page to the start page works" );
 			window.history.forward();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "anotherPage", "Landed on another page after going forward" );
 			$.mobile.back();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "4" }
 		},
 		function() {
 			ok( $.mobile.activePage.attr( "id" ) === "basicTestPage", "Coming back from another page to the start page works again" );
@@ -637,7 +637,7 @@ asyncTest( "Sequence page1 -> page2 -> popup -> page-styled-as-dialog <- back", 
 		},
 		{
 			pagecontainerchange: {
-				src: $.mobile.pageContainer,
+				src: $( ".ui-pagecontainer" ),
 				event: "pagecontainerchange" + eventNs + "1"
 			}
 		},
@@ -659,7 +659,7 @@ asyncTest( "Sequence page1 -> page2 -> popup -> page-styled-as-dialog <- back", 
 		},
 		{
 			pagecontainerchange: {
-				src: $.mobile.pageContainer,
+				src: $( ".ui-pagecontainer" ),
 				event: "pagecontainerchange" + eventNs + "3"
 			}
 		},
@@ -670,7 +670,7 @@ asyncTest( "Sequence page1 -> page2 -> popup -> page-styled-as-dialog <- back", 
 		},
 		{
 			pagecontainerchange: {
-				src: $.mobile.pageContainer,
+				src: $( ".ui-pagecontainer" ),
 				event: "pagecontainerchange" + eventNs + "4"
 			}
 		},
@@ -681,7 +681,7 @@ asyncTest( "Sequence page1 -> page2 -> popup -> page-styled-as-dialog <- back", 
 		},
 		{
 			pagecontainerchange: {
-				src: $.mobile.pageContainer,
+				src: $( ".ui-pagecontainer" ),
 				event: "pagecontainerchange" + eventNs + "4"
 			}
 		},

--- a/tests/integration/pagecontainer/page_load_failure_core.js
+++ b/tests/integration/pagecontainer/page_load_failure_core.js
@@ -15,13 +15,13 @@ $( document ).on( "pagecontainerloadfailed", function( event ) {
 				$( "#go-to-other-page" ).click();
 			},
 			function() {
-				deepEqual( $.mobile.pageContainer.pagecontainer( "getActivePage" )
+				deepEqual( $( ".ui-pagecontainer" ).pagecontainer( "getActivePage" )
 					.attr( "id" ), "other-page",
 					"The other page is the active page" );
 				$.mobile.back();
 			},
 			function() {
-				deepEqual( $.mobile.pageContainer.pagecontainer( "getActivePage" )
+				deepEqual( $( ".ui-pagecontainer" ).pagecontainer( "getActivePage" )
 					.attr( "id" ), "start-page",
 					"Returned to start page" );
 				start();

--- a/tests/integration/popup/popup_core.js
+++ b/tests/integration/popup/popup_core.js
@@ -158,7 +158,7 @@ asyncTest( "Popup does not go back in history twice when opening on separate pag
 			$( "#go-to-another-page" ).click();
 		},
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + eventNs + "1" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + eventNs + "1" }
 		},
 		function() {
 			strictEqual( $.mobile.activePage.attr( "id" ), "another-page",
@@ -403,7 +403,7 @@ asyncTest( "Opening another page from the popup leaves no trace of the popup in 
 					event: $.event.special.navigate.originalEventName + ".anotherPageStep3"
 				},
 				pagechange: {
-					src: $.mobile.pageContainer,
+					src: $( ".ui-pagecontainer" ),
 					event: "pagechange.anotherPageStep3"
 				}
 			},
@@ -552,7 +552,7 @@ asyncTest( "Navigating away from the popup page closes the no-history popup", fu
 
 		function() {
 			ok( $popup.is( ":visible" ), "popup is indeed visible" );
-			$.mobile.pageContainer.pagecontainer( "change", "#no-popups" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#no-popups" );
 		},
 
 		{

--- a/tests/integration/popup/popup_core.js
+++ b/tests/integration/popup/popup_core.js
@@ -552,7 +552,7 @@ asyncTest( "Navigating away from the popup page closes the no-history popup", fu
 
 		function() {
 			ok( $popup.is( ":visible" ), "popup is indeed visible" );
-			$.mobile.changePage( "#no-popups" );
+			$.mobile.pageContainer.pagecontainer( "change", "#no-popups" );
 		},
 
 		{

--- a/tests/integration/select/button_focus_core.js
+++ b/tests/integration/select/button_focus_core.js
@@ -15,7 +15,7 @@ function defineTest( testName, clickAction, expectChange ) {
 				}
 			},
 			function( result ) {
-				var activePage = $.mobile.pageContainer.pagecontainer( "getActivePage" );
+				var activePage = $( ".ui-pagecontainer" ).pagecontainer( "getActivePage" );
 
 				deepEqual( result.pagecontainerchange.timedOut, false, "Page change has occurred" );
 				deepEqual( activePage.attr( "id" ), "button-focus-test-dialog", "Dialog is active" );
@@ -37,7 +37,7 @@ function defineTest( testName, clickAction, expectChange ) {
 				}
 			} : {} ) ),
 			function( result ) {
-				var activePage = $.mobile.pageContainer.pagecontainer( "getActivePage" );
+				var activePage = $( ".ui-pagecontainer" ).pagecontainer( "getActivePage" );
 
 				deepEqual( result.pagecontainerchange.timedOut, false, "Page change has occurred" );
 				deepEqual( activePage.attr( "id" ), "default", "Default page is active" );

--- a/tests/integration/select/select_cached.js
+++ b/tests/integration/select/select_cached.js
@@ -22,7 +22,7 @@ QUnit.asyncTest( "dialog sized select should alter the value of its parent selec
 			resetHash,
 
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "cached.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "cached.html" );
 			},
 
 			function() {
@@ -59,7 +59,7 @@ QUnit.asyncTest( "dialog sized select should prevent the removal of its parent p
 			resetHash,
 
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "cached.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "cached.html" );
 			},
 
 			function() {
@@ -88,7 +88,7 @@ QUnit.asyncTest( "dialog sized select shouldn't rebind its parent page remove ha
 			resetHash,
 
 			function() {
-				$.mobile.pageContainer.pagecontainer( "change", "cached-dom-cache-true.html" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "cached-dom-cache-true.html" );
 			},
 
 			function() {
@@ -103,7 +103,7 @@ QUnit.asyncTest( "dialog sized select shouldn't rebind its parent page remove ha
 			function() {
 				ok( $.mobile.activePage.is( "#dialog-select-parent-domcache-test" ),
 					"the dialog closed" );
-				$.mobile.pageContainer.pagecontainer( "change", $( "#default" ) );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", $( "#default" ) );
 			},
 
 			function() {
@@ -120,7 +120,7 @@ QUnit.asyncTest( "menupage is removed when the parent page is removed", function
 		resetHash,
 
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "uncached-dom-cached-false.html" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "uncached-dom-cached-false.html" );
 		},
 
 		function() {

--- a/tests/integration/select/select_cached.js
+++ b/tests/integration/select/select_cached.js
@@ -22,7 +22,7 @@ QUnit.asyncTest( "dialog sized select should alter the value of its parent selec
 			resetHash,
 
 			function() {
-				$.mobile.changePage( "cached.html" );
+				$.mobile.pageContainer.pagecontainer( "change", "cached.html" );
 			},
 
 			function() {
@@ -59,7 +59,7 @@ QUnit.asyncTest( "dialog sized select should prevent the removal of its parent p
 			resetHash,
 
 			function() {
-				$.mobile.changePage( "cached.html" );
+				$.mobile.pageContainer.pagecontainer( "change", "cached.html" );
 			},
 
 			function() {
@@ -88,7 +88,7 @@ QUnit.asyncTest( "dialog sized select shouldn't rebind its parent page remove ha
 			resetHash,
 
 			function() {
-				$.mobile.changePage( "cached-dom-cache-true.html" );
+				$.mobile.pageContainer.pagecontainer( "change", "cached-dom-cache-true.html" );
 			},
 
 			function() {
@@ -101,9 +101,9 @@ QUnit.asyncTest( "dialog sized select shouldn't rebind its parent page remove ha
 			},
 
 			function() {
-				assert.ok( $.mobile.activePage.is( "#dialog-select-parent-domcache-test" ),
+				ok( $.mobile.activePage.is( "#dialog-select-parent-domcache-test" ),
 					"the dialog closed" );
-				$.mobile.changePage( $( "#default" ) );
+				$.mobile.pageContainer.pagecontainer( "change", $( "#default" ) );
 			},
 
 			function() {
@@ -120,7 +120,7 @@ QUnit.asyncTest( "menupage is removed when the parent page is removed", function
 		resetHash,
 
 		function() {
-			$.mobile.changePage( "uncached-dom-cached-false.html" );
+			$.mobile.pageContainer.pagecontainer( "change", "uncached-dom-cached-false.html" );
 		},
 
 		function() {

--- a/tests/integration/select/select_core.js
+++ b/tests/integration/select/select_core.js
@@ -456,7 +456,7 @@ QUnit.asyncTest( "dialog size select title should match the label when changed a
 QUnit.asyncTest( "destroying a select menu leaves no traces", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#destroyTest" );
+			$.mobile.pageContainer.pagecontainer( "change", "#destroyTest" );
 		},
 
 		// Check if two chunks of DOM are identical
@@ -501,7 +501,7 @@ QUnit.asyncTest( "destroying a custom select menu leaves no traces", function( a
 			"</select>" );
 	$.testHelper.detailedEventCascade( [
 		function() {
-			$.mobile.changePage( "#destroyTest" );
+			$.mobile.pageContainer.pagecontainer( "change", "#destroyTest" );
 		},
 
 		{

--- a/tests/integration/select/select_core.js
+++ b/tests/integration/select/select_core.js
@@ -431,7 +431,7 @@ QUnit.asyncTest( "dialog size select title should match the label when changed a
 
 			{
 				pagechange: {
-					src: $.mobile.pageContainer,
+					src: $( ".ui-pagecontainer" ),
 					event: "pagechange.dialogSizeSelectTitleMod1"
 				}
 			},
@@ -444,7 +444,7 @@ QUnit.asyncTest( "dialog size select title should match the label when changed a
 
 			{
 				pagechange: {
-					src: $.mobile.pageContainer,
+					src: $( ".ui-pagecontainer" ),
 					event: "pagechange.dialogSizeSelectTitleMod2"
 				}
 			},
@@ -456,7 +456,7 @@ QUnit.asyncTest( "dialog size select title should match the label when changed a
 QUnit.asyncTest( "destroying a select menu leaves no traces", function( assert ) {
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#destroyTest" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#destroyTest" );
 		},
 
 		// Check if two chunks of DOM are identical
@@ -501,11 +501,11 @@ QUnit.asyncTest( "destroying a custom select menu leaves no traces", function( a
 			"</select>" );
 	$.testHelper.detailedEventCascade( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#destroyTest" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#destroyTest" );
 		},
 
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + prefix + "0" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + prefix + "0" }
 		},
 
 		function() {
@@ -556,7 +556,7 @@ QUnit.asyncTest( "destroying a custom select menu leaves no traces", function( a
 		},
 
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + prefix + "3" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + prefix + "3" }
 		},
 
 		function() {
@@ -566,7 +566,7 @@ QUnit.asyncTest( "destroying a custom select menu leaves no traces", function( a
 		},
 
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + prefix + "4" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + prefix + "4" }
 		},
 
 		function() {
@@ -585,7 +585,7 @@ QUnit.asyncTest( "destroying a custom select menu leaves no traces", function( a
 		},
 
 		{
-			pagechange: { src: $.mobile.pageContainer, event: "pagechange" + prefix + "5" }
+			pagechange: { src: $( ".ui-pagecontainer" ), event: "pagechange" + prefix + "5" }
 		},
 
 		QUnit.start

--- a/tests/integration/transitions/transitions_core.js
+++ b/tests/integration/transitions/transitions_core.js
@@ -97,12 +97,12 @@ NOTES:
 Our default transition handler now has either one or two animationComplete calls - two if there are two pages in play (from and to)
 To is required, so each async function must call start() onToComplete, not onFromComplete.
 */
-asyncTest( "changePage applies perspective class to mobile viewport for flip", function() {
+asyncTest( "change() applies perspective class to mobile viewport for flip", function() {
 	expect( 1 );
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#foo" );
+			$.mobile.pageContainer.pagecontainer( "change", "#foo" );
 		},
 
 		function() {
@@ -116,11 +116,11 @@ asyncTest( "changePage applies perspective class to mobile viewport for flip", f
 	] );
 } );
 
-asyncTest( "changePage applies transition class to mobile viewport for default transition", function() {
+asyncTest( "change() applies transition class to mobile viewport for default transition", function() {
 	expect( 1 );
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.changePage( "#baz" );
+			$.mobile.pageContainer.pagecontainer( "change", "#baz" );
 		},
 
 		function() {
@@ -160,13 +160,13 @@ asyncTest( "default transition is fade", function() {
 	$( "#default-trans > a" ).click();
 } );
 
-asyncTest( "changePage queues requests", function() {
+asyncTest( "change() queues requests", function() {
 	expect( 4 )
 	var firstPage = $( "#foo" ),
 		secondPage = $( "#bar" );
 
-	$.mobile.changePage( firstPage );
-	$.mobile.changePage( secondPage );
+	$.mobile.pageContainer.pagecontainer( "change", firstPage );
+	$.mobile.pageContainer.pagecontainer( "change", secondPage );
 
 	onToComplete( function() {
 		ok( isTransitioningIn( firstPage ), "first page begins transition" );
@@ -204,7 +204,7 @@ function testTransitionMaxWidth( val, expected ) {
 		start();
 	}, 5000 );
 
-	$.mobile.changePage( $( ".ui-page:not(.ui-page-active)" ).first() );
+	$.mobile.pageContainer.pagecontainer( "change", $( ".ui-page:not(.ui-page-active)" ).first() );
 
 }
 

--- a/tests/integration/transitions/transitions_core.js
+++ b/tests/integration/transitions/transitions_core.js
@@ -102,7 +102,7 @@ asyncTest( "change() applies perspective class to mobile viewport for flip", fun
 
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#foo" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#foo" );
 		},
 
 		function() {
@@ -120,7 +120,7 @@ asyncTest( "change() applies transition class to mobile viewport for default tra
 	expect( 1 );
 	$.testHelper.pageSequence( [
 		function() {
-			$.mobile.pageContainer.pagecontainer( "change", "#baz" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#baz" );
 		},
 
 		function() {
@@ -165,8 +165,8 @@ asyncTest( "change() queues requests", function() {
 	var firstPage = $( "#foo" ),
 		secondPage = $( "#bar" );
 
-	$.mobile.pageContainer.pagecontainer( "change", firstPage );
-	$.mobile.pageContainer.pagecontainer( "change", secondPage );
+	$( ".ui-pagecontainer" ).pagecontainer( "change", firstPage );
+	$( ".ui-pagecontainer" ).pagecontainer( "change", secondPage );
 
 	onToComplete( function() {
 		ok( isTransitioningIn( firstPage ), "first page begins transition" );
@@ -204,7 +204,7 @@ function testTransitionMaxWidth( val, expected ) {
 		start();
 	}, 5000 );
 
-	$.mobile.pageContainer.pagecontainer( "change", $( ".ui-page:not(.ui-page-active)" ).first() );
+	$( ".ui-pagecontainer" ).pagecontainer( "change", $( ".ui-page:not(.ui-page-active)" ).first() );
 
 }
 

--- a/tests/jquery.testHelper.js
+++ b/tests/jquery.testHelper.js
@@ -227,7 +227,7 @@ $.testHelper = {
 			}, 10000 );
 
 			// bind the recursive call to the event
-			( self.eventTarget || $.mobile.pageContainer ).one( event, function( event, data ) {
+			( self.eventTarget || $( ".ui-pagecontainer" ) ).one( event, function( event, data ) {
 				clearTimeout( warnTimer );
 
 				// Let the current stack unwind before we fire off the next item in the sequence.

--- a/tests/unit/event/event_core.js
+++ b/tests/unit/event/event_core.js
@@ -7,7 +7,6 @@ var libName = "jquery.mobile.events.js",
 	components = [ "events/touch.js", "events/throttledresize.js", "events/scroll.js",
 		"events/orientationchange.js" ],
 	absFn = Math.abs,
-	originalPageContainer = $.mobile.pageContainer,
 	originalEventFn = $.Event.prototype.originalEvent,
 	preventDefaultFn = $.Event.prototype.preventDefault,
 	events = ( "touchstart touchmove touchend tap taphold " +
@@ -25,12 +24,9 @@ QUnit.module( libName, {
 		// the collections existence in non touch enabled test browsers
 		$.Event.prototype.touches = [ { pageX: 1, pageY: 1 } ];
 
-		$.mobile.pageContainer = originalPageContainer || $( "body" );
-
-		$( $.mobile.pageContainer ).unbind( "throttledresize" );
+		$( ".ui-pagecontainer" ).unbind( "throttledresize" );
 	},
 	teardown: function() {
-		$.mobile.pageContainer = originalPageContainer;
 
 		// NOTE unmock
 		Math.abs = absFn;
@@ -623,7 +619,7 @@ QUnit.asyncTest( "throttledresize event promises that a held call will execute o
 		}
 	] );
 
-	$.mobile.pageContainer
+	$( ".ui-pagecontainer" )
 		.trigger( "resize" )
 		.trigger( "resize" )
 		.trigger( "resize" );

--- a/tests/unit/init/init_core.js
+++ b/tests/unit/init/init_core.js
@@ -111,7 +111,7 @@ require( [
 				function() {
 					var firstPage = findFirstPage();
 
-					assert.deepEqual( $.mobile.pageContainer[ 0 ], firstPage.parent()[ 0 ] );
+					assert.deepEqual( $( ".ui-pagecontainer" )[ 0 ], firstPage.parent()[ 0 ] );
 				}
 			).then( start );
 		} );

--- a/tests/unit/page/page_core.js
+++ b/tests/unit/page/page_core.js
@@ -84,11 +84,11 @@ asyncTest( "page container is updated to page theme at pagebeforeshow", function
 
 	var pageTheme = "ui-overlay-" + $.mobile.activePage.page( "option", "theme" );
 
-	$.mobile.pageContainer.removeClass( pageTheme );
+	$( ".ui-pagecontainer" ).removeClass( pageTheme );
 
 	$.mobile.activePage
 		.bind( "pagebeforeshow", function() {
-			ok( $.mobile.pageContainer.hasClass( pageTheme ), "Page container has the same theme as the page on pagebeforeshow" );
+			ok( $( ".ui-pagecontainer" ).hasClass( pageTheme ), "Page container has the same theme as the page on pagebeforeshow" );
 			start();
 		} )
 		.trigger( "pagebeforeshow" );
@@ -101,11 +101,11 @@ asyncTest( "page container is updated to page theme at pagebeforeshow", function
 
 	var pageTheme = "ui-overlay-" + $.mobile.activePage.page( "option", "theme" );
 
-	$.mobile.pageContainer.addClass( pageTheme );
+	$( ".ui-pagecontainer" ).addClass( pageTheme );
 
 	$.mobile.activePage
 		.bind( "pagebeforehide", function() {
-			ok( !$.mobile.pageContainer.hasClass( pageTheme ), "Page container does not have the same theme as the page on pagebeforeshow" );
+			ok( !$( ".ui-pagecontainer" ).hasClass( pageTheme ), "Page container does not have the same theme as the page on pagebeforeshow" );
 			start();
 		} )
 		.trigger( "pagebeforehide" );

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -472,14 +472,14 @@ QUnit.asyncTest( "overlay panel should not call getWrapper", function( assert ) 
 		},
 		function() {
 			assert.deepEqual( count, 0, "getWrapper not called on close" );
-			$.mobile.pageContainer.pagecontainer( "change", "#page2" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#page2" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			assert.deepEqual( count, 0, "getWrapper not called on pagechange" );
-			$.mobile.pageContainer.pagecontainer( "change", "#page1" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#page1" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "4" }
@@ -517,14 +517,14 @@ QUnit.asyncTest( "push panel should call getWrapper only once on create", functi
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on close" );
-			$.mobile.pageContainer.pagecontainer( "change", "#page2" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#page2" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on pagechange" );
-			$.mobile.pageContainer.pagecontainer( "change", "#page1" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#page1" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "4" }
@@ -560,14 +560,14 @@ QUnit.asyncTest( "reveal panel should call getWrapper only once on create", func
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on close" );
-			$.mobile.pageContainer.pagecontainer( "change", "#page2" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#page2" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on pagechange" );
-			$.mobile.pageContainer.pagecontainer( "change", "#page1" );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", "#page1" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "4" }
@@ -604,7 +604,7 @@ QUnit.asyncTest( "external panel should call getWrapper once on create and on pa
 			},
 			function() {
 				assert.deepEqual( count, 1, "getWrapper not called on close" );
-				$.mobile.pageContainer.pagecontainer( "change", "#page2" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "#page2" );
 			},
 			{
 				pageshow: { src: $( "body" ), event: "pagecontainershow" }
@@ -621,7 +621,7 @@ QUnit.asyncTest( "external panel should call getWrapper once on create and on pa
 						QUnit.start();
 					}, 0 );
 				} );
-				$.mobile.pageContainer.pagecontainer( "change", "#page1" );
+				$( ".ui-pagecontainer" ).pagecontainer( "change", "#page1" );
 			}
 		] );
 	} );

--- a/tests/unit/panel/panel_core.js
+++ b/tests/unit/panel/panel_core.js
@@ -472,14 +472,14 @@ QUnit.asyncTest( "overlay panel should not call getWrapper", function( assert ) 
 		},
 		function() {
 			assert.deepEqual( count, 0, "getWrapper not called on close" );
-			$.mobile.changePage( "#page2" );
+			$.mobile.pageContainer.pagecontainer( "change", "#page2" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			assert.deepEqual( count, 0, "getWrapper not called on pagechange" );
-			$.mobile.changePage( "#page1" );
+			$.mobile.pageContainer.pagecontainer( "change", "#page1" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "4" }
@@ -517,14 +517,14 @@ QUnit.asyncTest( "push panel should call getWrapper only once on create", functi
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on close" );
-			$.mobile.changePage( "#page2" );
+			$.mobile.pageContainer.pagecontainer( "change", "#page2" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on pagechange" );
-			$.mobile.changePage( "#page1" );
+			$.mobile.pageContainer.pagecontainer( "change", "#page1" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "4" }
@@ -560,14 +560,14 @@ QUnit.asyncTest( "reveal panel should call getWrapper only once on create", func
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on close" );
-			$.mobile.changePage( "#page2" );
+			$.mobile.pageContainer.pagecontainer( "change", "#page2" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "3" }
 		},
 		function() {
 			assert.deepEqual( count, 1, "getWrapper not called on pagechange" );
-			$.mobile.changePage( "#page1" );
+			$.mobile.pageContainer.pagecontainer( "change", "#page1" );
 		},
 		{
 			pagechange: { src: $( "body" ), event: "pagechange" + eventNs + "4" }
@@ -604,7 +604,7 @@ QUnit.asyncTest( "external panel should call getWrapper once on create and on pa
 			},
 			function() {
 				assert.deepEqual( count, 1, "getWrapper not called on close" );
-				$.mobile.changePage( "#page2" );
+				$.mobile.pageContainer.pagecontainer( "change", "#page2" );
 			},
 			{
 				pageshow: { src: $( "body" ), event: "pagecontainershow" }
@@ -621,7 +621,7 @@ QUnit.asyncTest( "external panel should call getWrapper once on create and on pa
 						QUnit.start();
 					}, 0 );
 				} );
-				$.mobile.changePage( "#page1" );
+				$.mobile.pageContainer.pagecontainer( "change", "#page1" );
 			}
 		] );
 	} );

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -15,7 +15,7 @@ QUnit.module( "Basic Table", {
 				QUnit.start();
 			} );
 
-			$.mobile.changePage( hash );
+			$.mobile.pageContainer.pagecontainer( "change", hash );
 		}
 	},
 
@@ -81,7 +81,7 @@ QUnit.module( "Reflow Mode", {
 				QUnit.start();
 			} );
 
-			$.mobile.changePage( hash );
+			$.mobile.pageContainer.pagecontainer( "change", hash );
 		}
 	},
 
@@ -154,7 +154,7 @@ QUnit.module( "Column toggle table Mode", {
 				QUnit.start();
 			} );
 
-			$.mobile.changePage( hash );
+			$.mobile.pageContainer.pagecontainer( "change", hash );
 		}
 	},
 

--- a/tests/unit/table/table_core.js
+++ b/tests/unit/table/table_core.js
@@ -15,7 +15,7 @@ QUnit.module( "Basic Table", {
 				QUnit.start();
 			} );
 
-			$.mobile.pageContainer.pagecontainer( "change", hash );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", hash );
 		}
 	},
 
@@ -81,7 +81,7 @@ QUnit.module( "Reflow Mode", {
 				QUnit.start();
 			} );
 
-			$.mobile.pageContainer.pagecontainer( "change", hash );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", hash );
 		}
 	},
 
@@ -154,7 +154,7 @@ QUnit.module( "Column toggle table Mode", {
 				QUnit.start();
 			} );
 
-			$.mobile.pageContainer.pagecontainer( "change", hash );
+			$( ".ui-pagecontainer" ).pagecontainer( "change", hash );
 		}
 	},
 


### PR DESCRIPTION
This incorporates and updates #7947 this now uses the classes option to add `.ui-pagecontainer` and uses that as the canonical way to find a page container 
