### PR TITLE
Core: Add margin to floating icons

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -303,10 +303,12 @@ div.ui-mobile-viewport {
 .ui-widget-icon-floatbeginning {
 	bottom: auto;
 	float: left;
+	margin-right: 1em;
 }
 .ui-widget-icon-floatend {
 	bottom: auto;
 	float: right;
+	margin-left: 1em;
 }
 
 /* Button elements and input buttons */


### PR DESCRIPTION
The margin is equal to the padding on the button at the other side of the icon.
