### PR TITLE
Checkbox: Fix toggling of checkbox in case of enhanced

### DIFF
--- a/js/widgets/forms/checkboxradio.js
+++ b/js/widgets/forms/checkboxradio.js
@@ -42,7 +42,7 @@ $.widget( "ui.checkboxradio", $.ui.checkboxradio, {
 		if ( !this.options.enhanced ) {
 			this._super();
 		} else if ( this.options.icon ) {
-			this.icon = this.element.find( "ui-button-icon" );
+			this.icon = this.element.parent().find( ".ui-checkboxradio-icon" );
 		}
 	},
 


### PR DESCRIPTION
Fixes #8253

We were checking for a class without a "." prepended. Also the class that was being checked was not the correct one.
