### PR TITLE
Remove a useless instruction

### DIFF
--- a/js/widgets/forms/select.js
+++ b/js/widgets/forms/select.js
@@ -255,8 +255,6 @@ var selectmenu = $.widget( "mobile.selectmenu", [ {
 					text = selected.map( function() {
 						return $( this ).text();
 					} ).get().join( ", " );
-				} else {
-					text = that.placeholder;
 				}
 
 				if ( text ) {


### PR DESCRIPTION
The `text` variable is first initialized to `this.placeholder`, which is strictly equivalent to use `self.placeholder` inside the function used just after. So in case `selected.length` is falsy, this is not necessary to override `text` to the same value, i.e. its inital value.

Also fix a CS.
