### PR TITLE
Events: Remove unnecessary prop definition in vmouse

### DIFF
--- a/js/vmouse.js
+++ b/js/vmouse.js
@@ -95,7 +95,7 @@ function createVirtualEvent( event, eventType ) {
 	// this would happen if we could call $.event.fix instead of $.Event
 	// but we don't have a way to force an event to be fixed multiple times
 	if ( oe ) {
-		for ( i = props.length, prop; i; ) {
+		for ( i = props.length; i; ) {
 			prop = props[ --i ];
 			event[ prop ] = oe[ prop ];
 		}


### PR DESCRIPTION
Fixes #5246
[Test Link](https://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540output_file_name%2520default.js%250A%252F%252F%2520%2540compilation_level%2520ADVANCED_OPTIMIZATIONS%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250A%250Afunction%2520createVirtualEvent%28%2520event%252C%2520eventType%2520%29%2520%257B%250A%250A%2509var%2520t%2520%253D%2520event.type%252C%250A%2509%2509oe%252C%2520props%252C%2520ne%252C%2520prop%252C%2520ct%252C%2520touch%252C%2520i%252C%2520j%252C%2520len%253B%250A%250A%2509event%2520%253D%2520%2524.Event%28%2520event%2520%29%253B%250A%2509event.type%2520%253D%2520eventType%253B%250A%250A%2509oe%2520%253D%2520event.originalEvent%253B%250A%2509props%2520%253D%2520%2524.event.props%253B%250A%250A%2509%252F%252F%2520addresses%2520separation%2520of%2520%2524.event.props%2520in%2520to%2520%2524.event.mouseHook.props%2520and%2520Issue%25203280%250A%2509%252F%252F%2520https%253A%252F%252Fgithub.com%252Fjquery%252Fjquery-mobile%252Fissues%252F3280%250A%2509if%2520%28%2520t.search%28%2520%252F%255E%28mouse%257Cclick%29%252F%2520%29%2520%253E%2520-1%2520%29%2520%257B%250A%2509%2509props%2520%253D%2520mouseEventProps%253B%250A%2509%257D%250A%250A%2509%252F%252F%2520copy%2520original%2520event%2520properties%2520over%2520to%2520the%2520new%2520event%250A%2509%252F%252F%2520this%2520would%2520happen%2520if%2520we%2520could%2520call%2520%2524.event.fix%2520instead%2520of%2520%2524.Event%250A%2509%252F%252F%2520but%2520we%2520don't%2520have%2520a%2520way%2520to%2520force%2520an%2520event%2520to%2520be%2520fixed%2520multiple%2520times%250A%2509if%2520%28%2520oe%2520%29%2520%257B%250A%2509%2509for%2520%28%2520i%2520%253D%2520props.length%253B%2520i%253B%2520%29%2520%257B%250A%2509%2509%2509prop%2520%253D%2520props%255B%2520--i%2520%255D%253B%250A%2509%2509%2509event%255B%2520prop%2520%255D%2520%253D%2520oe%255B%2520prop%2520%255D%253B%250A%2509%2509%257D%250A%2509%257D%250A%250A%2509%252F%252F%2520make%2520sure%2520that%2520if%2520the%2520mouse%2520and%2520click%2520virtual%2520events%2520are%2520generated%250A%2509%252F%252F%2520without%2520a%2520.which%2520one%2520is%2520defined%250A%2509if%2520%28%2520t.search%28%2520%252Fmouse%28down%257Cup%29%257Cclick%252F%2520%29%2520%253E%2520-1%2520%2526%2526%2520!event.which%2520%29%2520%257B%250A%2509%2509event.which%2520%253D%25201%253B%250A%2509%257D%250A%250A%2509if%2520%28%2520t.search%28%2520%252F%255Etouch%252F%2520%29%2520!%253D%253D%2520-1%2520%29%2520%257B%250A%2509%2509ne%2520%253D%2520getNativeEvent%28%2520oe%2520%29%253B%250A%2509%2509t%2520%253D%2520ne.touches%253B%250A%2509%2509ct%2520%253D%2520ne.changedTouches%253B%250A%2509%2509touch%2520%253D%2520%28%2520t%2520%2526%2526%2520t.length%2520%29%2520%253F%2520t%255B%25200%2520%255D%2520%253A%2520%28%2520%28%2520ct%2520%2526%2526%2520ct.length%2520%29%2520%253F%2520ct%255B%25200%2520%255D%2520%253A%2520undefined%2520%29%253B%250A%250A%2509%2509if%2520%28%2520touch%2520%29%2520%257B%250A%2509%2509%2509for%2520%28%2520j%2520%253D%25200%252C%2520len%2520%253D%2520touchEventProps.length%253B%2520j%2520%253C%2520len%253B%2520j%252B%252B%2520%29%2520%257B%250A%2509%2509%2509%2509prop%2520%253D%2520touchEventProps%255B%2520j%2520%255D%253B%250A%2509%2509%2509%2509event%255B%2520prop%2520%255D%2520%253D%2520touch%255B%2520prop%2520%255D%253B%250A%2509%2509%2509%257D%250A%2509%2509%257D%250A%2509%257D%250A%250A%2509return%2520event%253B%250A%257D)
