### PR TITLE
Allow center click scrolling on Windows

### DIFF
--- a/js/events/touch.js
+++ b/js/events/touch.js
@@ -51,7 +51,7 @@ define( [ "jquery", "../vmouse", "../support/touch" ], function( jQuery ) {
 			$this.bind( "vmousedown", function( event ) {
 				isTaphold = false;
 				if ( event.which && event.which !== 1 ) {
-					return false;
+					return true;
 				}
 
 				var origTarget = event.target,


### PR DESCRIPTION
We started using jQuery Mobile for tap and taphold events on meh.com and then our users started complaining that we broke center-click-scrolling on Windows.

https://meh.com/forum/topics/why-can-i-not-center-click-to-scroll-in-the-forums-is-this-just-me

Here's a fiddle that demonstrates the broken functionality: http://jsfiddle.net/k7pzm6m5/1/

Expected behavior: The standard Windows scroll cursor should appear when clicking the center mouse button.
Actual behavior: Center mouse click is ignored.

This PR fixes it.
