### PR TITLE
TextInput: Add ui-state-disabled class when disabled

### DIFF
--- a/js/widgets/forms/textinput.js
+++ b/js/widgets/forms/textinput.js
@@ -87,10 +87,15 @@ $.widget( "mobile.textinput", {
 			"blur": "_handleBlur"
 		} );
 
+		if ( options.disabled !== undefined ) {
+			this.element.prop( "disabled", !!options.disabled );
+			this._toggleClass( this._outer, null, "ui-state-disabled", !!options.disabled );
+		}
+
 	},
 
 	refresh: function() {
-		this.setOptions( {
+		this._setOptions( {
 			"disabled": this.element.is( ":disabled" )
 		} );
 	},

--- a/tests/unit/textinput/index.html
+++ b/tests/unit/textinput/index.html
@@ -81,6 +81,7 @@
 			<input type="text" id="destroy-test" data-nstest-role="none">
 		</div>
 		<input type="text" id="disable-test">
+		<input type="text" id="disable-test-default" disabled="true">
 	</div>
 </body>
 </html>

--- a/tests/unit/textinput/textinput_core.js
+++ b/tests/unit/textinput/textinput_core.js
@@ -221,4 +221,13 @@ QUnit.test( "textinput is disabled/enabled correctly", function( assert ) {
 		"After disabling, the 'disabled' prop is true" );
 } );
 
+QUnit.test( "textinput is disabled correctly by default", function( assert ) {
+	var textinput = $( "#disable-test-default" );
+
+	assert.hasClasses( textinput.parent()[ 0 ], "ui-state-disabled",
+		"After disabling, the ui-state-disabled class is present" );
+	assert.deepEqual( textinput.prop( "disabled" ), true,
+		"After disabling, the 'disabled' prop is true" );
+} );
+
 } )( QUnit, jQuery );


### PR DESCRIPTION
By checking if the input has disabled attribute we add ui-state-disabled class to give it a look of disabled text input

Fixes #8251 
