### PR TITLE
Controlgroup height and default font-family

### DIFF
--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -277,8 +277,7 @@ div.ui-mobile-viewport {
 	height: 22px;
 	line-height: inherit;
 	vertical-align: middle;
-	position: relative;
-	bottom: 2px;
+	margin-top: -2px;
 }
 .ui-widget-icon-block {
 	display: block;
@@ -290,7 +289,6 @@ div.ui-mobile-viewport {
 	text-indent: 100%;
 	white-space: nowrap;
 	overflow: hidden;
-	bottom: auto;
 	top: 50%;
 	left: 50%;
 }
@@ -303,14 +301,12 @@ div.ui-mobile-viewport {
 
 /* Float icons helper classes */
 .ui-widget-icon-floatbeginning {
-	bottom: auto;
 	float: left;
-	margin-right: 1em;
+	margin: 1px 1em 0 0;
 }
 .ui-widget-icon-floatend {
-	bottom: auto;
 	float: right;
-	margin-left: 1em;
+	margin: 1px 0 0 1em;
 }
 
 /* Button elements and input buttons */

--- a/css/structure/jquery.mobile.core.css
+++ b/css/structure/jquery.mobile.core.css
@@ -327,7 +327,8 @@ input.ui-button-inline,
 	width: auto;
 }
 /* Firefox adds a 1px border in a button element. We negate this to make sure they have the same height as other buttons in controlgroups. */
-button.ui-button::-moz-focus-inner {
+button.ui-button::-moz-focus-inner,
+input.ui-button::-moz-focus-inner {
 	border: 0;
 }
 button.ui-button-icon-only,

--- a/css/themes/default/jquery.mobile.theme.css
+++ b/css/themes/default/jquery.mobile.theme.css
@@ -14,7 +14,7 @@ button,
 .ui-button {
 	font-size: 1em;
 	line-height: 1.3;
-	font-family: sans-serif /*{global-font-family}*/;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif /*{global-font-family}*/;
 }
 legend,
 .ui-textinput-text input,


### PR DESCRIPTION
Icons: Use margin instead of bottom offset for vertical icon position - This makes sure the buttons inside a controlgroup all have the same height, no matter what font is used, and floating icons (selectmenu button) and inline icons have the same vertical position.

Core: Also unset moz-focus-inner border for input elements - Same as we did for buttons on firefox needs to be done for input buttons to prevent them being 1px higher than other buttons inside a controlgroup.

Theme: Set system font as default font - See https://github.com/jquery/jquery-mobile/issues/8503#issuecomment-244038535
