### PR TITLE
Docs: Don't specify the required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The easiest way to obtain a custom build is to use the [download builder](http:/
 
 ### Requirements
 
-* [node.js](http://nodejs.org/) ~0.8.22
+* [node.js](http://nodejs.org/)
 * [grunt-cli](http://gruntjs.com/)
 
 ### Commands


### PR DESCRIPTION
With Node.js 0.10, 0.12 and - soon - 4.0 available it doesn't make sense
to make people install Node.js 0.8, especially that it's no longer supported.
Building jQuery Mobile should work with any recent Node.js version.

Fixes gh-7900

Or do you prefer to just not mention Node.js at all?
